### PR TITLE
Missing flags NetManager crash fix

### DIFF
--- a/BattleNetwork/bnCachedResource.h
+++ b/BattleNetwork/bnCachedResource.h
@@ -1,6 +1,8 @@
 #pragma once
+#include "bnCurrentTime.h"
 #include <Swoosh/Timer.h>
 #include <memory>
+
 /*! \brief Represents a cached resource of type T. It knows how frequently it is used.
 */
 template<typename T>

--- a/BattleNetwork/bnNetManager.cpp
+++ b/BattleNetwork/bnNetManager.cpp
@@ -3,7 +3,8 @@
 
 NetManager::NetManager()
 {
-
+  client = std::make_shared<Poco::Net::DatagramSocket>();
+  BindPort(0);
 }
 
 NetManager::~NetManager()
@@ -89,7 +90,7 @@ const bool NetManager::BindPort(int port)
 {
   try {
     Poco::Net::SocketAddress sa(Poco::Net::IPAddress(), port);
-    client = std::make_shared<Poco::Net::DatagramSocket>(sa);
+    client->bind(sa);
     client->setBlocking(false);
   }
   catch (...) {

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -74,6 +74,7 @@ Overworld::OnlineArea::OnlineArea(
 
 Overworld::OnlineArea::~OnlineArea()
 {
+  // TODO: network manager is deleted by the time this deconstructor is reached...
   sendLogoutSignal();
   Net().DropProcessor(packetProcessor);
 }


### PR DESCRIPTION
Fixes a NetManager crash caused by socket client not being created unless a port is binded

Also added back todo comment and fixed a compilation error with clang