### PR TITLE
Fix some issues found in the discord playtest

### DIFF
--- a/BattleNetwork/bnMessageQuiz.cpp
+++ b/BattleNetwork/bnMessageQuiz.cpp
@@ -1,6 +1,6 @@
 #include "bnMessageQuiz.h"
 
-Quiz::Quiz(std::string optionA, std::string optionB, std::string optionC, std::function<void(int)> onResponse) :
+Quiz::Quiz(const std::string& optionA, const std::string& optionB, const std::string& optionC, const std::function<void(int)>& onResponse) :
   MessageInterface(("  " +optionA + "\n  " + optionB + "\n  " + optionC).c_str()),
   onResponse(onResponse) {
   selection = 0;
@@ -86,7 +86,7 @@ void Quiz::OnDraw(sf::RenderTarget& target, sf::RenderStates states) {
   auto textboxBottom = textboxPosition.y - 40 + 1;
 
   auto cursorX = textboxPosition.x + 100 + 1;
-  auto cursorY = textboxBottom + selection * 12 * 2;
+  auto cursorY = textboxBottom + (float)selection * 12 * 2;
 
   selectCursor.setPosition(cursorX,  cursorY);
 

--- a/BattleNetwork/bnMessageQuiz.cpp
+++ b/BattleNetwork/bnMessageQuiz.cpp
@@ -66,8 +66,8 @@ const bool Quiz::SelectDown() {
 }
 
 void Quiz::ConfirmSelection() {
-  GetTextBox()->DequeMessage();
   onResponse(selection);
+  GetTextBox()->DequeMessage();
 }
 
 void Quiz::OnUpdate(double elapsed) {

--- a/BattleNetwork/bnMessageQuiz.h
+++ b/BattleNetwork/bnMessageQuiz.h
@@ -22,7 +22,7 @@ private:
   int selection;
   std::array<std::string, 3> options;
 public:
-  Quiz(std::string optionA, std::string optionB, std::string optionC, std::function<void(int)> onResponse = [](int){});
+  Quiz(const std::string& optionA, const std::string& optionB, const std::string& optionC, const std::function<void(int)>& onResponse = [](int){});
 
   /**
    * @brief Moves selection up if applicable

--- a/BattleNetwork/overworld/bnOverworldActor.cpp
+++ b/BattleNetwork/overworld/bnOverworldActor.cpp
@@ -179,8 +179,7 @@ void Overworld::Actor::UpdateAnimationState(float elapsed) {
     }
 
     if (lastStateStr != stateStr) {
-      animProgress = 0;
-      anims[stateStr].SyncTime(0);
+      anims[stateStr].SyncTime(animProgress);
 
       // we have changed states
       anims[stateStr].Refresh(getSprite());

--- a/BattleNetwork/overworld/bnOverworldActor.cpp
+++ b/BattleNetwork/overworld/bnOverworldActor.cpp
@@ -321,15 +321,39 @@ const std::pair<bool, sf::Vector2f> Overworld::Actor::CanMoveTo(Direction dir, M
 
   auto [canMove, firstPositionResult] = CanMoveTo(newPos, map, spatialMap);
 
-  if (!canMove && second != Direction::none) {
+  if (!canMove) {
     // test alternate directions, this provides a sliding effect
-    auto [canMoveOffsetX, offsetXResult] = CanMoveTo(sf::Vector2f(currPos.x + offset.x, currPos.y), map, spatialMap);
+    sf::Vector2f altOffsetA;
+    sf::Vector2f altOffsetB;
+
+    if (second != Direction::none) {
+      altOffsetA.x = offset.x;
+      altOffsetB.y = offset.y;
+    }
+    else if (first == Direction::left || first == Direction::right) {
+      // normalized diagonal
+      altOffsetA.x = offset.x * 0.5f;
+      altOffsetA.y = altOffsetA.x;
+      // flipped y
+      altOffsetB.x = altOffsetA.x;
+      altOffsetB.y = -altOffsetA.y;
+    }
+    else {
+      // normalized diagonal
+      altOffsetA.x = offset.y * 0.5f;
+      altOffsetA.y = altOffsetA.x;
+      // flipped x
+      altOffsetB.x = -altOffsetA.x;
+      altOffsetB.y = altOffsetA.y;
+    }
+
+    auto [canMoveOffsetX, offsetXResult] = CanMoveTo(currPos + altOffsetA, map, spatialMap);
 
     if (canMoveOffsetX) {
       return { canMoveOffsetX, offsetXResult };
     }
 
-    auto [canMoveOffsetY, offsetYResult] = CanMoveTo(sf::Vector2f(currPos.x, currPos.y + offset.y), map, spatialMap);
+    auto [canMoveOffsetY, offsetYResult] = CanMoveTo(currPos + altOffsetB, map, spatialMap);
 
     if (canMoveOffsetY) {
       return { canMoveOffsetY, offsetYResult };

--- a/BattleNetwork/overworld/bnOverworldActor.h
+++ b/BattleNetwork/overworld/bnOverworldActor.h
@@ -207,5 +207,6 @@ namespace Overworld {
 
     const std::optional<sf::Vector2f> CollidesWith(const Actor& actor, const sf::Vector2f& offset = sf::Vector2f{});
     const std::pair<bool, sf::Vector2f> CanMoveTo(Direction dir, MovementState state, float elapsed, Map& map, SpatialMap& spatialMap);
+    const std::pair<bool, sf::Vector2f> CanMoveTo(sf::Vector2f pos, Map& map, SpatialMap& spatialMap);
   };
 }

--- a/BattleNetwork/overworld/bnOverworldHomepage.cpp
+++ b/BattleNetwork/overworld/bnOverworldHomepage.cpp
@@ -33,7 +33,7 @@ Overworld::Homepage::Homepage(swoosh::ActivityController& controller, bool guest
       auto tileSize = map.GetTileSize();
 
       netWarpTilePos = sf::Vector2f(
-        std::floor(centerPos.x / (tileSize.x / 2)),
+        std::floor(centerPos.x / (float)(tileSize.x / 2)),
         std::floor(centerPos.y / tileSize.y)
       );
       netWarpObjectId = tileObject.id;
@@ -59,7 +59,7 @@ Overworld::Homepage::Homepage(swoosh::ActivityController& controller, bool guest
 
     // we ensure pointer to mrprog is alive because when we interact, 
     // mrprog must've been alive to interact in the first place...
-    mrprog->SetInteractCallback([mrprog = mrprog.get(), this](std::shared_ptr<Overworld::Actor> with) {
+    mrprog->SetInteractCallback([mrprog = mrprog.get(), this](const std::shared_ptr<Overworld::Actor>& with) {
       // Face them
       mrprog->Face(*with);
 
@@ -320,7 +320,7 @@ void Overworld::Homepage::OnInteract() {
   auto targetPos = player->PositionInFrontOf();
   auto targetOffset = targetPos - player->getPosition();
 
-  for (auto other : GetSpatialMap().GetChunk(targetPos.x, targetPos.y)) {
+  for (const auto& other : GetSpatialMap().GetChunk(targetPos.x, targetPos.y)) {
     if (player == other) continue;
 
     auto collision = player->CollidesWith(*other, targetOffset);

--- a/BattleNetwork/overworld/bnOverworldHomepage.cpp
+++ b/BattleNetwork/overworld/bnOverworldHomepage.cpp
@@ -134,7 +134,7 @@ void Overworld::Homepage::PingRemoteAreaServer()
           }
         }
       }
-      catch (Poco::IOException& e) {
+      catch (Poco::IOException&) {
         cyberworldStatus = CyberworldStatus::offline;
         reconnecting = false;
         client.close();
@@ -157,7 +157,7 @@ void Overworld::Homepage::PingRemoteAreaServer()
         reconnecting = true;
         doSendThunk();
       }
-      catch (Poco::IOException& e) {
+      catch (Poco::IOException&) {
         reconnecting = false;
       }
     }

--- a/BattleNetwork/overworld/bnOverworldMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldMap.cpp
@@ -6,7 +6,7 @@
 
 
 namespace Overworld {
-  Map::Map(std::size_t cols, std::size_t rows, int tileWidth, int tileHeight) {
+  Map::Map(unsigned cols, unsigned rows, int tileWidth, int tileHeight) {
     this->tileWidth = tileWidth;
     this->tileHeight = tileHeight;
     this->cols = cols;
@@ -119,7 +119,7 @@ namespace Overworld {
     return tileMetas[tileGid];
   }
 
-  std::shared_ptr<Tileset> Map::GetTileset(std::string name) {
+  std::shared_ptr<Tileset> Map::GetTileset(const std::string& name) {
     if (tilesets.find(name) == tilesets.end()) {
       return nullptr;
     }
@@ -135,7 +135,7 @@ namespace Overworld {
     return tileToTilesetMap[tileGid];
   }
 
-  void Map::SetTileset(std::shared_ptr<Tileset> tileset, std::shared_ptr<TileMeta> tileMeta) {
+  void Map::SetTileset(const std::shared_ptr<Tileset>& tileset, const std::shared_ptr<TileMeta>& tileMeta) {
     auto tileGid = tileMeta->gid;
 
     if (tileToTilesetMap.size() <= tileGid) {
@@ -219,7 +219,7 @@ namespace Overworld {
 
   static Tile nullTile = Tile(0);
 
-  Map::Layer::Layer(std::size_t cols, std::size_t rows) {
+  Map::Layer::Layer(unsigned cols, unsigned rows) {
     this->cols = cols;
     this->rows = rows;
     tiles.resize(cols * rows, nullTile);
@@ -273,7 +273,7 @@ namespace Overworld {
     return *iter;
   }
 
-  std::optional<std::reference_wrapper<TileObject>> Map::Layer::GetTileObject(std::string name) {
+  std::optional<std::reference_wrapper<TileObject>> Map::Layer::GetTileObject(const std::string& name) {
     auto iterEnd = tileObjects.end();
     auto iter = std::find_if(tileObjects.begin(), tileObjects.end(), [name](TileObject& tileObject) { return tileObject.name == name; });
 
@@ -304,7 +304,7 @@ namespace Overworld {
     return *iter;
   }
 
-  std::optional<std::reference_wrapper<ShapeObject>> Map::Layer::GetShapeObject(std::string name) {
+  std::optional<std::reference_wrapper<ShapeObject>> Map::Layer::GetShapeObject(const std::string& name) {
     auto iterEnd = shapeObjects.end();
     auto iter = std::find_if(shapeObjects.begin(), shapeObjects.end(), [name](ShapeObject& shapeObject) { return shapeObject.name == name; });
 

--- a/BattleNetwork/overworld/bnOverworldMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldMap.cpp
@@ -108,7 +108,7 @@ namespace Overworld {
   }
 
   unsigned int Map::GetTileCount() {
-    return tileMetas.size();
+    return static_cast<unsigned int>(tileMetas.size());
   }
 
   std::shared_ptr<TileMeta> Map::GetTileMeta(unsigned int tileGid) {
@@ -227,7 +227,7 @@ namespace Overworld {
 
   Tile& Map::Layer::GetTile(int x, int y)
   {
-    if (x < 0 || y < 0 || x >= cols || y >= rows) {
+    if (x < 0 || y < 0 || x >= (int)cols || y >= (int)rows) {
       // reset nullTile as it may have been mutated
       nullTile = Tile(0);
       return nullTile;
@@ -243,7 +243,7 @@ namespace Overworld {
 
   Tile& Map::Layer::SetTile(int x, int y, Tile tile)
   {
-    if (x < 0 || y < 0 || x >= cols || y >= rows) {
+    if (x < 0 || y < 0 || x >= (int)cols || y >= (int)rows) {
       // reset nullTile as it may have been mutated
       nullTile = Tile(0);
       return nullTile;

--- a/BattleNetwork/overworld/bnOverworldMap.h
+++ b/BattleNetwork/overworld/bnOverworldMap.h
@@ -44,19 +44,19 @@ namespace Overworld {
       Tile& SetTile(float x, float y, unsigned int gid);
 
       std::optional<std::reference_wrapper<TileObject>> GetTileObject(unsigned int id);
-      std::optional<std::reference_wrapper<TileObject>> GetTileObject(std::string name);
+      std::optional<std::reference_wrapper<TileObject>> GetTileObject(const std::string& name);
       const std::vector<TileObject>& GetTileObjects();
       void AddTileObject(TileObject tileObject);
 
       std::optional<std::reference_wrapper<ShapeObject>> GetShapeObject(unsigned int id);
-      std::optional<std::reference_wrapper<ShapeObject>> GetShapeObject(std::string name);
+      std::optional<std::reference_wrapper<ShapeObject>> GetShapeObject(const std::string& name);
       const std::vector<ShapeObject>& GetShapeObjects();
       void AddShapeObject(ShapeObject shapeObject);
 
     private:
-      Layer(size_t cols, size_t rows);
+      Layer(unsigned cols, unsigned rows);
 
-      size_t cols, rows;
+      unsigned cols, rows;
       std::vector<Tile> tiles;
       std::vector<ShapeObject> shapeObjects;
       std::vector<TileObject> tileObjects;
@@ -68,7 +68,7 @@ namespace Overworld {
     /**
      * \brief Simple constructor
      */
-    Map(size_t cols, size_t rows, int tileWidth, int tileHeight);
+    Map(unsigned cols, unsigned rows, int tileWidth, int tileHeight);
 
     /**
      * @brief Updates tile animations and tile objects
@@ -113,9 +113,9 @@ namespace Overworld {
     const unsigned GetRows() const;
     unsigned int GetTileCount();
     std::shared_ptr<TileMeta> GetTileMeta(unsigned int tileGid);
-    std::shared_ptr<Tileset> GetTileset(std::string name);
+    std::shared_ptr<Tileset> GetTileset(const std::string& name);
     std::shared_ptr<Tileset> GetTileset(unsigned int tileGid);
-    void SetTileset(std::shared_ptr<Tileset> tileset, std::shared_ptr<TileMeta> tileMeta);
+    void SetTileset(const std::shared_ptr<Tileset>& tileset, const std::shared_ptr<TileMeta>& tileMeta);
     size_t GetLayerCount() const;
     Layer& GetLayer(size_t index);
     Layer& AddLayer();

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -87,10 +87,11 @@ void Overworld::OnlineArea::onUpdate(double elapsed)
 
   SceneBase::onUpdate(elapsed);
 
-  if (lastFrameNavi != GetCurrentNavi()) {
+  auto currentNavi = GetCurrentNavi();
+  if (lastFrameNavi != currentNavi) {
     sendAvatarChangeSignal();
-  }
     lastFrameNavi = currentNavi;
+  }
 
   for (auto& pair : onlinePlayers) {
     auto& onlinePlayer = pair.second;

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -17,16 +17,16 @@ constexpr sf::Int32 MAX_TIMEOUT_SECONDS = 5;
 const std::string sanitize_folder_name(std::string in) {
   // todo: use regex for multiple erroneous folder names?
 
-  size_t pos = in.find(".");
+  size_t pos = in.find('.');
 
   // Repeat till end is reached
   while (pos != std::string::npos)
   {
     in.replace(pos, 1, "_");
-    pos = in.find(".", pos + 1);
+    pos = in.find('.', pos + 1);
   }
 
-  pos = in.find(":");
+  pos = in.find(':');
 
   // Repeat till end is reached
   if (pos != std::string::npos)
@@ -123,7 +123,7 @@ void Overworld::OnlineArea::onUpdate(double elapsed)
     onlinePlayer.emoteNode.Update(elapsed);
   }
 
-  for (auto remove : removePlayers) {
+  for (const auto& remove : removePlayers) {
     auto it = onlinePlayers.find(remove);
 
     if (it == onlinePlayers.end()) {
@@ -269,7 +269,7 @@ void Overworld::OnlineArea::OnInteract() {
 
   auto positionInFrontOffset = frontPosition - playerActor->getPosition();
 
-  for (auto other : GetSpatialMap().GetChunk(frontPosition.x, frontPosition.y)) {
+  for (const auto& other : GetSpatialMap().GetChunk(frontPosition.x, frontPosition.y)) {
     if (playerActor == other) continue;
 
     auto collision = playerActor->CollidesWith(*other, positionInFrontOffset);
@@ -283,7 +283,7 @@ void Overworld::OnlineArea::OnInteract() {
   }
 
   sendTileInteractionSignal(
-    frontPosition.x / (tileSize.x / 2),
+    frontPosition.x / (float)(tileSize.x / 2),
     frontPosition.y / tileSize.y,
     0.0
   );
@@ -809,7 +809,7 @@ void Overworld::OnlineArea::receiveQuestionSignal(BufferReader& reader, const Po
   auto& textbox = GetTextBox();
   textbox.SetNextSpeaker(face, animation);
   textbox.EnqueueQuestion(message,
-    [=](int response) { sendDialogResponseSignal(response); }
+    [=](int response) { sendDialogResponseSignal((char)response); }
   );
 }
 
@@ -830,7 +830,7 @@ void Overworld::OnlineArea::receiveQuizSignal(BufferReader& reader, const Poco::
   auto& textbox = GetTextBox();
   textbox.SetNextSpeaker(face, animation);
   textbox.EnqueueQuiz(optionA, optionB, optionC,
-    [=](int response) { sendDialogResponseSignal(response); }
+    [=](int response) { sendDialogResponseSignal((char)response); }
   );
 }
 
@@ -879,7 +879,7 @@ void Overworld::OnlineArea::receiveNaviConnectedSignal(BufferReader& reader, con
   actor->SetSolid(solid);
   actor->CollideWithMap(false);
   actor->SetCollisionRadius(6);
-  actor->SetInteractCallback([=](std::shared_ptr<Actor> with) {
+  actor->SetInteractCallback([=](const std::shared_ptr<Actor>& with) {
     sendNaviInteractionSignal(ticket);
   });
 
@@ -957,7 +957,6 @@ void Overworld::OnlineArea::receiveNaviMoveSignal(BufferReader& reader, const Po
     auto currentTime = CurrentTime::AsMilli();
     auto endBroadcastPos = onlinePlayer.endBroadcastPos;
     auto newPos = sf::Vector2f(x, y);
-    auto deltaTime = static_cast<double>(currentTime - onlinePlayer.timestamp) / 1000.0;
     auto delta = endBroadcastPos - newPos;
     float distance = std::sqrt(std::pow(delta.x, 2.0f) + std::pow(delta.y, 2.0f));
     double incomingLag = (currentTime - static_cast<double>(onlinePlayer.timestamp)) / 1000.0;
@@ -965,7 +964,6 @@ void Overworld::OnlineArea::receiveNaviMoveSignal(BufferReader& reader, const Po
     // Adjust the lag time by the lag of this incoming frame
     double expectedTime = calculatePlayerLag(onlinePlayer, incomingLag);
 
-    Direction newHeading = Actor::MakeDirectionFromVector(delta);
     auto teleportController = &onlinePlayer.teleportController;
     auto actor = onlinePlayer.actor;
 
@@ -984,7 +982,6 @@ void Overworld::OnlineArea::receiveNaviMoveSignal(BufferReader& reader, const Po
     // update our records
     onlinePlayer.startBroadcastPos = endBroadcastPos;
     onlinePlayer.endBroadcastPos = sf::Vector2f(x, y);
-    auto previous = onlinePlayer.timestamp;
     onlinePlayer.timestamp = currentTime;
     onlinePlayer.packets++;
     onlinePlayer.lagWindow[onlinePlayer.packets % Overworld::LAG_WINDOW_LEN] = incomingLag;
@@ -1047,7 +1044,7 @@ const bool Overworld::OnlineArea::isMouseHovering(const sf::Vector2f& mouse, con
   auto position = src.getPosition();
   auto screenPosition = map.WorldToScreen(position);
   auto bounds = sf::FloatRect(
-    (screenPosition.x - textureRect.width / 2) * scale.x,
+    (screenPosition.x - (float)(textureRect.width / 2)) * scale.x,
     (screenPosition.y - textureRect.height) * scale.y,
     textureRect.width * scale.x,
     textureRect.height * scale.y

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -455,7 +455,7 @@ void Overworld::OnlineArea::sendAssetStreamSignal(ClientEvents event, uint16_t h
 
   while (remainingBytes > 0) {
     const uint16_t availableRoom = maxPayloadSize - headerSize - 2;
-    uint16_t size = remainingBytes < availableRoom ? remainingBytes : availableRoom;
+    uint16_t size = remainingBytes < availableRoom ? (uint16_t)remainingBytes : availableRoom;
     remainingBytes -= size;
 
     Poco::Buffer<char> buffer{ 0 };

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -90,6 +90,7 @@ void Overworld::OnlineArea::onUpdate(double elapsed)
   if (lastFrameNavi != GetCurrentNavi()) {
     sendAvatarChangeSignal();
   }
+    lastFrameNavi = currentNavi;
 
   for (auto& pair : onlinePlayers) {
     auto& onlinePlayer = pair.second;

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -33,7 +33,7 @@ namespace Overworld {
     std::string ticket; //!< How we are represented on the server
     Poco::Net::DatagramSocket client; //!< us
     Poco::Net::SocketAddress remoteAddress; //!< server
-    size_t maxPayloadSize;
+    uint16_t maxPayloadSize;
     bool isConnected{ false };
     PacketShipper packetShipper;
     PacketSorter packetSorter;

--- a/BattleNetwork/overworld/bnOverworldPathController.cpp
+++ b/BattleNetwork/overworld/bnOverworldPathController.cpp
@@ -18,7 +18,7 @@ void Overworld::PathController::Update(double elapsed, Map& map, SpatialMap& spa
     return;
   }
 
-  if(commands.front()(elapsed, map, spatialMap)) {
+  if(commands.front()((float)elapsed, map, spatialMap)) {
     commands.pop();
   }
 }

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -457,7 +457,7 @@ void Overworld::SceneBase::DrawTiles(sf::RenderTarget& target, sf::RenderStates 
       ));
 
       tileSprite.setPosition(ortho + tileMeta->drawingOffset + tileOffset);
-      tileSprite.setRotation(tile.rotated ? 90 : 0);
+      tileSprite.setRotation(tile.rotated ? 90.0f : 0.0f);
       tileSprite.setScale(
         tile.flippedHorizontal ? -1.0f : 1.0f,
         tile.flippedVertical ? -1.0f : 1.0f
@@ -833,8 +833,8 @@ std::shared_ptr<Overworld::Tileset> Overworld::SceneBase::ParseTileset(const XML
 
   for (auto& child : tilesetElement.children) {
     if (child.name == "tileoffset") {
-      drawingOffset.x = child.GetAttributeInt("x");
-      drawingOffset.y = child.GetAttributeInt("y");
+      drawingOffset.x = child.GetAttributeFloat("x");
+      drawingOffset.y = child.GetAttributeFloat("y");
     }
     else if (child.name == "grid") {
       orientation =

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -88,9 +88,9 @@ namespace Overworld {
 
     std::future<WebAccounts::AccountState> accountCommandResponse; /*!< Response object that will wait for data from web server*/
 
-    std::shared_ptr<Tileset> ParseTileset(XMLElement element, unsigned int firstgid);
-    std::vector<std::shared_ptr<Overworld::TileMeta>> ParseTileMetas(XMLElement tilesetElement, std::shared_ptr<Overworld::Tileset> tileset);
-    void HandleCamera(double elapsed);
+    std::shared_ptr<Tileset> ParseTileset(const XMLElement& element, unsigned int firstgid);
+    std::vector<std::shared_ptr<Overworld::TileMeta>> ParseTileMetas(const XMLElement& tilesetElement, const Overworld::Tileset& tileset);
+    void HandleCamera(float elapsed);
     void HandleInput();
     void LoadBackground(const std::string& value);
     void DrawMap(sf::RenderTarget& target, sf::RenderStates states);
@@ -183,26 +183,26 @@ namespace Overworld {
      * @brief Add a sprite
      * @param sprite
      */
-    void AddSprite(std::shared_ptr<WorldSprite> sprite);
+    void AddSprite(const std::shared_ptr<WorldSprite>& sprite);
 
     /**
      * @brief Remove a sprite
      * @param sprite
      */
-    void RemoveSprite(const std::shared_ptr<WorldSprite> sprite);
+    void RemoveSprite(const std::shared_ptr<WorldSprite>& sprite);
 
     /**
      * @brief Adds Actor for updates and rendering. (Calls AddSprite)
      * @param actor
      */
-    void AddActor(std::shared_ptr<Actor> actor);
+    void AddActor(const std::shared_ptr<Actor>& actor);
 
 
     /**
      * @brief Removes the actor for updates and rendering (Calls RemoveSprite)
      * @param actor
      */
-    void RemoveActor(const std::shared_ptr<Actor> actor);
+    void RemoveActor(const std::shared_ptr<Actor>& actor);
 
 
     /**

--- a/BattleNetwork/overworld/bnOverworldShapes.cpp
+++ b/BattleNetwork/overworld/bnOverworldShapes.cpp
@@ -195,7 +195,7 @@ namespace Overworld {
           try {
             x = stof(pointsString.substr(sliceStart, i));
           }
-          catch (std::exception& e) {
+          catch (std::exception&) {
             x = 0;
           }
 
@@ -209,7 +209,7 @@ namespace Overworld {
           try {
             y = stof(pointsString.substr(sliceStart, i));
           }
-          catch (std::exception& e) {
+          catch (std::exception&) {
             y = 0;
           }
 

--- a/BattleNetwork/overworld/bnOverworldSpatialMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldSpatialMap.cpp
@@ -10,11 +10,11 @@ namespace Overworld {
     this->chunkLength = 32;
   }
 
-  void SpatialMap::AddActor(std::shared_ptr<Actor> actor) {
+  void SpatialMap::AddActor(const std::shared_ptr<Actor>& actor) {
     actors.insert(actor);
   }
 
-  void SpatialMap::RemoveActor(std::shared_ptr<Actor> actor) {
+  void SpatialMap::RemoveActor(const std::shared_ptr<Actor>& actor) {
     auto iterEnd = actors.end();
     auto iter = find(actors.begin(), iterEnd, actor);
 
@@ -45,17 +45,17 @@ namespace Overworld {
   static void ForEachOverlappingChunk(
     float chunkLength,
     Actor& actor,
-    const std::function<void(size_t)> callback
+    const std::function<void(size_t)>& callback
   ) {
     auto pos = actor.getPosition();
     auto radius = actor.GetCollisionRadius() / chunkLength;
     auto x = pos.x / chunkLength;
     auto y = pos.y / chunkLength;
 
-    int startX = x - radius;
-    int startY = y - radius;
-    int endX = x + radius + 1;
-    int endY = y + radius + 1;
+    int startX = static_cast<int>(x - radius);
+    int startY = static_cast<int>(y - radius);
+    int endX = static_cast<int>(x + radius + 1);
+    int endY = static_cast<int>(y + radius + 1);
 
     for (int i = startX; i < endX; i++) {
       for (int j = startY; j < endY; j++) {

--- a/BattleNetwork/overworld/bnOverworldSpatialMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldSpatialMap.cpp
@@ -28,7 +28,7 @@ namespace Overworld {
   }
 
   std::vector<std::shared_ptr<Actor>> SpatialMap::GetChunk(float x, float y) {
-    auto chunkHash = GetHash(x / chunkLength, y / chunkLength);
+    auto chunkHash = GetHash((size_t)(x / chunkLength), (size_t)(y / chunkLength));
 
     auto it = chunks.find(chunkHash);
 

--- a/BattleNetwork/overworld/bnOverworldSpatialMap.h
+++ b/BattleNetwork/overworld/bnOverworldSpatialMap.h
@@ -15,8 +15,8 @@ namespace Overworld {
     SpatialMap();
 
     // automatically handled by Overworld::SceneBase AddActor/RemoveActor
-    void AddActor(std::shared_ptr<Actor> actor);
-    void RemoveActor(std::shared_ptr<Actor> actor);
+    void AddActor(const std::shared_ptr<Actor>& actor);
+    void RemoveActor(const std::shared_ptr<Actor>& actor);
     std::vector<std::shared_ptr<Actor>> GetChunk(float x, float y);
     std::unordered_set<std::shared_ptr<Actor>> GetNeighbors(Actor& actor);
 

--- a/BattleNetwork/overworld/bnOverworldTextBox.cpp
+++ b/BattleNetwork/overworld/bnOverworldTextBox.cpp
@@ -7,7 +7,7 @@
 namespace Overworld {
   TextBox::TextBox(sf::Vector2f pos) : textbox(pos) {}
 
-  void TextBox::SetNextSpeaker(sf::Sprite speaker, Animation animation) {
+  void TextBox::SetNextSpeaker(const sf::Sprite& speaker, const Animation& animation) {
     nextSpeaker = speaker;
     nextAnimation = animation;
   }

--- a/BattleNetwork/overworld/bnOverworldTextBox.h
+++ b/BattleNetwork/overworld/bnOverworldTextBox.h
@@ -12,7 +12,7 @@ namespace Overworld {
   public:
     TextBox(sf::Vector2f pos);
 
-    void SetNextSpeaker(sf::Sprite speaker, Animation animation);
+    void SetNextSpeaker(const sf::Sprite& speaker, const Animation& animation);
     void EnqueueMessage(const std::string& message, const std::function<void()>& onComplete = []() {});
     void EnqueueQuestion(const std::string& prompt, const std::function<void(bool)>& onResponse);
     void EnqueueQuiz(

--- a/BattleNetwork/overworld/bnOverworldTile.cpp
+++ b/BattleNetwork/overworld/bnOverworldTile.cpp
@@ -42,7 +42,7 @@ namespace Overworld {
     if (tileset->orientation == Projection::Orthographic) {
       // tiled uses position on sprite with orthographic projection
 
-      testPosition.x += tileSize.x / 2;
+      testPosition.x += static_cast<float>(tileSize.x / 2);
       testPosition.y += spriteBounds.height - tileSize.y;
     }
     else {

--- a/BattleNetwork/overworld/bnOverworldTile.cpp
+++ b/BattleNetwork/overworld/bnOverworldTile.cpp
@@ -21,7 +21,7 @@ namespace Overworld {
     auto tileSize = map.GetTileSize();
 
     if (rotated) {
-      auto tileCenter = sf::Vector2f(0, tileSize.y / 2);
+      auto tileCenter = sf::Vector2f(0, (float)(tileSize.y / 2));
 
       testPosition -= tileCenter;
       // rotate position counter clockwise

--- a/BattleNetwork/overworld/bnPacketShipper.cpp
+++ b/BattleNetwork/overworld/bnPacketShipper.cpp
@@ -4,7 +4,7 @@
 #include <Poco/Net/NetException.h>
 #include <algorithm>
 
-Overworld::PacketShipper::PacketShipper(Poco::Net::SocketAddress socketAddress)
+Overworld::PacketShipper::PacketShipper(const Poco::Net::SocketAddress& socketAddress)
 {
   this->socketAddress = socketAddress;
   nextUnreliableSequenced = 0;
@@ -20,7 +20,7 @@ bool Overworld::PacketShipper::HasFailed() {
 void Overworld::PacketShipper::Send(
   Poco::Net::DatagramSocket& socket,
   Reliability reliability,
-  const Poco::Buffer<char> body)
+  const Poco::Buffer<char>& body)
 {
   Poco::Buffer<char> data(0);
 
@@ -113,7 +113,7 @@ void Overworld::PacketShipper::sendSafe(
   }
   catch (Poco::IOException& e)
   {
-    if(e.code() == POCO_EWOULDBLOCK) {
+    if (e.code() == POCO_EWOULDBLOCK) {
       return;
     }
     Logger::Logf("Shipper Network exception: %s", e.displayText().c_str());

--- a/BattleNetwork/overworld/bnPacketShipper.h
+++ b/BattleNetwork/overworld/bnPacketShipper.h
@@ -31,10 +31,10 @@ namespace Overworld
     void acknowledgedReliableOrdered(uint64_t id);
 
   public:
-    PacketShipper(Poco::Net::SocketAddress socketAddress);
+    PacketShipper(const Poco::Net::SocketAddress& socketAddress);
 
     bool HasFailed();
-    void Send(Poco::Net::DatagramSocket& socket, Reliability Reliability, const Poco::Buffer<char> body);
+    void Send(Poco::Net::DatagramSocket& socket, Reliability Reliability, const Poco::Buffer<char>& body);
     void ResendBackedUpPackets(Poco::Net::DatagramSocket& socket);
     void Acknowledged(Reliability reliability, uint64_t id);
   };

--- a/BattleNetwork/overworld/bnPacketSorter.cpp
+++ b/BattleNetwork/overworld/bnPacketSorter.cpp
@@ -3,7 +3,7 @@
 #include "bnBufferReader.h"
 #include "../bnLogger.h"
 
-Overworld::PacketSorter::PacketSorter(Poco::Net::SocketAddress socketAddress)
+Overworld::PacketSorter::PacketSorter(const Poco::Net::SocketAddress& socketAddress)
 {
   this->socketAddress = socketAddress;
   nextReliable = 0;

--- a/BattleNetwork/overworld/bnPacketSorter.h
+++ b/BattleNetwork/overworld/bnPacketSorter.h
@@ -28,7 +28,7 @@ namespace Overworld
     void sendAck(Poco::Net::DatagramSocket& socket, Reliability Reliability, uint64_t id);
 
   public:
-    PacketSorter(Poco::Net::SocketAddress socketAddress);
+    PacketSorter(const Poco::Net::SocketAddress& socketAddress);
 
     std::chrono::time_point<std::chrono::steady_clock> GetLastMessageTime();
     std::vector<Poco::Buffer<char>> SortPacket(Poco::Net::DatagramSocket& socket, Poco::Buffer<char> packet);

--- a/BattleNetwork/overworld/bnXML.cpp
+++ b/BattleNetwork/overworld/bnXML.cpp
@@ -16,7 +16,7 @@ int XMLElement::GetAttributeInt(const std::string& name) const {
   try {
     return stoi(GetAttribute(name));
   }
-  catch (std::exception& e) {
+  catch (std::exception&) {
     // conversion failure, use default value (0)
   }
 
@@ -27,7 +27,7 @@ float XMLElement::GetAttributeFloat(const std::string& name) const {
   try {
     return stof(GetAttribute(name));
   }
-  catch (std::exception& e) {
+  catch (std::exception&) {
     // conversion failure, use default value (0)
   }
 


### PR DESCRIPTION
Changes:
 - Animations no longer reset when state changes
   - Fixes my spam input gliding issue
   - Fixes animation resetting when changing direction 
 - Sliding in every direction (diagonal)
 - Sliding on everything (actors)
 - Quiz no longer segfaults
 - Correctly track previous avatar in online area again
   - Fixes lag when switching avatar
 - Apply fixes suggested by warnings

Missing:
 - "iterator went past .end() somewhere"
   - Need to figure out how to reproduce this