### PR TITLE
Fixed missing include in bnTaskGroup.cpp

### DIFF
--- a/BattleNetwork/bnTaskGroup.cpp
+++ b/BattleNetwork/bnTaskGroup.cpp
@@ -1,3 +1,4 @@
+#include <string>
 #include "bnTaskGroup.h"
 
 TaskGroup::TaskGroup(TaskGroup && other) noexcept


### PR DESCRIPTION
#include <string> was missing and causing compile time errors.  This PR fixes that.  
Konst told me to do this in Discord  :v 