### PR TITLE
Server initiated PVP + Warps

### DIFF
--- a/BattleNetwork/overworld/bnOverworldMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldMap.cpp
@@ -445,7 +445,7 @@ namespace Overworld {
     return *iter;
   }
 
-  const std::vector<TileObject>& Map::Layer::GetTileObjects() {
+  std::vector<TileObject>& Map::Layer::GetTileObjects() {
     return tileObjects;
   }
 

--- a/BattleNetwork/overworld/bnOverworldMap.h
+++ b/BattleNetwork/overworld/bnOverworldMap.h
@@ -49,7 +49,7 @@ namespace Overworld {
 
       std::optional<std::reference_wrapper<TileObject>> GetTileObject(unsigned int id);
       std::optional<std::reference_wrapper<TileObject>> GetTileObject(const std::string& name);
-      const std::vector<TileObject>& GetTileObjects();
+      std::vector<TileObject>& GetTileObjects(); // todo: make std::span
       void AddTileObject(TileObject tileObject);
 
       std::optional<std::reference_wrapper<ShapeObject>> GetShapeObject(unsigned int id);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -1144,22 +1144,7 @@ void Overworld::OnlineArea::receiveMapSignal(BufferReader& reader, const Poco::B
         tileObject.solid = false;
         warpLayer.push_back(&tileObject);
       }
-      else if (type == "Server Warp") {
-        minimap.AddWarpPosition(map.WorldToScreen(objectCenterPos) + zOffset);
-        tileObject.solid = false;
-        warpLayer.push_back(&tileObject);
-      }
-      else if (type == "Custom Server Warp") {
-        minimap.AddWarpPosition(map.WorldToScreen(objectCenterPos) + zOffset);
-        tileObject.solid = false;
-        warpLayer.push_back(&tileObject);
-      }
-      else if (type == "Position Warp") {
-        minimap.AddWarpPosition(map.WorldToScreen(objectCenterPos) + zOffset);
-        tileObject.solid = false;
-        warpLayer.push_back(&tileObject);
-      }
-      else if (type == "Custom Warp") {
+      else if (type == "Server Warp" || type == "Custom Server Warp" || type == "Position Warp" || type == "Custom Warp") {
         minimap.AddWarpPosition(map.WorldToScreen(objectCenterPos) + zOffset);
         tileObject.solid = false;
         warpLayer.push_back(&tileObject);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -1127,6 +1127,8 @@ void Overworld::OnlineArea::receiveMapSignal(BufferReader& reader, const Poco::B
     for (auto& tileObject : map.GetLayer(i).GetTileObjects()) {
       const std::string& type = tileObject.type;
 
+      if (type == "") continue;
+
       auto tileMeta = map.GetTileMeta(tileObject.tile.gid);
 
       if (!tileMeta) continue;

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -121,6 +121,7 @@ namespace Overworld {
     void receiveAppendPostsSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveRemovePostSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receivePostSelectionAckSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receivePVPSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveActorConnectedSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveActorDisconnectedSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveActorSetNameSignal(BufferReader& reader, const Poco::Buffer<char>&);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -60,17 +60,19 @@ namespace Overworld {
     AssetMeta incomingAsset;
     std::map<std::string, OnlinePlayer> onlinePlayers;
     std::map<unsigned, ExcludedObjectData> excludedObjects;
+    std::vector<std::vector<TileObject*>> warps;
     std::list<std::string> removePlayers;
+    sf::Vector3f lastPosition;
     Timer movementTimer;
     Text transitionText;
     Text nameText;
     bool wasReadingTextBox{ false };
-    std::vector<std::unordered_map<int, std::function<void()>>> tileTriggers;
 
-
-    void processPacketBody(const Poco::Buffer<char>& data);
-
+    void detectWarp();
+    bool positionIsInWarp(sf::Vector3f position);
+    Overworld::TeleportController::Command& teleportIn(sf::Vector3f position, Direction direction);
     void transferServer(const std::string& address, uint16_t port, const std::string& data, bool warpOut);
+    void processPacketBody(const Poco::Buffer<char>& data);
 
     void sendAssetFoundSignal(const std::string& path, uint64_t lastModified);
     void sendAssetsFound();
@@ -80,6 +82,7 @@ namespace Overworld {
     void sendRequestJoinSignal();
     void sendReadySignal();
     void sendTransferredOutSignal();
+    void sendCustomWarpSignal(unsigned int tileObjectId);
     void sendPositionSignal();
     void sendAvatarChangeSignal();
     void sendAvatarAssetStream();

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -79,6 +79,7 @@ namespace Overworld {
     void sendLogoutSignal();
     void sendRequestJoinSignal();
     void sendReadySignal();
+    void sendTransferredOutSignal();
     void sendPositionSignal();
     void sendAvatarChangeSignal();
     void sendAvatarAssetStream();
@@ -93,6 +94,7 @@ namespace Overworld {
     void sendPostSelectSignal(const std::string& postId);
 
     void receiveLoginSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveTransferWarpSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveTransferStartSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveTransferCompleteSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveTransferServerSignal(BufferReader& reader, const Poco::Buffer<char>&);

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -1444,6 +1444,21 @@ std::shared_ptr<Background> Overworld::SceneBase::GetBackground()
   return this->bg;
 }
 
+PA& Overworld::SceneBase::GetProgramAdvance() {
+  return programAdvance;
+}
+
+std::optional<CardFolder*> Overworld::SceneBase::GetSelectedFolder() {
+  CardFolder* folder;
+
+  if (folders.GetFolder(0, folder)) {
+    return folder;
+  }
+  else {
+    return {};
+  }
+}
+
 Overworld::MenuSystem& Overworld::SceneBase::GetMenuSystem()
 {
   return menuSystem;

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -1242,7 +1242,11 @@ void Overworld::SceneBase::RemoveActor(const std::shared_ptr<Actor>& actor) {
 }
 
 bool Overworld::SceneBase::IsInputLocked() {
-  return inputLocked || !personalMenu.IsClosed() || !menuSystem.IsClosed() || gotoNextScene || showMinimap || !teleportController.IsComplete();
+  return
+    inputLocked || gotoNextScene || showMinimap ||
+    !personalMenu.IsClosed() ||
+    !menuSystem.IsClosed() ||
+    !teleportController.IsComplete() || teleportController.TeleportedOut();
 }
 
 void Overworld::SceneBase::LockInput() {

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -3,6 +3,7 @@
 #include <SFML/Graphics.hpp>
 #include <time.h>
 #include <future>
+#include <optional>
 #include <Swoosh/Activity.h>
 #include <Swoosh/ActivityController.h>
 
@@ -283,6 +284,8 @@ namespace Overworld {
     SelectedNavi& GetCurrentNavi();
     EmoteNode& GetEmoteNode();
     std::shared_ptr<Background> GetBackground();
+    PA& GetProgramAdvance();
+    std::optional<CardFolder*> GetSelectedFolder();
     Overworld::MenuSystem& GetMenuSystem();
     bool IsInputLocked();
     bool IsCameraLocked();

--- a/BattleNetwork/overworld/bnOverworldShadowMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldShadowMap.cpp
@@ -15,12 +15,14 @@ namespace Overworld {
   }
 
   void ShadowMap::CalculateShadows(Map& map) {
-    for (size_t x = 0; x < cols; x++) {
-      for (size_t y = 0; y < rows; y++) {
+    auto layerCount = map.GetLayerCount();
+
+    for (size_t y = 0; y < rows; y++) {
+      for (size_t x = 0; x < cols; x++) {
         auto shadowIndex = calculateIndex(cols, x, y);
         shadows[shadowIndex] = 0;
 
-        for (auto index = map.GetLayerCount() - 1; index >= 1; index--) {
+        for (auto index = layerCount - 1; index >= 1; index--) {
           auto& layer = map.GetLayer(index);
           auto& tile = layer.GetTile((int)x, (int)y);
 

--- a/BattleNetwork/overworld/bnOverworldTeleportController.cpp
+++ b/BattleNetwork/overworld/bnOverworldTeleportController.cpp
@@ -18,29 +18,36 @@ Overworld::TeleportController::TeleportController()
 Overworld::TeleportController::Command& Overworld::TeleportController::TeleportOut(std::shared_ptr<Actor> actor)
 {
   this->actor = actor;
-  this->actor->Hide();
 
-  auto onStart = [=] {
-    if (!mute) {
-      Audio().Play(AudioType::AREA_GRAB);
-    }
-  };
+  if (!teleportedOut) {
+    actor->Hide();
 
-  auto onFinish = [=] {
-    this->animComplete = true;
-  };
+    auto onStart = [=] {
+      if (!mute) {
+        Audio().Play(AudioType::AREA_GRAB);
+      }
+    };
 
-  this->animComplete = false;
-  this->beamAnim << "TELEPORT_OUT" << Animator::On(1, onStart) << onFinish;
-  this->beamAnim.Refresh(this->beam->getSprite());
-  this->beam->Set3DPosition(actor->Get3DPosition());
+    auto onFinish = [=] {
+      this->animComplete = true;
+    };
 
-  this->sequence.push(Command{ Command::state::teleport_out });
-  return this->sequence.back();
+    animComplete = false;
+    beamAnim << "TELEPORT_OUT" << Animator::On(1, onStart) << onFinish;
+    beamAnim.Refresh(beam->getSprite());
+    beam->Set3DPosition(actor->Get3DPosition());
+
+    teleportedOut = true;
+  }
+
+  sequence.push(Command{ Command::state::teleport_out });
+  return sequence.back();
 }
 
 Overworld::TeleportController::Command& Overworld::TeleportController::TeleportIn(std::shared_ptr<Actor> actor, const sf::Vector3f& start, Direction dir, bool doSpin)
 {
+  teleportedOut = false;
+
   auto onStart = [=] {
     if (!mute) {
       Audio().Play(AudioType::AREA_GRAB);
@@ -125,6 +132,10 @@ void Overworld::TeleportController::Update(double elapsed)
       sequence.pop();
     }
   }
+}
+
+bool Overworld::TeleportController::TeleportedOut() const {
+  return teleportedOut;
 }
 
 const bool Overworld::TeleportController::IsComplete() const

--- a/BattleNetwork/overworld/bnOverworldTeleportController.h
+++ b/BattleNetwork/overworld/bnOverworldTeleportController.h
@@ -29,6 +29,7 @@ namespace Overworld {
     Command& TeleportOut(std::shared_ptr<Actor> actor);
     Command& TeleportIn(std::shared_ptr<Actor> actor, const sf::Vector3f& start, Direction dir, bool doSpin = false);
     void Update(double elapsed);
+    bool TeleportedOut() const;
     const bool IsComplete() const;
     std::shared_ptr<WorldSprite> GetBeam();
     void EnableSound(bool enable);
@@ -36,7 +37,7 @@ namespace Overworld {
   private:
     std::queue<Command> sequence;
 
-    bool animComplete{ true }, walkoutComplete{ true }, entered{ false }, spin{ false };
+    bool animComplete{ true }, walkoutComplete{ true }, entered{ false }, spin{ false }, teleportedOut{ false };
     bool mute{ false };
     float spinProgress{};
     frame_time_t walkFrames{};

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 14;
+  const uint64_t VERSION_ITERATION = 15;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -78,6 +78,7 @@ namespace Overworld
     append_posts,
     remove_post,
     post_selection_ack,
+    initiate_pvp,
     actor_connected,
     actor_disconnect,
     actor_set_name,

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 13;
+  const uint64_t VERSION_ITERATION = 14;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -26,6 +26,7 @@ namespace Overworld
     position,
     avatar_change,
     emote,
+    custom_warp,
     object_interaction,
     actor_interaction,
     tile_interaction,

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 12;
+  const uint64_t VERSION_ITERATION = 13;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -22,6 +22,7 @@ namespace Overworld
     logout,
     request_join,
     ready,
+    transferred_out,
     position,
     avatar_change,
     emote,
@@ -49,6 +50,7 @@ namespace Overworld
     pong = 0,
     ack,
     login,
+    transfer_warp,
     transfer_start,
     transfer_complete,
     transfer_server,


### PR DESCRIPTION
Changes
 - Added initiate_pvp packet for OW to start pvp
 - Custom warps will warp out players and send a signal when the animation completes
 - Warps in online scene require collisions defined
 - Slight optimization to ShadowMap
