### PR TITLE
Packet processor fixes and overworld optimizations

### DIFF
--- a/BattleNetwork/overworld/bnOverworldHomepage.cpp
+++ b/BattleNetwork/overworld/bnOverworldHomepage.cpp
@@ -290,11 +290,19 @@ void Overworld::Homepage::onResume()
   SceneBase::onResume();
   Audio().Stream("resources/loops/loop_overworld.ogg", false);
   infocus = true;
+
+  if (packetProcessor) {
+    Net().AddHandler(remoteAddress, packetProcessor);
+  }
 }
 
 void Overworld::Homepage::onLeave()
 {
   infocus = false;
+
+  if (packetProcessor) {
+    Net().DropProcessor(packetProcessor);
+  }
 
   // repeat reconnection in case there was a fail that
   // forced us to return

--- a/BattleNetwork/overworld/bnOverworldMap.h
+++ b/BattleNetwork/overworld/bnOverworldMap.h
@@ -9,6 +9,7 @@
 #include "bnOverworldSprite.h"
 #include "bnOverworldTile.h"
 #include "bnOverworldObject.h"
+#include "bnOverworldShadowMap.h"
 #include "../bnAnimation.h"
 
 namespace Overworld {
@@ -65,6 +66,7 @@ namespace Overworld {
       std::vector<ShapeObject> shapeObjects;
       std::vector<TileObject> tileObjects;
       std::vector<std::shared_ptr<WorldSprite>> spritesForAddition;
+      bool tilesModified{};
 
       friend class Map;
     };
@@ -154,6 +156,7 @@ namespace Overworld {
     bool CanMoveTo(float x, float y, float z, int layer); // todo: move to layer?
     float GetElevationAt(float x, float y, int layer);
     bool IgnoreTileAbove(float x, float y, int layer);
+    bool HasShadow(sf::Vector2i tilePos, int layer);
     void RemoveSprites(SceneBase& scene);
 
   protected:
@@ -161,10 +164,12 @@ namespace Overworld {
     int tileWidth{}, tileHeight{}; /*!< tile dimensions */
     std::string name, backgroundName, backgroundCustomTexturePath, backgroundCustomAnimationPath, songPath;
     sf::Vector2f backgroundCustomVelocity;
+    ShadowMap shadowMap;
     std::vector<Layer> layers;
     std::vector<std::shared_ptr<Tileset>> tileToTilesetMap;
     std::unordered_map<std::string, std::shared_ptr<Tileset>> tilesets;
     std::vector<std::shared_ptr<TileMeta>> tileMetas;
+    bool tilesModified{};
 
     /**
      * @brief Transforms an iso vector into an orthographic vector

--- a/BattleNetwork/overworld/bnOverworldObject.cpp
+++ b/BattleNetwork/overworld/bnOverworldObject.cpp
@@ -49,6 +49,11 @@ namespace Overworld {
       ortho.y = std::sin(orthoRadians + rotationRadians) * magnitude;
     }
 
+    // scale
+    auto scale = sf::Vector2f(size.x / spriteBounds.width, size.y / spriteBounds.height);
+    ortho.x /= scale.x;
+    ortho.y /= scale.y;
+
     // calculate offset separately as we need to transform it separately
     auto orthoOffset = -tileset->alignmentOffset;
 
@@ -88,11 +93,6 @@ namespace Overworld {
 
     ortho += orthoOffset;
 
-    // scale
-    auto scale = sf::Vector2f(size.x / spriteBounds.width, size.y / spriteBounds.height);
-    ortho.x /= scale.x;
-    ortho.y /= scale.y;
-
     iso = map.OrthoToIsometric(ortho);
 
     return tile.Intersects(map, iso.x, iso.y);
@@ -119,16 +119,19 @@ namespace Overworld {
     auto horizontalMultiplier = tile.flippedHorizontal ? -1.0f : 1.0f;
     auto verticalMultiplier = tile.flippedVertical ? -1.0f : 1.0f;
     auto localBounds = worldSprite->getLocalBounds();
+    auto scale = sf::Vector2f(size.x / localBounds.width, size.y / localBounds.height);
 
     worldSprite->setPosition(position);
-    worldSprite->setScale(horizontalMultiplier * size.x / localBounds.width, verticalMultiplier * size.y / localBounds.height);
+    worldSprite->setScale(horizontalMultiplier * scale.x, verticalMultiplier * scale.y);
 
     auto ortho = map.WorldToScreen(position);
 
     sf::Transform preTransform;
     preTransform.translate(ortho);
     preTransform.rotate(rotation);
+    preTransform.scale(scale.x, scale.y);
     preTransform.translate(tileMeta->alignmentOffset + tileMeta->drawingOffset + origin);
+    preTransform.scale(1.0f / scale.x, 1.0f / scale.y);
     preTransform.translate(-ortho);
     worldSprite->SetPreTransform(preTransform);
   }

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -78,16 +78,16 @@ Overworld::OnlineArea::~OnlineArea()
 
 void Overworld::OnlineArea::onUpdate(double elapsed)
 {
+  if (!packetProcessor) {
+    return;
+  }
+
   if (packetProcessor->TimedOut()) {
     leave();
     return;
   }
 
-  if (kicked) {
-    return;
-  }
-
-  if (!isConnected) {
+  if (!isConnected || kicked) {
     return;
   }
 
@@ -265,20 +265,28 @@ void Overworld::OnlineArea::onStart()
 
 void Overworld::OnlineArea::onEnd()
 {
-  sendLogoutSignal();
-  Net().DropProcessor(packetProcessor);
+  if (packetProcessor) {
+    sendLogoutSignal();
+    Net().DropProcessor(packetProcessor);
+  }
 }
 
 void Overworld::OnlineArea::onLeave()
 {
   SceneBase::onLeave();
-  packetProcessor->SetBackground();
+
+  if (packetProcessor) {
+    packetProcessor->SetBackground();
+  }
 }
 
 void Overworld::OnlineArea::onResume()
 {
   SceneBase::onResume();
-  packetProcessor->SetForeground();
+
+  if (packetProcessor) {
+    packetProcessor->SetForeground();
+  }
 }
 
 void Overworld::OnlineArea::OnTileCollision()
@@ -1751,6 +1759,11 @@ void Overworld::OnlineArea::receiveActorAnimateSignal(BufferReader& reader, cons
 }
 
 void Overworld::OnlineArea::leave() {
+  if (packetProcessor) {
+    Net().DropProcessor(packetProcessor);
+    packetProcessor = nullptr;
+  }
+
   using effect = segue<PixelateBlackWashFade>;
   getController().pop<effect>();
 }

--- a/BattleNetwork/overworld/bnOverworldPacketProcessor.h
+++ b/BattleNetwork/overworld/bnOverworldPacketProcessor.h
@@ -25,7 +25,7 @@ namespace Overworld {
     PacketShipper packetShipper;
     PacketSorter packetSorter;
     Reliability keepAliveReliability;
-    Poco::Buffer<char> keepAliveBody { 0 };
+    Poco::Buffer<char> keepAliveBody{ 0 };
     double keepAliveTimer{};
     double packetResendTimer{};
     bool background{};

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -492,9 +492,6 @@ void Overworld::SceneBase::onDraw(sf::RenderTexture& surface) {
 }
 
 void Overworld::SceneBase::DrawWorld(sf::RenderTarget& target, sf::RenderStates states) {
-  // resize shadow grid
-  shadowMap.CalculateShadows(map);
-
   const auto& mapScale = GetMap().getScale();
   sf::Vector2f cameraCenter = camera.GetView().getCenter();
   cameraCenter.x = std::floor(cameraCenter.x) * mapScale.x;
@@ -587,7 +584,7 @@ void Overworld::SceneBase::DrawMapLayer(sf::RenderTarget& target, sf::RenderStat
 
       if (/*cam && cam->IsInView(tileSprite)*/ true) {
         sf::Color originalColor = tileSprite.getColor();
-        if (shadowMap.HasShadow(j, i, index)) {
+        if (map.HasShadow({ j, i }, index)) {
           sf::Uint8 r, g, b;
           r = sf::Uint8(originalColor.r * 0.65);
           b = sf::Uint8(originalColor.b * 0.65);
@@ -633,14 +630,7 @@ void Overworld::SceneBase::DrawSpriteLayer(sf::RenderTarget& target, sf::RenderS
         index = index >= 1 ? (index - 1) : 0;
       }
 
-      // index == 0 will NEVER have sprites
-      bool evaluate = (
-        gridPos.x >= 0 &&
-        gridPos.y >= 0 &&
-        index > 0 && index < mapLayerCount + 1
-        );
-
-      if (evaluate && shadowMap.HasShadow(gridPos.x, gridPos.y, index - 1)) {
+      if (map.HasShadow(gridPos, int(index) - 1)) {
         sf::Uint8 r, g, b;
         r = sf::Uint8(originalColor.r * 0.5);
         b = sf::Uint8(originalColor.b * 0.5);

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -25,6 +25,7 @@
 #include "bnOverworldPathController.h"
 #include "bnOverworldTeleportController.h"
 #include "bnOverworldSpatialMap.h"
+#include "bnOverworldShadowMap.h"
 #include "bnOverworldMap.h"
 #include "bnOverworldPersonalMenu.h"
 #include "bnOverworldMenuSystem.h"
@@ -79,7 +80,7 @@ namespace Overworld {
     Overworld::Map map; /*!< Overworld map */
     std::vector<std::shared_ptr<WorldSprite>> sprites;
     std::vector<std::vector<std::shared_ptr<WorldSprite>>> spriteLayers;
-    std::vector<short> gridShadows;
+    ShadowMap shadowMap;
     Overworld::MenuSystem menuSystem;
 
     /*!< Current navi selection index */
@@ -99,8 +100,8 @@ namespace Overworld {
     void HandleInput();
     void LoadBackground(const Map& map, const std::string& value);
     void DrawWorld(sf::RenderTarget& target, sf::RenderStates states);
-    void DrawMapLayer(sf::RenderTarget& target, sf::RenderStates states, size_t layer, size_t maxLayers, std::vector<short>&);
-    void DrawSpriteLayer(sf::RenderTarget& target, sf::RenderStates states, size_t layer, const std::vector<short>&);
+    void DrawMapLayer(sf::RenderTarget& target, sf::RenderStates states, size_t layer, size_t maxLayers);
+    void DrawSpriteLayer(sf::RenderTarget& target, sf::RenderStates states, size_t layer);
     void PrintTime(sf::RenderTarget& target);
 
 #ifdef __ANDROID__

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -25,7 +25,6 @@
 #include "bnOverworldPathController.h"
 #include "bnOverworldTeleportController.h"
 #include "bnOverworldSpatialMap.h"
-#include "bnOverworldShadowMap.h"
 #include "bnOverworldMap.h"
 #include "bnOverworldPersonalMenu.h"
 #include "bnOverworldMenuSystem.h"
@@ -80,7 +79,6 @@ namespace Overworld {
     Overworld::Map map; /*!< Overworld map */
     std::vector<std::shared_ptr<WorldSprite>> sprites;
     std::vector<std::vector<std::shared_ptr<WorldSprite>>> spriteLayers;
-    ShadowMap shadowMap;
     Overworld::MenuSystem menuSystem;
 
     /*!< Current navi selection index */

--- a/BattleNetwork/overworld/bnOverworldShadowMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldShadowMap.cpp
@@ -1,0 +1,51 @@
+#include "bnOverworldShadowMap.h"
+
+static inline size_t calculateIndex(size_t cols, size_t x, size_t y) {
+  return y * cols + x;
+}
+
+namespace Overworld {
+  void ShadowMap::CalculateShadows(Map& map) {
+    cols = (size_t)map.GetCols();
+    rows = (size_t)map.GetRows();
+
+    shadows.resize(cols * rows);
+    std::fill(shadows.begin(), shadows.end(), 0);
+
+
+    for (size_t x = 0; x < cols; x++) {
+      for (size_t y = 0; y < rows; y++) {
+        for (auto index = map.GetLayerCount() - 1; index >= 1; index--) {
+          auto& layer = map.GetLayer(index);
+          auto& tile = layer.GetTile((int)x, (int)y);
+
+          if (tile.gid == 0) {
+            continue;
+          }
+
+          if (map.IgnoreTileAbove(float(x), float(y), int(index - 1))) {
+            continue;
+          }
+
+          auto shadowIndex = calculateIndex(cols, x, y);
+          shadows[shadowIndex] = index;
+          break;
+        }
+      }
+    }
+  }
+
+  bool ShadowMap::HasShadow(size_t x, size_t y, size_t layer) {
+    if (x >= cols || y >= rows) {
+      return false;
+    }
+
+    auto shadowIndex = calculateIndex(cols, x, y);
+
+    if (shadowIndex > shadows.size()) {
+      return false;
+    }
+
+    return layer < shadows[shadowIndex];
+  }
+}

--- a/BattleNetwork/overworld/bnOverworldShadowMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldShadowMap.cpp
@@ -1,20 +1,25 @@
 #include "bnOverworldShadowMap.h"
 
+#include "bnOverworldMap.h"
+
 static inline size_t calculateIndex(size_t cols, size_t x, size_t y) {
   return y * cols + x;
 }
 
 namespace Overworld {
+  ShadowMap::ShadowMap(size_t cols, size_t rows) :
+    cols(cols),
+    rows(rows)
+  {
+    shadows.resize(cols * rows, 0);
+  }
+
   void ShadowMap::CalculateShadows(Map& map) {
-    cols = (size_t)map.GetCols();
-    rows = (size_t)map.GetRows();
-
-    shadows.resize(cols * rows);
-    std::fill(shadows.begin(), shadows.end(), 0);
-
-
     for (size_t x = 0; x < cols; x++) {
       for (size_t y = 0; y < rows; y++) {
+        auto shadowIndex = calculateIndex(cols, x, y);
+        shadows[shadowIndex] = 0;
+
         for (auto index = map.GetLayerCount() - 1; index >= 1; index--) {
           auto& layer = map.GetLayer(index);
           auto& tile = layer.GetTile((int)x, (int)y);
@@ -27,7 +32,6 @@ namespace Overworld {
             continue;
           }
 
-          auto shadowIndex = calculateIndex(cols, x, y);
           shadows[shadowIndex] = index;
           break;
         }

--- a/BattleNetwork/overworld/bnOverworldShadowMap.h
+++ b/BattleNetwork/overworld/bnOverworldShadowMap.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "bnOverworldMap.h"
+
+namespace Overworld {
+  class ShadowMap {
+  public:
+    void CalculateShadows(Map& map);
+    bool HasShadow(size_t x, size_t y, size_t layer);
+  private:
+    std::vector<size_t> shadows;
+    size_t cols, rows;
+  };
+}

--- a/BattleNetwork/overworld/bnOverworldShadowMap.h
+++ b/BattleNetwork/overworld/bnOverworldShadowMap.h
@@ -1,9 +1,13 @@
 #pragma once
-#include "bnOverworldMap.h"
+#include <vector>
 
 namespace Overworld {
+  class Map;
+
   class ShadowMap {
   public:
+    ShadowMap(size_t cols, size_t rows);
+
     void CalculateShadows(Map& map);
     bool HasShadow(size_t x, size_t y, size_t layer);
   private:


### PR DESCRIPTION
Changes:
  - Tile culling
  - Shadow crash fix
  - Shadow optimization (updates only on map changes, uses less memory)
  - Fix packet processor tracking in NetManager
  - Remove Homepage packet processor when leaving homepage, add back when resuming