### PR TITLE
OW undefined behavior fixes

### DIFF
--- a/BattleNetwork/bnSpriteProxyNode.h
+++ b/BattleNetwork/bnSpriteProxyNode.h
@@ -68,13 +68,6 @@ public:
   sf::Sprite& getSprite() const;
 
   /**
-  * @brief returns the sprite's origin values
-  */
-  const sf::Vector2f getOrigin() const {
-    return sprite->getOrigin();
-  }
-
-  /**
    * @brief Get current texture proxy
    * @return texture of sprite
    */

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -1532,7 +1532,7 @@ void Overworld::OnlineArea::receiveActorConnectedSignal(BufferReader& reader, co
   actor->LoadAnimations(animation);
 
   auto& emoteNode = onlinePlayer.emoteNode;
-  float emoteY = -actor->getOrigin().y - emoteNode.getSprite().getLocalBounds().height / 2 - 1;
+  float emoteY = -actor->getSprite().getOrigin().y - emoteNode.getSprite().getLocalBounds().height / 2 - 1;
   emoteNode.setPosition(0, emoteY);
 
   auto& teleportController = onlinePlayer.teleportController;
@@ -1699,7 +1699,7 @@ void Overworld::OnlineArea::receiveActorSetAvatarSignal(BufferReader& reader, co
   animation.LoadWithData(GetText(animationPath));
   actor->LoadAnimations(animation);
 
-  float emoteY = -actor->getOrigin().y - emoteNode->getSprite().getLocalBounds().height / 2;
+  float emoteY = -actor->getSprite().getOrigin().y - emoteNode->getSprite().getLocalBounds().height / 2;
   emoteNode->setPosition(0, emoteY);
 }
 

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -697,7 +697,7 @@ void Overworld::SceneBase::RefreshNaviSprite()
     playerActor->LoadAnimations(owPath);
 
     // move the emote above the player's head
-    float emoteY = -playerActor->getOrigin().y - emoteNode.getSprite().getLocalBounds().height / 2;
+    float emoteY = -playerActor->getSprite().getOrigin().y - emoteNode.getSprite().getLocalBounds().height / 2;
     emoteNode.setPosition(0, emoteY);
 
     auto iconTexture = meta.GetIconTexture();
@@ -1492,7 +1492,7 @@ std::pair<unsigned, unsigned> Overworld::SceneBase::PixelToRowCol(const sf::Vect
 const bool Overworld::SceneBase::IsMouseHovering(const sf::Vector2f& mouse, const WorldSprite& src)
 {
   auto textureRect = src.getSprite().getTextureRect();
-  auto origin = src.getOrigin();
+  auto origin = src.getSprite().getOrigin();
 
   auto& map = GetMap();
   auto tileSize = map.GetTileSize();

--- a/BattleNetwork/overworld/bnOverworldShapes.cpp
+++ b/BattleNetwork/overworld/bnOverworldShapes.cpp
@@ -89,6 +89,14 @@ namespace Overworld {
   void Polygon::AddPoint(float x, float y) {
     points.emplace_back(std::make_tuple(x, y));
 
+    if(points.size() == 1) {
+      smallestX = x;
+      smallestY = y;
+      largestX = x;
+      largestY = y;
+      return;
+    }
+
     if (x < smallestX) {
       smallestX = x;
     }


### PR DESCRIPTION
Changes:
  - SpriteProxyNode no longer shadows Transformable's getOrigin
  - Fixed a segfault in minimap's copy constructor
  - Fixed multiple comparisons against uninitialized values in Polygon::AddPoint 