### PR TITLE
Server transfers, Sound effects, Avatars, Idle Direction Syncing

### DIFF
--- a/BattleNetwork/overworld/bnOverworldHomepage.cpp
+++ b/BattleNetwork/overworld/bnOverworldHomepage.cpp
@@ -345,10 +345,13 @@ void Overworld::Homepage::OnTileCollision()
       netWarpTilePos.z
     );
 
+    auto address = getController().CommandLineValue<std::string>("cyberworld");
+    auto port = getController().CommandLineValue<uint16_t>("remotePort");
+
     auto teleportToCyberworld = [=] {
       this->TeleportUponReturn(returnPoint);
       client.close();
-      getController().push<segue<BlackWashFade>::to<Overworld::OnlineArea>>(maxPayloadSize, guest);
+      getController().push<segue<BlackWashFade>::to<Overworld::OnlineArea>>(address, port, "", maxPayloadSize, guest);
     };
 
     playerController.ReleaseActor();

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -1289,14 +1289,22 @@ void Overworld::OnlineArea::receiveNaviSetAvatarSignal(BufferReader& reader, con
   std::string texturePath = reader.ReadString(buffer);
   std::string animationPath = reader.ReadString(buffer);
 
-  if (user == ticket) return;
+  EmoteNode* emoteNode;
+  std::shared_ptr<Actor> actor;
 
-  auto userIter = onlinePlayers.find(user);
+  if (user == ticket) {
+    actor = GetPlayer();
+    emoteNode = &GetEmoteNode();
+  }
+  else {
+    auto userIter = onlinePlayers.find(user);
 
-  if (userIter == onlinePlayers.end()) return;
+    if (userIter == onlinePlayers.end()) return;
 
-  auto& onlinePlayer = userIter->second;
-  auto& actor = onlinePlayer.actor;
+    auto& onlinePlayer = userIter->second;
+    actor = onlinePlayer.actor;
+    emoteNode = &onlinePlayer.emoteNode;
+  }
 
   actor->setTexture(GetTexture(texturePath));
 
@@ -1304,9 +1312,8 @@ void Overworld::OnlineArea::receiveNaviSetAvatarSignal(BufferReader& reader, con
   animation.LoadWithData(GetText(animationPath));
   actor->LoadAnimations(animation);
 
-  auto& emoteNode = onlinePlayer.emoteNode;
-  float emoteY = -actor->getOrigin().y - emoteNode.getSprite().getLocalBounds().height / 2;
-  emoteNode.setPosition(0, emoteY);
+  float emoteY = -actor->getOrigin().y - emoteNode->getSprite().getLocalBounds().height / 2;
+  emoteNode->setPosition(0, emoteY);
 }
 
 void Overworld::OnlineArea::receiveNaviEmoteSignal(BufferReader& reader, const Poco::Buffer<char>& buffer)

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -391,8 +391,14 @@ void Overworld::OnlineArea::processIncomingPackets(double elapsed)
         case ServerEvents::asset_stream_complete:
           receiveAssetStreamCompleteSignal(reader, data);
           break;
+        case ServerEvents::preload:
+          receivePreloadSignal(reader, data);
+          break;
         case ServerEvents::map:
           receiveMapSignal(reader, data);
+          break;
+        case ServerEvents::play_sound:
+          receivePlaySoundSignal(reader, data);
           break;
         case ServerEvents::exclude_object:
           receiveExcludeObjectSignal(reader, data);
@@ -764,6 +770,12 @@ void Overworld::OnlineArea::receiveAssetStreamCompleteSignal(BufferReader& reade
   assetBuffer.setCapacity(0);
 }
 
+void Overworld::OnlineArea::receivePreloadSignal(BufferReader& reader, const Poco::Buffer<char>& buffer) {
+  auto name = reader.ReadString(buffer);
+
+  serverAssetManager.Preload(name);
+}
+
 static Direction resolveDirectionString(const std::string& direction) {
   if (direction == "Left") {
     return Direction::left;
@@ -915,6 +927,12 @@ void Overworld::OnlineArea::receiveMapSignal(BufferReader& reader, const Poco::B
       }
     }
   }
+}
+
+void Overworld::OnlineArea::receivePlaySoundSignal(BufferReader& reader, const Poco::Buffer<char>& buffer) {
+  auto name = reader.ReadString(buffer);
+
+  Audio().Play(GetAudio(name));
 }
 
 void Overworld::OnlineArea::receiveExcludeObjectSignal(BufferReader& reader, const Poco::Buffer<char>& buffer)

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -83,7 +83,9 @@ namespace Overworld {
     void receiveAssetRemoveSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveAssetStreamSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveAssetStreamCompleteSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receivePreloadSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveMapSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receivePlaySoundSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveExcludeObjectSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveIncludeObjectSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveTransferStartSignal(BufferReader& reader, const Poco::Buffer<char>&);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -21,7 +21,7 @@ namespace Overworld {
     std::shared_ptr<Overworld::Actor> actor;
     Overworld::EmoteNode emoteNode;
     Overworld::TeleportController teleportController{};
-    SelectedNavi currNavi{ std::numeric_limits<SelectedNavi>::max() };
+    Direction idleDirection;
     sf::Vector3f startBroadcastPos{};
     sf::Vector3f endBroadcastPos{};
     long long timestamp{};
@@ -98,7 +98,6 @@ namespace Overworld {
     void receiveNaviDisconnectedSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveNaviSetNameSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveNaviMoveSignal(BufferReader& reader, const Poco::Buffer<char>&);
-    void receiveNaviSetDirectionSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveNaviSetAvatarSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveNaviEmoteSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveNaviAnimateSignal(BufferReader& reader, const Poco::Buffer<char>&);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -16,7 +16,7 @@ namespace Overworld {
   constexpr size_t LAG_WINDOW_LEN = 300;
 
   struct OnlinePlayer {
-    OnlinePlayer(std::string name): actor(std::make_shared<Overworld::Actor>(name)) {}
+    OnlinePlayer(std::string name) : actor(std::make_shared<Overworld::Actor>(name)) {}
 
     std::shared_ptr<Overworld::Actor> actor;
     Overworld::EmoteNode emoteNode;
@@ -39,8 +39,10 @@ namespace Overworld {
     std::string ticket; //!< How we are represented on the server
     Poco::Net::DatagramSocket client; //!< us
     Poco::Net::SocketAddress remoteAddress; //!< server
+    std::string connectData;
     uint16_t maxPayloadSize;
     bool isConnected{ false };
+    bool transferringServers{ false };
     bool kicked{ false };
     PacketShipper packetShipper;
     PacketSorter packetSorter;
@@ -54,13 +56,13 @@ namespace Overworld {
     double packetResendTimer;
     Text transitionText;
     Text nameText;
-    bool wasReadingTextBox{false};
+    bool wasReadingTextBox{ false };
     std::vector<std::unordered_map<int, std::function<void()>>> tileTriggers;
 
 
     void processIncomingPackets(double elapsed);
 
-    void login();
+    void transferServer(const std::string& address, uint16_t port, const std::string& data, bool warpOut);
 
     void sendAssetFoundSignal(const std::string& path, uint64_t lastModified);
     void sendAssetsFound();
@@ -79,6 +81,9 @@ namespace Overworld {
     void sendDialogResponseSignal(char response);
 
     void receiveLoginSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveTransferStartSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveTransferCompleteSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveTransferServerSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveKickSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveAssetRemoveSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveAssetStreamSignal(BufferReader& reader, const Poco::Buffer<char>&);
@@ -88,8 +93,6 @@ namespace Overworld {
     void receivePlaySoundSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveExcludeObjectSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveIncludeObjectSignal(BufferReader& reader, const Poco::Buffer<char>&);
-    void receiveTransferStartSignal(BufferReader& reader, const Poco::Buffer<char>&);
-    void receiveTransferCompleteSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveMoveCameraSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveSlideCameraSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveMoveSignal(BufferReader& reader, const Poco::Buffer<char>&);
@@ -117,7 +120,14 @@ namespace Overworld {
     /**
      * @brief Loads the player's library data and loads graphics
      */
-    OnlineArea(swoosh::ActivityController&, uint16_t maxPayloadSize, bool guestAccount);
+    OnlineArea(
+      swoosh::ActivityController&,
+      const std::string& address,
+      uint16_t port,
+      const std::string& connectData,
+      uint16_t maxPayloadSize,
+      bool guestAccount
+    );
 
     /**
     * @brief deconstructor

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -1446,6 +1446,11 @@ SelectedNavi& Overworld::SceneBase::GetCurrentNavi()
   return currentNavi;
 }
 
+Overworld::EmoteNode& Overworld::SceneBase::GetEmoteNode()
+{
+  return emoteNode;
+}
+
 std::shared_ptr<Background> Overworld::SceneBase::GetBackground()
 {
   return this->bg;

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -282,6 +282,7 @@ namespace Overworld {
     PlayerController& GetPlayerController();
     TeleportController& GetTeleportController();
     SelectedNavi& GetCurrentNavi();
+    EmoteNode& GetEmoteNode();
     std::shared_ptr<Background> GetBackground();
     Overworld::TextBox& GetTextBox();
     bool IsInputLocked();

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -5,8 +5,8 @@
 
 namespace Overworld
 {
-  const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 4;
+  const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server/tree/development";
+  const uint64_t VERSION_ITERATION = 8;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -75,7 +75,6 @@ namespace Overworld
     navi_disconnect,
     navi_set_name,
     navi_move_to,
-    navi_set_direction,
     navi_set_avatar,
     navi_emote,
     navi_animate,

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server/tree/development";
-  const uint64_t VERSION_ITERATION = 8;
+  const uint64_t VERSION_ITERATION = 9;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -57,7 +57,9 @@ namespace Overworld
     remove_asset,
     asset_stream,
     asset_stream_complete,
+    preload,
     map,
+    play_sound,
     exclude_object,
     include_object,
     transfer_start,

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -5,8 +5,8 @@
 
 namespace Overworld
 {
-  const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server/tree/development";
-  const uint64_t VERSION_ITERATION = 9;
+  const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
+  const uint64_t VERSION_ITERATION = 5;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 5;
+  const uint64_t VERSION_ITERATION = 6;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -53,6 +53,9 @@ namespace Overworld
     pong = 0,
     ack,
     login,
+    transfer_start,
+    transfer_complete,
+    transfer_server,
     kick,
     remove_asset,
     asset_stream,
@@ -62,8 +65,6 @@ namespace Overworld
     play_sound,
     exclude_object,
     include_object,
-    transfer_start,
-    transfer_complete,
     move_camera,
     slide_camera,
     unlock_camera,

--- a/BattleNetwork/overworld/bnServerAssetManager.cpp
+++ b/BattleNetwork/overworld/bnServerAssetManager.cpp
@@ -146,34 +146,65 @@ std::vector<char> Overworld::ServerAssetManager::LoadFromCache(const std::string
   return data;
 }
 
-std::string Overworld::ServerAssetManager::GetText(const std::string& name) {
+void Overworld::ServerAssetManager::Preload(const std::string& name) {
+  auto extensionPos = name.rfind('.');
+
+  if (extensionPos == std::string::npos) {
+    PreloadText(name);
+    return;
+  }
+
+  auto extension = name.substr(extensionPos);
+
+  if (extension == ".ogg") {
+    PreloadAudio(name);
+  }
+  else if (extension == ".png" || extension == ".bmp") {
+    PreloadTexture(name);
+  }
+  else {
+    PreloadText(name);
+  }
+}
+
+void Overworld::ServerAssetManager::PreloadText(const std::string& name) {
   if (textAssets.find(name) == textAssets.end()) {
     auto data = LoadFromCache(name);
     std::string text(data.data(), data.size());
     textAssets[name] = text;
   }
-  return textAssets[name];
 }
 
-std::shared_ptr<sf::Texture> Overworld::ServerAssetManager::GetTexture(const std::string& name) {
+void Overworld::ServerAssetManager::PreloadTexture(const std::string& name) {
   if (textureAssets.find(name) == textureAssets.end()) {
     auto data = LoadFromCache(name);
     auto texture = std::make_shared<sf::Texture>();
     texture->loadFromMemory(data.data(), data.size());
     textureAssets[name] = texture;
   }
-
-  return textureAssets[name];
 }
 
-std::shared_ptr<sf::SoundBuffer> Overworld::ServerAssetManager::GetAudio(const std::string& name) {
+void Overworld::ServerAssetManager::PreloadAudio(const std::string& name) {
   if (audioAssets.find(name) == audioAssets.end()) {
     auto data = LoadFromCache(name);
     auto audio = std::make_shared<sf::SoundBuffer>();
     audio->loadFromMemory(data.data(), data.size());
     audioAssets[name] = audio;
   }
+}
 
+std::string Overworld::ServerAssetManager::GetText(const std::string& name) {
+  PreloadText(name);
+  return textAssets[name];
+}
+
+std::shared_ptr<sf::Texture> Overworld::ServerAssetManager::GetTexture(const std::string& name) {
+  PreloadTexture(name);
+  return textureAssets[name];
+}
+
+std::shared_ptr<sf::SoundBuffer> Overworld::ServerAssetManager::GetAudio(const std::string& name) {
+  PreloadAudio(name);
   return audioAssets[name];
 }
 

--- a/BattleNetwork/overworld/bnServerAssetManager.h
+++ b/BattleNetwork/overworld/bnServerAssetManager.h
@@ -30,6 +30,11 @@ namespace Overworld {
     std::string GetPath(const std::string& name);
     const std::unordered_map<std::string, CacheMeta>& GetCachedAssetList();
 
+    void Preload(const std::string& name);
+    void PreloadText(const std::string& name);
+    void PreloadTexture(const std::string& name);
+    void PreloadAudio(const std::string& name);
+
     std::string GetText(const std::string& name);
     std::shared_ptr<sf::Texture> GetTexture(const std::string& name);
     std::shared_ptr<sf::SoundBuffer> GetAudio(const std::string& name);


### PR DESCRIPTION
Changes:
  - Add Server Warp and Custom Server Warp
    - Eventually they should ping servers and download icons
  - Add transfer_server packet
  - Add preload and play_sound packets
  - Update client avatar on receiveNaviSetAvatarSignal
    - Allows the server to override your overworld avatar
  - Sync direction when the player is idle
    - Fixes facing direction when warped or stuck