### PR TITLE
Player data and clean up

### DIFF
--- a/BattleNetwork/bnDirection.h
+++ b/BattleNetwork/bnDirection.h
@@ -2,8 +2,10 @@
 #include <Swoosh/Ease.h>
 #include <math.h>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <SFML/System/Vector2.hpp>
+#include "stx/string.h"
 
 /**
 * @brief Used by entity movement
@@ -300,29 +302,38 @@ inline sf::Vector2f UnitVector(Direction dir) {
   return sf::Vector2f();
 }
 
-inline Direction FromString(const std::string& direction) {
-  if (direction == "Left") {
+inline Direction FromString(const std::string_view& direction) {
+  constexpr std::string_view left = "Left";
+  constexpr std::string_view right = "Right";
+  constexpr std::string_view up = "Up";
+  constexpr std::string_view down = "Down";
+  constexpr std::string_view up_left = "Up Left";
+  constexpr std::string_view up_right = "Up Right";
+  constexpr std::string_view down_left = "Down Left";
+  constexpr std::string_view down_right = "Down Right";
+
+  if (stx::insensitive_equals(direction, left)) {
     return Direction::left;
   }
-  else if (direction == "Right") {
+  else if (stx::insensitive_equals(direction, right)) {
     return Direction::right;
   }
-  else if (direction == "Up") {
+  else if (stx::insensitive_equals(direction, up)) {
     return Direction::up;
   }
-  else if (direction == "Down") {
+  else if (stx::insensitive_equals(direction, down)) {
     return Direction::down;
   }
-  else if (direction == "Up Left") {
+  else if (stx::insensitive_equals(direction, up_left)) {
     return Direction::up_left;
   }
-  else if (direction == "Up Right") {
+  else if (stx::insensitive_equals(direction, up_right)) {
     return Direction::up_right;
   }
-  else if (direction == "Down Left") {
+  else if (stx::insensitive_equals(direction, down_left)) {
     return Direction::down_left;
   }
-  else if (direction == "Down Right") {
+  else if (stx::insensitive_equals(direction, down_right)) {
     return Direction::down_right;
   }
 

--- a/BattleNetwork/bnFileUtil.h
+++ b/BattleNetwork/bnFileUtil.h
@@ -92,11 +92,10 @@ public:
 
     if (in.open(_path) && in.getSize() > 0) {
       sf::Int64 size = in.getSize();
-      char* buffer = new char[size + 1];
+      char* buffer = new char[size];
       in.read(buffer, size);
-      buffer[size] = '\0';
 
-      std::string strbuff(buffer);
+      std::string strbuff(buffer, size);
 
       delete[] buffer;
 

--- a/BattleNetwork/bnGame.cpp
+++ b/BattleNetwork/bnGame.cpp
@@ -89,7 +89,10 @@ void Game::SetCommandLineValues(const cxxopts::ParseResult& values) {
   unsigned int myPort = CommandLineValue<unsigned int>("port");
   uint16_t maxPayloadSize = CommandLineValue<uint16_t>("mtu");
   netManager.BindPort(myPort);
-  netManager.SetMaxPayloadSize(maxPayloadSize);
+
+  if (maxPayloadSize != 0) {
+    netManager.SetMaxPayloadSize(maxPayloadSize);
+  }
 }
 
 TaskGroup Game::Boot(const cxxopts::ParseResult& values)

--- a/BattleNetwork/bnGameOverScene.cpp
+++ b/BattleNetwork/bnGameOverScene.cpp
@@ -51,7 +51,7 @@ void GameOverScene::onUpdate(double elapsed) {
       leave = false;
 
       using effect = segue<WhiteWashFade, milliseconds<500>>;
-      getController().push<effect::to<Overworld::Homepage>>(!WEBCLIENT.IsLoggedIn());
+      getController().push<effect::to<Overworld::Homepage>>();
     }
   }
 }

--- a/BattleNetwork/bnNaviRegistration.cpp
+++ b/BattleNetwork/bnNaviRegistration.cpp
@@ -142,6 +142,11 @@ const std::string NaviRegistration::NaviMeta::GetName() const
   return navi->GetName();
 }
 
+int NaviRegistration::NaviMeta::GetHP() const
+{
+  return hp;
+}
+
 const std::string NaviRegistration::NaviMeta::GetHPString() const
 {
   return std::to_string(hp);

--- a/BattleNetwork/bnNaviRegistration.h
+++ b/BattleNetwork/bnNaviRegistration.h
@@ -196,6 +196,12 @@ public:
     const std::string GetName() const;
     
     /**
+     * @brief Gets the navi HP
+     * @return int
+     */
+    int GetHP() const;
+    
+    /**
      * @brief Gets the navi HP as a string to display
      * @return const std::string
      */

--- a/BattleNetwork/bnTitleScene.cpp
+++ b/BattleNetwork/bnTitleScene.cpp
@@ -134,7 +134,7 @@ void TitleScene::onUpdate(double elapsed)
 
       // We want the next screen to be the main menu screen
       using tx = segue<DiamondTileCircle>::to<Overworld::Homepage>;
-      getController().push<tx>(loginSelected);
+      getController().push<tx>();
 
       /*if (!loginSelected) {
         getController().push<ConfigScene>();

--- a/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
+++ b/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
@@ -39,8 +39,7 @@ using swoosh::ActivityController;
 
 NetworkBattleScene::NetworkBattleScene(ActivityController& controller, const NetworkBattleSceneProps& props, BattleResultsFunc onEnd) :
   BattleSceneBase(controller, props.base, onEnd),
-  ping(Font::Style::wide),
-  remoteAddress(props.netconfig.remote)
+  ping(Font::Style::wide)
 {
   ping.setPosition(480 - (2.f * 16) - 4, 320 - 2.f); // screen upscaled w - (16px*upscale scale) - (2px*upscale)
   ping.SetColor(sf::Color::Red);
@@ -64,8 +63,6 @@ NetworkBattleScene::NetworkBattleScene(ActivityController& controller, const Net
   packetProcessor->SetPacketBodyCallback([this](NetPlaySignals header, const Poco::Buffer<char>& buffer) {
     this->processPacketBody(header, buffer);
   });
-
-  Net().AddHandler(remoteAddress, packetProcessor);
 
   // If playing co-op, add more players to track here
   players = { clientPlayer };
@@ -325,7 +322,6 @@ void NetworkBattleScene::onResume()
 void NetworkBattleScene::onEnd()
 {
   BattleSceneBase::onEnd();
-  Net().DropHandlers(remoteAddress);
 }
 
 void NetworkBattleScene::Inject(PlayerInputReplicator& pub)

--- a/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.h
+++ b/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.h
@@ -80,7 +80,6 @@ private:
   Text ping;
   SelectedNavi selectedNavi; //!< the type of navi we selected
   NetPlayFlags remoteState; //!< remote state flags to ensure stability
-  Poco::Net::SocketAddress remoteAddress;
   std::vector<Player*> players; //!< Track all players
   std::vector<std::shared_ptr<TrackedFormData>> trackedForms;
   SpriteProxyNode pingIndicator;

--- a/BattleNetwork/netplay/bnBufferReader.cpp
+++ b/BattleNetwork/netplay/bnBufferReader.cpp
@@ -33,6 +33,9 @@ std::string BufferReader::ReadTerminatedString(const Poco::Buffer<char>& buffer)
     }
   }
 
+  Logger::Log("BufferReader read past end!");
+  offset = buffer.size();
+
   return "";
 }
 

--- a/BattleNetwork/netplay/bnBufferReader.cpp
+++ b/BattleNetwork/netplay/bnBufferReader.cpp
@@ -36,17 +36,3 @@ std::string BufferReader::ReadTerminatedString(const Poco::Buffer<char>& buffer)
   return "";
 }
 
-std::string BufferReader::ReadString(const Poco::Buffer<char>& buffer)
-{
-  auto length = Read<uint64_t>(buffer);
-  auto remainingBytes = buffer.size() - offset;
-
-  if (remainingBytes < length) {
-    return "";
-  }
-
-  auto result = std::string(buffer.begin() + offset, length);
-  offset += length;
-
-  return result;
-}

--- a/BattleNetwork/netplay/bnBufferReader.h
+++ b/BattleNetwork/netplay/bnBufferReader.h
@@ -33,6 +33,21 @@ public:
     return result;
   }
 
+  template <typename Size>
+  std::string ReadString(const Poco::Buffer<char>& buffer)
+  {
+    auto length = Read<Size>(buffer);
+    auto remainingBytes = buffer.size() - offset;
+
+    if (remainingBytes < length) {
+      return "";
+    }
+
+    auto result = std::string(buffer.begin() + offset, length);
+    offset += length;
+
+    return result;
+  }
+
   std::string ReadTerminatedString(const Poco::Buffer<char>& buffer);
-  std::string ReadString(const Poco::Buffer<char>& buffer);
 };

--- a/BattleNetwork/netplay/bnBufferReader.h
+++ b/BattleNetwork/netplay/bnBufferReader.h
@@ -37,9 +37,16 @@ public:
   std::string ReadString(const Poco::Buffer<char>& buffer)
   {
     auto length = Read<Size>(buffer);
+
+    return ReadString(buffer, length);
+  }
+
+  std::string ReadString(const Poco::Buffer<char>& buffer, size_t length)
+  {
     auto remainingBytes = buffer.size() - offset;
 
     if (remainingBytes < length) {
+      Logger::Log("BufferReader read past end!");
       return "";
     }
 

--- a/BattleNetwork/netplay/bnBufferWriter.cpp
+++ b/BattleNetwork/netplay/bnBufferWriter.cpp
@@ -1,0 +1,11 @@
+#include "bnBufferWriter.h"
+
+BufferWriter::BufferWriter()
+{
+}
+
+void BufferWriter::WriteTerminatedString(Poco::Buffer<char>& buffer, const std::string& text)
+{
+  buffer.append(text.c_str(), text.size());
+  buffer.append(0);
+}

--- a/BattleNetwork/netplay/bnBufferWriter.h
+++ b/BattleNetwork/netplay/bnBufferWriter.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <Poco/Buffer.h>
 #include "../bnLogger.h"
+#include <Poco/Buffer.h>
+#include <limits>
 
 class BufferWriter
 {
@@ -25,6 +26,13 @@ public:
   void WriteString(Poco::Buffer<char>& buffer, const std::string& text)
   {
     auto len = (Size)text.size();
+
+    if(text.size() > std::numeric_limits<Size>::max()) {
+      // prevent corruption by capping len at sizeof(Size)
+      len = std::numeric_limits<Size>::max();
+      Logger::Log("String length longer than Size, truncating...");
+    }
+
     Write<Size>(buffer, len);
     buffer.append(text.c_str(), len);
   }

--- a/BattleNetwork/netplay/bnBufferWriter.h
+++ b/BattleNetwork/netplay/bnBufferWriter.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Poco/Buffer.h>
+#include "../bnLogger.h"
+
+class BufferWriter
+{
+public:
+  BufferWriter();
+
+  // warning: this method breaks if the endianness of the server and client differ!
+  // no lifetimes in this language, so forcing you to pass buffer to be explicit
+  template <typename T>
+  void Write(Poco::Buffer<char>& buffer, const T& data)
+  {
+    buffer.append((char*)&data, sizeof(T));
+  }
+
+  template <typename T>
+  void WriteBytes(Poco::Buffer<char>& buffer, T* data, size_t len) {
+    buffer.append((char*)data, len);
+  }
+
+  template <typename Size>
+  void WriteString(Poco::Buffer<char>& buffer, const std::string& text)
+  {
+    auto len = (Size)text.size();
+    Write<Size>(buffer, len);
+    buffer.append(text.c_str(), len);
+  }
+
+  void WriteTerminatedString(Poco::Buffer<char>& buffer, const std::string& text);
+};

--- a/BattleNetwork/netplay/bnMatchMakingScene.cpp
+++ b/BattleNetwork/netplay/bnMatchMakingScene.cpp
@@ -562,7 +562,6 @@ void MatchMakingScene::onUpdate(double elapsed) {
         compatibleNavi = selectedNavi;
       }
 
-      config.remote = theirIP;
       config.myNavi = compatibleNavi;
 
       auto& meta = NAVIS.At(compatibleNavi);

--- a/BattleNetwork/netplay/bnMatchMakingScene.cpp
+++ b/BattleNetwork/netplay/bnMatchMakingScene.cpp
@@ -417,6 +417,8 @@ void MatchMakingScene::onStart() {
 }
 
 void MatchMakingScene::onResume() {
+  isScreenReady = true;
+
   if (!canProceedToBattle) {
     // If this condition is false, we could not download assets we needed
     // Reset for next match attempt
@@ -629,6 +631,7 @@ void MatchMakingScene::onUpdate(double elapsed) {
 
 void MatchMakingScene::onLeave()
 {
+  isScreenReady = false;
 }
 
 void MatchMakingScene::onEnter()

--- a/BattleNetwork/netplay/bnNetPlayConfig.h
+++ b/BattleNetwork/netplay/bnNetPlayConfig.h
@@ -8,6 +8,5 @@ struct NetPlayConfig {
   static constexpr const uint16_t OBN_PORT = 8765;
 
   // struct vars
-  std::string remote;
   uint16_t myNavi{ 0 };
 };

--- a/BattleNetwork/overworld/bnIdentityManager.cpp
+++ b/BattleNetwork/overworld/bnIdentityManager.cpp
@@ -1,0 +1,40 @@
+#include "bnIdentityManager.h"
+
+#include "bnServerAssetManager.h"
+#include "../bnFileUtil.h"
+#include <Poco/RandomStream.h>
+#include <filesystem>
+
+constexpr std::string_view IDENTITY_FOLDER = "identity";
+
+namespace Overworld {
+  IdentityManager::IdentityManager(const std::string& address, uint16_t port)
+  {
+    path = std::string(IDENTITY_FOLDER) + "/" + URIEncode(address + "_p" + std::to_string(port));
+  }
+
+  std::string IdentityManager::GetIdentity() {
+    if (!identity.empty()) {
+      return identity;
+    }
+
+    identity = FileUtil::Read(path);
+
+    if (identity.empty()) {
+      // make sure the identity folder exists
+      std::filesystem::create_directories(IDENTITY_FOLDER);
+
+      char buffer[255];
+
+      Poco::RandomBuf randomBuf;
+      int read = randomBuf.readFromDevice(buffer, 255);
+
+      identity = std::string(buffer, read);
+
+      auto writeStream = FileUtil::WriteStream(path);
+      writeStream << identity;
+    }
+
+    return identity;
+  }
+}

--- a/BattleNetwork/overworld/bnIdentityManager.cpp
+++ b/BattleNetwork/overworld/bnIdentityManager.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 
 constexpr std::string_view IDENTITY_FOLDER = "identity";
+constexpr std::streamsize IDENTITY_LENGTH = 32;
 
 namespace Overworld {
   IdentityManager::IdentityManager(const std::string& address, uint16_t port)
@@ -24,10 +25,10 @@ namespace Overworld {
       // make sure the identity folder exists
       std::filesystem::create_directories(IDENTITY_FOLDER);
 
-      char buffer[255];
+      char buffer[IDENTITY_LENGTH];
 
       Poco::RandomBuf randomBuf;
-      int read = randomBuf.readFromDevice(buffer, 255);
+      int read = randomBuf.readFromDevice(buffer, IDENTITY_LENGTH);
 
       identity = std::string(buffer, read);
 

--- a/BattleNetwork/overworld/bnIdentityManager.h
+++ b/BattleNetwork/overworld/bnIdentityManager.h
@@ -1,0 +1,16 @@
+#include <string>
+
+namespace Overworld {
+  /**
+   * Identities should not be shared beyond a single server
+   */
+  class IdentityManager {
+    public:
+      IdentityManager(const std::string& address, uint16_t port);
+
+      std::string GetIdentity();
+    private:
+      std::string path;
+      std::string identity;
+  };
+}

--- a/BattleNetwork/overworld/bnMinimap.cpp
+++ b/BattleNetwork/overworld/bnMinimap.cpp
@@ -386,6 +386,8 @@ Overworld::Minimap& Overworld::Minimap::operator=(const Minimap& rhs)
   warp.setTexture(rhs.warp.getTexture(), false);
   player.setPosition(rhs.player.getPosition());
   hp.setPosition(rhs.hp.getPosition());
+  hp.setColor(rhs.hp.getColor());
+  hp.SetLayer(rhs.hp.GetLayer());
   bakedMap.setPosition(rhs.bakedMap.getPosition());
   EnforceTextureSizeLimits();
 

--- a/BattleNetwork/overworld/bnMinimap.cpp
+++ b/BattleNetwork/overworld/bnMinimap.cpp
@@ -218,8 +218,8 @@ void Overworld::Minimap::FindTileMarkers(Map& map) {
 
     for (auto col = 0; col < cols; col++) {
       for (auto row = 0; row < rows; row++) {
-        auto& tile = layer.GetTile(col, row);
-        auto tileMeta = map.GetTileMeta(tile.gid);
+        auto tile = layer.GetTile(col, row);
+        auto tileMeta = map.GetTileMeta(tile->gid);
 
         if (!tileMeta) {
           continue;
@@ -233,11 +233,11 @@ void Overworld::Minimap::FindTileMarkers(Map& map) {
           auto worldPos = map.TileToWorld(pos);
           auto direction = FromString(tileMeta->customProperties.GetProperty("Direction"));
 
-          if (tile.flippedHorizontal) {
+          if (tile->flippedHorizontal) {
             direction = FlipHorizontal(direction);
           }
 
-          if (tile.flippedVertical) {
+          if (tile->flippedVertical) {
             direction = FlipVertical(direction);
           }
 
@@ -263,10 +263,10 @@ void Overworld::Minimap::DrawLayer(sf::RenderTarget& target, sf::Shader& shader,
 
   for (int i = 0; i < rows; i++) {
     for (int j = 0; j < cols; j++) {
-      auto& tile = layer.GetTile(j, i);
-      if (tile.gid == 0) continue;
+      auto tile = layer.GetTile(j, i);
+      if (tile->gid == 0) continue;
 
-      auto tileMeta = map.GetTileMeta(tile.gid);
+      auto tileMeta = map.GetTileMeta(tile->gid);
 
       // failed to load tile
       if (tileMeta == nullptr) continue;
@@ -290,16 +290,16 @@ void Overworld::Minimap::DrawLayer(sf::RenderTarget& target, sf::Shader& shader,
       ));
 
       tileSprite.setPosition(ortho + tileMeta->drawingOffset + tileOffset);
-      tileSprite.setRotation(tile.rotated ? 90.0f : 0.0f);
+      tileSprite.setRotation(tile->rotated ? 90.0f : 0.0f);
       tileSprite.setScale(
-        tile.flippedHorizontal ? -1.0f : 1.0f,
-        tile.flippedVertical ? -1.0f : 1.0f
+        tile->flippedHorizontal ? -1.0f : 1.0f,
+        tile->flippedVertical ? -1.0f : 1.0f
       );
 
       // pass info to shader
       auto center = sf::Vector2f(float(subRect.left), float(subRect.top));
 
-      if(tile.flippedHorizontal) {
+      if(tile->flippedHorizontal) {
         center.x += float(subRect.width) - (tileSize.x / 2.0f);
         center.x += tileMeta->drawingOffset.x;
       } else {
@@ -307,7 +307,7 @@ void Overworld::Minimap::DrawLayer(sf::RenderTarget& target, sf::Shader& shader,
         center.x += -tileMeta->drawingOffset.x;
       }
 
-      if (tile.flippedVertical) {
+      if (tile->flippedVertical) {
         center.y += tileSize.y / 2.0f;
         center.y += tileMeta->drawingOffset.y;
       } else {

--- a/BattleNetwork/overworld/bnMinimap.cpp
+++ b/BattleNetwork/overworld/bnMinimap.cpp
@@ -234,7 +234,7 @@ void Overworld::Minimap::FindTileMarkers(Map& map) {
           pos.y += 0.5f;
 
           auto worldPos = map.TileToWorld(pos);
-          auto direction = FromString(tileMeta->customProperties.GetProperty("Direction"));
+          auto direction = FromString(tileMeta->customProperties.GetProperty("direction"));
 
           if (tile->flippedHorizontal) {
             direction = FlipHorizontal(direction);

--- a/BattleNetwork/overworld/bnMinimap.cpp
+++ b/BattleNetwork/overworld/bnMinimap.cpp
@@ -1,7 +1,10 @@
 #include "bnMinimap.h"
+
+#include "bnOverworldTileType.h"
+#include "../bnTextureResourceManager.h"
+#include "../stx/string.h"
 #include <Swoosh/EmbedGLSL.h>
 #include <cmath>
-#include "../bnTextureResourceManager.h"
 
 const auto CONCEALED_COLOR = sf::Color(165, 165, 165, 165); // 65% transparency, similar to world sprite darkening
 
@@ -225,7 +228,7 @@ void Overworld::Minimap::FindTileMarkers(Map& map) {
           continue;
         }
 
-        if (tileMeta->type == "Conveyor") {
+        if (TileType::FromString(tileMeta->type) == TileType::conveyor) {
           auto pos = sf::Vector2f(col, row);
           pos.x += 0.5f;
           pos.y += 0.5f;
@@ -318,7 +321,7 @@ void Overworld::Minimap::DrawLayer(sf::RenderTarget& target, sf::Shader& shader,
       sf::Vector2f sizeUv(tileSprite.getTexture()->getSize());
       shader.setUniform("center", sf::Glsl::Vec2(center.x / sizeUv.x, center.y / sizeUv.y));
       shader.setUniform("tileSize", sf::Glsl::Vec2((tileSize.x + 1) / sizeUv.x, (tileSize.y + 1) / sizeUv.y));
-      shader.setUniform("mask", tileMeta->type != "Stairs");
+      shader.setUniform("mask", TileType::FromString(tileMeta->type) != TileType::stairs);
 
       // draw
       target.draw(tileSprite, states);

--- a/BattleNetwork/overworld/bnMinimap.h
+++ b/BattleNetwork/overworld/bnMinimap.h
@@ -20,6 +20,7 @@ namespace Overworld {
     void EnforceTextureSizeLimits();
     void DrawLayer(sf::RenderTarget& target, sf::Shader& shader, sf::RenderStates states, Map& map, size_t index);
     void FindTileMarkers(Map& map);
+    void FindObjectMarkers(Map& map);
     void AddMarker(const std::shared_ptr<SpriteProxyNode>& marker, const sf::Vector2f& pos, bool inShadow);
   public:
     static Minimap CreateFrom(const std::string& name, Map& map);

--- a/BattleNetwork/overworld/bnOverworldCustomProperties.cpp
+++ b/BattleNetwork/overworld/bnOverworldCustomProperties.cpp
@@ -1,5 +1,7 @@
 #include "bnOverworldCustomProperties.h"
 
+#include <algorithm>
+
 namespace Overworld {
   bool CustomProperties::HasProperty(const std::string& name) const {
     return properties.find(name) != properties.end();
@@ -53,7 +55,11 @@ namespace Overworld {
         continue;
       }
 
-      properties.properties[child.GetAttribute("name")] = child.GetAttribute("value");
+      auto name = child.GetAttribute("name");
+
+      std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+
+      properties.properties[name] = child.GetAttribute("value");
     }
 
     return properties;

--- a/BattleNetwork/overworld/bnOverworldCustomProperties.h
+++ b/BattleNetwork/overworld/bnOverworldCustomProperties.h
@@ -7,6 +7,7 @@
 namespace Overworld {
   class CustomProperties {
   public:
+    // property names will be converted to lower case!
     static CustomProperties From(const XMLElement& propertiesElement);
 
     bool HasProperty(const std::string& name) const;

--- a/BattleNetwork/overworld/bnOverworldHomepage.cpp
+++ b/BattleNetwork/overworld/bnOverworldHomepage.cpp
@@ -12,9 +12,8 @@ using namespace swoosh::types;
 constexpr sf::Int32 PING_SERVER_MILI = 1000;
 constexpr size_t DEFAULT_PORT = 8765;
 
-Overworld::Homepage::Homepage(swoosh::ActivityController& controller, bool guestAccount) :
-  guest(guestAccount),
-  SceneBase(controller, guestAccount)
+Overworld::Homepage::Homepage(swoosh::ActivityController& controller) :
+  SceneBase(controller)
 {
   std::string destination_ip = WEBCLIENT.GetValue("homepage_warp:0");
 
@@ -454,8 +453,7 @@ void Overworld::Homepage::OnTileCollision()
     auto port = remoteAddress.port();
 
     auto teleportToCyberworld = [=] {
-      // Net().GetSocket().close();
-      getController().push<segue<BlackWashFade>::to<Overworld::OnlineArea>>(address, port, "", maxPayloadSize, guest);
+      getController().push<segue<BlackWashFade>::to<Overworld::OnlineArea>>(address, port, "", maxPayloadSize);
     };
 
     this->TeleportUponReturn(returnPoint);

--- a/BattleNetwork/overworld/bnOverworldHomepage.cpp
+++ b/BattleNetwork/overworld/bnOverworldHomepage.cpp
@@ -9,7 +9,6 @@
 
 using namespace swoosh::types;
 
-constexpr sf::Int32 PING_SERVER_MILI = 1000;
 constexpr size_t DEFAULT_PORT = 8765;
 
 Overworld::Homepage::Homepage(swoosh::ActivityController& controller) :
@@ -32,20 +31,17 @@ Overworld::Homepage::Homepage(swoosh::ActivityController& controller) :
   if (remotePort > 0 && cyberworld.size()) {
     try {
       remoteAddress = Poco::Net::SocketAddress(cyberworld, remotePort);
-      packetProcessor = std::make_shared<Overworld::PacketProcessor>(
+
+      packetProcessor = std::make_shared<Overworld::PollingPacketProcessor>(
         remoteAddress,
         Net().GetMaxPayloadSize(),
-        [this](auto& body) { ProcessPacketBody(body); }
+        [this](auto status, auto maxPayloadSize) { UpdateServerStatus(status, maxPayloadSize); }
       );
+
       Net().AddHandler(remoteAddress, packetProcessor);
     }
     catch (Poco::IOException&) {}
   }
-
-  pingServerTimer.reverse(true);
-  pingServerTimer.set(sf::milliseconds(PING_SERVER_MILI));
-  pingServerTimer.start();
-
 
   LoadMap(FileUtil::Read("resources/ow/maps/homepage.tmx"));
 
@@ -124,14 +120,17 @@ Overworld::Homepage::Homepage(swoosh::ActivityController& controller) :
       std::string message = "If you're seeing this message, something has gone horribly wrong with the next area.";
       message += "For your safety you cannot enter the next area!";
 
-      switch (cyberworldStatus) {
-      case CyberworldStatus::online:
+      switch (serverStatus) {
+      case ServerStatus::online:
         message = "This is your homepage! Walk into the telepad to enter cyberspace!";
         break;
-      case CyberworldStatus::mismatched_version:
+      case ServerStatus::older_version:
+        message = "This is your homepage! But it looks like you need to downgrade to connect to cyberspace...";
+        break;
+      case ServerStatus::newer_version:
         message = "This is your homepage! But it looks like you need an update to connect to cyberspace...";
         break;
-      case CyberworldStatus::offline:
+      case ServerStatus::offline:
         message = "This is your homepage! But it looks like the next area is offline...";
         break;
       }
@@ -174,7 +173,7 @@ Overworld::Homepage::Homepage(swoosh::ActivityController& controller) :
 
             try {
               Net().DropHandlers(remoteAddress);
-              
+
               // first check if this is an ip address
               try {
                 dest = Poco::Net::IPAddress::parse(dest).toString();
@@ -199,10 +198,10 @@ Overworld::Homepage::Homepage(swoosh::ActivityController& controller) :
               }
 
               remoteAddress = Poco::Net::SocketAddress(dest);
-              packetProcessor = std::make_shared<Overworld::PacketProcessor>(
+              packetProcessor = std::make_shared<Overworld::PollingPacketProcessor>(
                 remoteAddress,
                 Net().GetMaxPayloadSize(),
-                [this](auto& body) { ProcessPacketBody(body); }
+                [this](auto status, auto maxPayloadSize) { UpdateServerStatus(status, maxPayloadSize); }
               );
               Net().AddHandler(remoteAddress, packetProcessor);
 
@@ -242,51 +241,11 @@ Overworld::Homepage::Homepage(swoosh::ActivityController& controller) :
 Overworld::Homepage::~Homepage() {
 }
 
-void Overworld::Homepage::PingRemoteAreaServer()
-{
-  if (!packetProcessor) {
-    return;
-  }
+void Overworld::Homepage::UpdateServerStatus(ServerStatus status, uint16_t serverMaxPayloadSize) {
+  serverStatus = status;
+  maxPayloadSize = serverMaxPayloadSize;
 
-  if (pingServerTimer.getElapsed().asMilliseconds() != 0) {
-    return;
-  }
-
-  Poco::Buffer<char> buffer{ 0 };
-
-  auto clientEvent = ClientEvents::ping;
-  buffer.append((char*)&clientEvent, sizeof(uint16_t));
-
-  packetProcessor->SendPacket(Reliability::Unreliable, buffer);
-
-  pingServerTimer.set(sf::milliseconds(PING_SERVER_MILI));
-
-}
-
-void Overworld::Homepage::ProcessPacketBody(const Poco::Buffer<char>& body) {
-  if (!infocus) {
-    return;
-  }
-
-  BufferReader reader;
-  auto sig = reader.Read<ServerEvents>(body);
-  auto version = reader.ReadString<uint16_t>(body);
-  auto iteration = reader.Read<uint64_t>(body);
-  maxPayloadSize = reader.Read<uint16_t>(body);
-
-  if (sig != ServerEvents::pong) {
-    return;
-  }
-
-  if (version == VERSION_ID && iteration == VERSION_ITERATION) {
-    cyberworldStatus = CyberworldStatus::online;
-  }
-  else {
-    cyberworldStatus = CyberworldStatus::mismatched_version;
-  }
-
-  auto isOnline = cyberworldStatus == CyberworldStatus::online;
-  EnableNetWarps(isOnline);
+  EnableNetWarps(status == ServerStatus::online);
 }
 
 void Overworld::Homepage::EnableNetWarps(bool enabled) {
@@ -306,12 +265,6 @@ void Overworld::Homepage::EnableNetWarps(bool enabled) {
 
 void Overworld::Homepage::onUpdate(double elapsed)
 {
-  if (infocus)
-  {
-    pingServerTimer.update(sf::seconds(static_cast<float>(elapsed)));
-    PingRemoteAreaServer();
-  }
-
   // Update our logic
   auto& map = GetMap();
   auto& window = getController().getWindow();
@@ -416,10 +369,6 @@ void Overworld::Homepage::onLeave()
   if (packetProcessor) {
     Net().DropProcessor(packetProcessor);
   }
-
-  // repeat reconnection in case there was a fail that
-  // forced us to return
-  cyberworldStatus = CyberworldStatus::offline;
 }
 
 void Overworld::Homepage::OnTileCollision()
@@ -438,7 +387,7 @@ void Overworld::Homepage::OnTileCollision()
 
   auto& teleportController = GetTeleportController();
 
-  if (netWarpTilePos == tilePos && teleportController.IsComplete() && cyberworldStatus == CyberworldStatus::online) {
+  if (netWarpTilePos == tilePos && teleportController.IsComplete() && serverStatus == ServerStatus::online) {
     auto& playerController = GetPlayerController();
 
     // Calculate the origin by grabbing this tile's grid Y/X values

--- a/BattleNetwork/overworld/bnOverworldHomepage.cpp
+++ b/BattleNetwork/overworld/bnOverworldHomepage.cpp
@@ -271,7 +271,7 @@ void Overworld::Homepage::ProcessPacketBody(const Poco::Buffer<char>& body) {
 
   BufferReader reader;
   auto sig = reader.Read<ServerEvents>(body);
-  auto version = reader.ReadTerminatedString(body);
+  auto version = reader.ReadString<uint16_t>(body);
   auto iteration = reader.Read<uint64_t>(body);
   maxPayloadSize = reader.Read<uint16_t>(body);
 

--- a/BattleNetwork/overworld/bnOverworldHomepage.h
+++ b/BattleNetwork/overworld/bnOverworldHomepage.h
@@ -15,7 +15,7 @@ namespace Overworld {
     };
 
     bool scaledmap{ false }, clicked{ false };
-    bool guest{ false }, infocus{ false };
+    bool infocus{ false };
     Poco::Net::SocketAddress remoteAddress; //!< server
     std::shared_ptr<PacketProcessor> packetProcessor;
     uint16_t maxPayloadSize{};
@@ -33,7 +33,7 @@ namespace Overworld {
     /**
      * @brief Loads the player's library data and loads graphics
      */
-    Homepage(swoosh::ActivityController&, bool guestAccount);
+    Homepage(swoosh::ActivityController&);
     ~Homepage();
 
     void onUpdate(double elapsed) override;

--- a/BattleNetwork/overworld/bnOverworldHomepage.h
+++ b/BattleNetwork/overworld/bnOverworldHomepage.h
@@ -1,31 +1,22 @@
 #pragma once
-#include <Swoosh/Timer.h>
 #include <Poco/Net/DatagramSocket.h>
 #include <Poco/Buffer.h>
 #include "bnOverworldSceneBase.h"
-#include "bnOverworldPacketProcessor.h"
+#include "bnOverworldPollingPacketProcessor.h"
 
 namespace Overworld {
   class Homepage final : public SceneBase {
   private:
-    enum class CyberworldStatus {
-      mismatched_version,
-      offline,
-      online
-    };
-
     bool scaledmap{ false }, clicked{ false };
     bool infocus{ false };
     Poco::Net::SocketAddress remoteAddress; //!< server
-    std::shared_ptr<PacketProcessor> packetProcessor;
+    std::shared_ptr<PollingPacketProcessor> packetProcessor;
     uint16_t maxPayloadSize{};
-    swoosh::Timer pingServerTimer;
     sf::Vector3f netWarpTilePos;
     unsigned int netWarpObjectId{};
-    CyberworldStatus cyberworldStatus{ CyberworldStatus::offline };
+    ServerStatus serverStatus{ ServerStatus::offline };
 
-    void PingRemoteAreaServer();
-    void ProcessPacketBody(const Poco::Buffer<char>& buffer);
+    void UpdateServerStatus(ServerStatus status, uint16_t serverMaxPayloadSize);
     void EnableNetWarps(bool enabled);
 
   public:

--- a/BattleNetwork/overworld/bnOverworldMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldMap.cpp
@@ -76,6 +76,23 @@ namespace Overworld {
     return { tileSpace.x * (float)tileWidth * 0.5f, tileSpace.y * (float)tileHeight };
   }
 
+  Tile* Map::GetTileFromWorld(sf::Vector3f worldPos) {
+    if(worldPos.z < 0) {
+      return nullptr;
+    }
+
+    auto layerIndex = size_t(worldPos.z);
+    auto tilePos = sf::Vector2i(WorldToTileSpace({ worldPos.x, worldPos.y }));
+
+    if (layerIndex >= layers.size()) {
+      return nullptr;
+    }
+
+    auto& layer = layers[layerIndex];
+
+    return layer.GetTile(tilePos.x, tilePos.y);
+  }
+
   size_t Map::HashTilePosition(sf::Vector2f position) const {
     return size_t(position.x) + size_t(cols) * size_t(position.y);
   }

--- a/BattleNetwork/overworld/bnOverworldMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldMap.cpp
@@ -322,7 +322,7 @@ namespace Overworld {
 
     auto& tileMeta = tileMetas[tile->gid];
 
-    if (!tileMeta || tileMeta->type != "Stairs") {
+    if (!tileMeta || tileMeta->type != TileType::stairs) {
       return layerElevation;
     }
 
@@ -371,7 +371,7 @@ namespace Overworld {
 
     auto& tileMeta = tileMetas[tile->gid];
 
-    return tileMeta && tileMeta->type == "Stairs";
+    return tileMeta && tileMeta->type == TileType::stairs;
   }
 
   bool Map::HasShadow(sf::Vector2i tilePos, int layer) {

--- a/BattleNetwork/overworld/bnOverworldMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldMap.cpp
@@ -314,7 +314,7 @@ namespace Overworld {
     relativeY = std::modf(y, &_);
 
     float layerRelativeElevation = 0.0;
-    Direction direction = FromString(tileMeta->customProperties.GetProperty("Direction"));
+    Direction direction = FromString(tileMeta->customProperties.GetProperty("direction"));
 
     if (tile->flippedHorizontal) {
       direction = FlipHorizontal(direction);

--- a/BattleNetwork/overworld/bnOverworldMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldMap.cpp
@@ -314,20 +314,14 @@ namespace Overworld {
     relativeY = std::modf(y, &_);
 
     float layerRelativeElevation = 0.0;
-    auto directionString = tileMeta->customProperties.GetProperty("Direction");
-    Direction direction;
+    Direction direction = FromString(tileMeta->customProperties.GetProperty("Direction"));
 
-    if (directionString == "Up Left") {
-      direction = tile->flippedHorizontal ? Direction::up_right : Direction::up_left;
+    if (tile->flippedHorizontal) {
+      direction = FlipHorizontal(direction);
     }
-    else if (directionString == "Up Right") {
-      direction = tile->flippedHorizontal ? Direction::up_left : Direction::up_right;
-    }
-    if (directionString == "Down Left") {
-      direction = tile->flippedHorizontal ? Direction::down_right : Direction::down_left;
-    }
-    else if (directionString == "Down Right") {
-      direction = tile->flippedHorizontal ? Direction::down_left : Direction::down_right;
+
+    if (tile->flippedVertical) {
+      direction = FlipVertical(direction);
     }
 
     switch (direction) {

--- a/BattleNetwork/overworld/bnOverworldMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldMap.cpp
@@ -294,17 +294,16 @@ namespace Overworld {
     }
 
     layerIndex = std::max(layerIndex, 0);
+    auto layerElevation = (float)layerIndex;
 
     auto& layer = layers[layerIndex];
     auto tile = layer.GetTile(x, y);
 
     if (!tile) {
-      return 0.0f;
+      return layerElevation;
     }
 
     auto& tileMeta = tileMetas[tile->gid];
-
-    auto layerElevation = (float)layerIndex;
 
     if (!tileMeta || tileMeta->type != "Stairs") {
       return layerElevation;

--- a/BattleNetwork/overworld/bnOverworldMap.h
+++ b/BattleNetwork/overworld/bnOverworldMap.h
@@ -117,6 +117,8 @@ namespace Overworld {
      */
     sf::Vector2f TileToWorld(sf::Vector2f tile) const;
 
+    Tile* GetTileFromWorld(sf::Vector3f);
+
     size_t HashTilePosition(sf::Vector2f position) const;
 
     /**

--- a/BattleNetwork/overworld/bnOverworldMap.h
+++ b/BattleNetwork/overworld/bnOverworldMap.h
@@ -38,11 +38,11 @@ namespace Overworld {
       Layer(const Layer&) = delete;
       Layer(Layer&&) = default;
 
-      Tile& GetTile(int x, int y);
-      Tile& GetTile(float x, float y);
-      Tile& SetTile(int x, int y, Tile tile);
-      Tile& SetTile(int x, int y, unsigned int gid);
-      Tile& SetTile(float x, float y, unsigned int gid);
+      Tile* GetTile(int x, int y);
+      Tile* GetTile(float x, float y);
+      Tile* SetTile(int x, int y, Tile tile);
+      Tile* SetTile(int x, int y, unsigned int gid);
+      Tile* SetTile(float x, float y, unsigned int gid);
 
       void SetVisible(bool enabled);
       bool IsVisible() const;

--- a/BattleNetwork/overworld/bnOverworldObject.cpp
+++ b/BattleNetwork/overworld/bnOverworldObject.cpp
@@ -139,7 +139,8 @@ namespace Overworld {
 
   static void AdoptAttributes(MapObject& object, const XMLElement& element) {
     object.name = element.GetAttribute("name");
-    object.type = element.GetAttribute("type");
+    object.typeString = element.GetAttribute("type");
+    object.type = ObjectType::FromString(object.typeString);
     object.position = sf::Vector2f(
       element.GetAttributeFloat("x"),
       element.GetAttributeFloat("y")

--- a/BattleNetwork/overworld/bnOverworldObject.h
+++ b/BattleNetwork/overworld/bnOverworldObject.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <memory>
 
+#include "bnOverworldObjectType.h"
 #include "bnOverworldSprite.h"
 #include "bnOverworldCustomProperties.h"
 #include "bnOverworldShapes.h"
@@ -21,7 +22,8 @@ namespace Overworld {
   public:
     unsigned int id;
     std::string name;
-    std::string type;
+    std::string typeString;
+    ObjectType::ObjectType type;
     bool visible{ true };
     bool solid{};
     sf::Vector2f position;

--- a/BattleNetwork/overworld/bnOverworldObjectType.h
+++ b/BattleNetwork/overworld/bnOverworldObjectType.h
@@ -1,0 +1,64 @@
+#pragma once
+#include <string_view>
+#include "../stx/string.h"
+
+namespace Overworld {
+  namespace ObjectType {
+    enum ObjectType {
+      custom_warp,
+      server_warp,
+      position_warp,
+      custom_server_warp,
+      home_warp,
+      board,
+      shop,
+      undefined,
+    };
+
+    inline ObjectType FromString(const std::string_view& type_string) {
+      constexpr std::string_view custom_warp_string = "Custom Warp";
+      constexpr std::string_view server_warp_string = "Server Warp";
+      constexpr std::string_view position_warp_string = "Position Warp";
+      constexpr std::string_view custom_server_warp_string = "Custom Server Warp";
+      constexpr std::string_view home_warp_string = "Home Warp";
+      constexpr std::string_view board_string = "Board";
+      constexpr std::string_view shop_string = "Shop";
+
+      if (stx::insensitive_equals(type_string, custom_warp_string)) {
+        return ObjectType::custom_warp;
+      }
+      if (stx::insensitive_equals(type_string, server_warp_string)) {
+        return ObjectType::server_warp;
+      }
+      if (stx::insensitive_equals(type_string, position_warp_string)) {
+        return ObjectType::position_warp;
+      }
+      if (stx::insensitive_equals(type_string, custom_server_warp_string)) {
+        return ObjectType::custom_server_warp;
+      }
+      if (stx::insensitive_equals(type_string, home_warp_string)) {
+        return ObjectType::home_warp;
+      }
+      if (stx::insensitive_equals(type_string, board_string)) {
+        return ObjectType::board;
+      }
+      if (stx::insensitive_equals(type_string, shop_string)) {
+        return ObjectType::shop;
+      }
+
+      return ObjectType::undefined;
+    }
+
+    inline bool IsWarp(ObjectType type) {
+      return type == custom_warp ||
+        type == server_warp ||
+        type == position_warp ||
+        type == custom_server_warp ||
+        type == home_warp;
+    }
+
+    inline bool IsCustomWarp(ObjectType type) {
+      return type == custom_warp || type == custom_server_warp;
+    }
+  };
+}

--- a/BattleNetwork/overworld/bnOverworldObjectType.h
+++ b/BattleNetwork/overworld/bnOverworldObjectType.h
@@ -50,11 +50,16 @@ namespace Overworld {
     }
 
     inline bool IsWarp(ObjectType type) {
-      return type == custom_warp ||
-        type == server_warp ||
-        type == position_warp ||
-        type == custom_server_warp ||
-        type == home_warp;
+      switch (type) {
+      case custom_warp:
+      case server_warp:
+      case position_warp:
+      case custom_server_warp:
+      case home_warp:
+        return true;
+      default:
+        return false;
+      }
     }
 
     inline bool IsCustomWarp(ObjectType type) {

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -281,9 +281,9 @@ void Overworld::OnlineArea::detectWarp(std::shared_ptr<Overworld::Actor>& player
     else if (type == TileType::server_warp) {
       warpCameraController.QueueMoveCamera(map.WorldToScreen(position3), interpolateTime);
 
-      auto address = tileObject.customProperties.GetProperty("Address");
-      auto port = (uint16_t)tileObject.customProperties.GetPropertyInt("Port");
-      auto data = tileObject.customProperties.GetProperty("Data");
+      auto address = tileObject.customProperties.GetProperty("address");
+      auto port = (uint16_t)tileObject.customProperties.GetPropertyInt("port");
+      auto data = tileObject.customProperties.GetProperty("data");
 
       command.onFinish.Slot([=] {
         GetPlayerController().ReleaseActor();
@@ -292,14 +292,14 @@ void Overworld::OnlineArea::detectWarp(std::shared_ptr<Overworld::Actor>& player
     }
     else if (type == TileType::position_warp) {
       auto targetTilePos = sf::Vector2f(
-        tileObject.customProperties.GetPropertyFloat("X"),
-        tileObject.customProperties.GetPropertyFloat("Y")
+        tileObject.customProperties.GetPropertyFloat("x"),
+        tileObject.customProperties.GetPropertyFloat("y")
       );
 
       auto targetWorldPos = map.TileToWorld(targetTilePos);
 
-      auto targetPosition = sf::Vector3f(targetWorldPos.x, targetWorldPos.y, tileObject.customProperties.GetPropertyFloat("Z"));
-      auto direction = FromString(tileObject.customProperties.GetProperty("Direction"));
+      auto targetPosition = sf::Vector3f(targetWorldPos.x, targetWorldPos.y, tileObject.customProperties.GetPropertyFloat("z"));
+      auto direction = FromString(tileObject.customProperties.GetProperty("direction"));
 
       sf::Vector2f player_pos = { player->getPosition().x, player->getPosition().y };
       float distance = std::pow(targetWorldPos.x - player_pos.x, 2.0f) + std::pow(targetWorldPos.y - player_pos.y, 2.0f);
@@ -355,7 +355,7 @@ void Overworld::OnlineArea::detectConveyor(std::shared_ptr<Overworld::Actor>& pl
     return;
   }
 
-  auto direction = FromString(tileMeta->customProperties.GetProperty("Direction"));
+  auto direction = FromString(tileMeta->customProperties.GetProperty("direction"));
 
   if (tile->flippedHorizontal) {
     direction = FlipHorizontal(direction);
@@ -451,7 +451,7 @@ void Overworld::OnlineArea::detectConveyor(std::shared_ptr<Overworld::Actor>& pl
 
   propertyAnimator.Reset();
 
-  auto speed = tileMeta->customProperties.GetPropertyFloat("Speed");
+  auto speed = tileMeta->customProperties.GetPropertyFloat("speed");
 
   if (speed == 0.0f) {
     speed = DEFAULT_CONVEYOR_SPEED;
@@ -461,7 +461,7 @@ void Overworld::OnlineArea::detectConveyor(std::shared_ptr<Overworld::Actor>& pl
 
   ActorPropertyAnimator::PropertyStep sfxProperty;
   sfxProperty.property = ActorProperty::sound_effect_loop;
-  sfxProperty.stringValue = GetPath(tileMeta->customProperties.GetProperty("Sound Effect"));
+  sfxProperty.stringValue = GetPath(tileMeta->customProperties.GetProperty("sound effect"));
 
   ActorPropertyAnimator::KeyFrame startKeyframe;
   startKeyframe.propertySteps.push_back(animationProperty);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -1874,7 +1874,6 @@ void Overworld::OnlineArea::receivePVPSignal(BufferReader& reader, const Poco::B
   player->SetEmotion(GetPlayerSession().emotion);
 
   try {
-    Logger::Log(addressString.c_str());
     auto remote = Poco::Net::SocketAddress(addressString);
     netBattleProcessor = std::make_shared<Netplay::PacketProcessor>(remote, Net().GetMaxPayloadSize());
     Net().AddHandler(remote, netBattleProcessor);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -776,6 +776,12 @@ void Overworld::OnlineArea::processPacketBody(const Poco::Buffer<char>& data)
     case ServerEvents::money:
       receiveMoneySignal(reader, data);
       break;
+    case ServerEvents::add_item:
+      receiveItemSignal(reader, data);
+      break;
+    case ServerEvents::remove_item:
+      receiveRemoveItemSignal(reader, data);
+      break;
     case ServerEvents::play_sound:
       receivePlaySoundSignal(reader, data);
       break;
@@ -1428,6 +1434,21 @@ void Overworld::OnlineArea::receiveMoneySignal(BufferReader& reader, const Poco:
 {
   auto balance = reader.Read<int>(buffer);
   GetPersonalMenu().SetMonies(balance);
+}
+
+void Overworld::OnlineArea::receiveItemSignal(BufferReader& reader, const Poco::Buffer<char>& buffer)
+{
+  auto name = reader.ReadString<uint8_t>(buffer);
+  auto description = reader.ReadString<uint16_t>(buffer);
+
+  AddItem(name, description);
+}
+
+void Overworld::OnlineArea::receiveRemoveItemSignal(BufferReader& reader, const Poco::Buffer<char>& buffer)
+{
+  auto name = reader.ReadString<uint8_t>(buffer);
+
+  RemoveItem(name);
 }
 
 void Overworld::OnlineArea::receivePlaySoundSignal(BufferReader& reader, const Poco::Buffer<char>& buffer) {

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -183,22 +183,22 @@ void Overworld::OnlineArea::updateOtherPlayers(double elapsed) {
     auto newPos = onlinePlayer.startBroadcastPos + delta * alpha;
     actor->Set3DPosition(newPos);
 
-    if (!(onlinePlayer.propertyAnimator.IsAnimating() && actor->IsPlayingCustomAnimation())) {
-      // animate the player if they're not being animated by the property animator
+    if (onlinePlayer.propertyAnimator.IsAnimating() && actor->IsPlayingCustomAnimation()) {
+      // skip animating the player if they're being animated by the property animator
+      continue;
+    }
 
-      Direction newHeading = Actor::MakeDirectionFromVector({ delta.x, delta.y });
-      auto oldHeading = actor->GetHeading();
+    Direction newHeading = Actor::MakeDirectionFromVector({ delta.x, delta.y });
+    auto oldHeading = actor->GetHeading();
 
-
-      if (distance == 0.0) {
-        actor->Face(onlinePlayer.idleDirection);
-      }
-      else if (distance <= actor->GetWalkSpeed() * expectedTime) {
-        actor->Walk(newHeading, false); // Don't actually move or collide, but animate
-      }
-      else {
-        actor->Run(newHeading, false);
-      }
+    if (distance == 0.0) {
+      actor->Face(onlinePlayer.idleDirection);
+    }
+    else if (distance <= actor->GetWalkSpeed() * expectedTime) {
+      actor->Walk(newHeading, false); // Don't actually move or collide, but animate
+    }
+    else {
+      actor->Run(newHeading, false);
     }
   }
 }

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -115,6 +115,7 @@ void Overworld::OnlineArea::onUpdate(double elapsed)
 
   auto currentTime = CurrentTime::AsMilli();
 
+  // update other players
   for (auto& pair : onlinePlayers) {
     auto& onlinePlayer = pair.second;
     auto& actor = onlinePlayer.actor;
@@ -133,18 +134,22 @@ void Overworld::OnlineArea::onUpdate(double elapsed)
     float distance = std::sqrt(std::pow(delta.x, 2.0f) + std::pow(delta.y, 2.0f));
     double expectedTime = Net().CalculateLag(onlinePlayer.packets, onlinePlayer.lagWindow, 0.0);
     float alpha = static_cast<float>(ease::linear(deltaTime, expectedTime, 1.0));
-    Direction newHeading = Actor::MakeDirectionFromVector({ delta.x, delta.y });
 
-    auto oldHeading = actor->GetHeading();
+    if (!(onlinePlayer.propertyAnimator.IsAnimating() && actor->IsPlayingCustomAnimation())) {
+      // animate the player if they're not being animated by the property animator
 
-    if (distance == 0.0) {
-      actor->Face(onlinePlayer.idleDirection);
-    }
-    else if (distance <= actor->GetWalkSpeed() * expectedTime) {
-      actor->Walk(newHeading, false); // Don't actually move or collide, but animate
-    }
-    else {
-      actor->Run(newHeading, false);
+      Direction newHeading = Actor::MakeDirectionFromVector({ delta.x, delta.y });
+      auto oldHeading = actor->GetHeading();
+
+      if (distance == 0.0) {
+        actor->Face(onlinePlayer.idleDirection);
+      }
+      else if (distance <= actor->GetWalkSpeed() * expectedTime) {
+        actor->Walk(newHeading, false); // Don't actually move or collide, but animate
+      }
+      else {
+        actor->Run(newHeading, false);
+      }
     }
 
     auto newPos = onlinePlayer.startBroadcastPos + delta * alpha;

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -61,8 +61,6 @@ Overworld::OnlineArea::OnlineArea(
 
   lastFrameNavi = this->GetCurrentNavi();
 
-  SetBackground(std::make_shared<XmasBackground>());
-
   propertyAnimator.OnComplete([this] {
     // todo: this may cause issues when leaving the scene through Home and Server Warps
     GetPlayerController().ControlActor(GetPlayer());

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -46,7 +46,8 @@ Overworld::OnlineArea::OnlineArea(
   ),
   connectData(connectData),
   maxPayloadSize(maxPayloadSize),
-  serverAssetManager(address, port)
+  serverAssetManager(address, port),
+  identityManager(address, port)
 {
   transitionText.setScale(2, 2);
   transitionText.SetString("Connecting...");
@@ -930,7 +931,8 @@ void Overworld::OnlineArea::sendLoginSignal()
   BufferWriter writer;
   Poco::Buffer<char> buffer{ 0 };
   writer.Write(buffer, ClientEvents::login);
-  writer.WriteString<uint16_t>(buffer, username);
+  writer.WriteString<uint8_t>(buffer, username);
+  writer.WriteString<uint8_t>(buffer, identityManager.GetIdentity());
   writer.WriteString<uint16_t>(buffer, connectData);
   packetProcessor->SendPacket(Reliability::ReliableOrdered, buffer);
 }

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -31,9 +31,9 @@ Overworld::OnlineArea::OnlineArea(
   const std::string& address,
   uint16_t port,
   const std::string& connectData,
-  uint16_t maxPayloadSize,
-  bool guestAccount) :
-  SceneBase(controller, guestAccount),
+  uint16_t maxPayloadSize
+) :
+  SceneBase(controller),
   transitionText(Font::Style::small),
   nameText(Font::Style::small),
   connectData(connectData),
@@ -42,7 +42,7 @@ Overworld::OnlineArea::OnlineArea(
   identityManager(address, port)
 {
   try {
-    remoteAddress = Poco::Net::SocketAddress(address, port);
+    auto remoteAddress = Poco::Net::SocketAddress(address, port);
     packetProcessor = std::make_shared<Overworld::PacketProcessor>(
       remoteAddress,
       maxPayloadSize,
@@ -613,8 +613,6 @@ void Overworld::OnlineArea::onResume()
     Net().DropProcessor(netBattleProcessor);
     netBattleProcessor = nullptr;
   }
-
-  // isEnteringBattle = false;
 }
 
 void Overworld::OnlineArea::OnTileCollision() { }
@@ -705,7 +703,7 @@ Overworld::TeleportController::Command& Overworld::OnlineArea::teleportIn(sf::Ve
 
 void Overworld::OnlineArea::transferServer(const std::string& address, uint16_t port, const std::string& data, bool warpOut) {
   auto transfer = [=] {
-    getController().replace<segue<BlackWashFade>::to<Overworld::OnlineArea>>(address, port, data, maxPayloadSize, !WEBCLIENT.IsLoggedIn());
+    getController().replace<segue<BlackWashFade>::to<Overworld::OnlineArea>>(address, port, data, maxPayloadSize);
   };
 
   if (warpOut) {
@@ -1893,9 +1891,6 @@ void Overworld::OnlineArea::receivePVPSignal(BufferReader& reader, const Poco::B
     netBattleProcessor
   };
 
-  // isEnteringBattle = true;
-  // 
-  // EXAMPLE AND TEMP DEMO PURPOSES BELOW:
   BattleResultsFunc callback = [this](const BattleResults& results) {
     sendBattleResultsSignal(results);
   };

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -21,6 +21,7 @@
 
 using namespace swoosh::types;
 constexpr float SECONDS_PER_MOVEMENT = 1.f / 10.f;
+constexpr float DEFAULT_CONVEYOR_SPEED = 6.0f;
 
 Overworld::OnlineArea::OnlineArea(
   swoosh::ActivityController& controller,
@@ -452,7 +453,7 @@ void Overworld::OnlineArea::detectConveyor(std::shared_ptr<Overworld::Actor>& pl
   auto speed = tileMeta->customProperties.GetPropertyFloat("Speed");
 
   if (speed == 0.0f) {
-    speed = 6.0f;
+    speed = DEFAULT_CONVEYOR_SPEED;
   }
 
   auto duration = tileDistance / speed;

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -46,7 +46,7 @@ Overworld::OnlineArea::OnlineArea(
   ),
   connectData(connectData),
   maxPayloadSize(maxPayloadSize),
-  serverAssetManager("cache", address + "_p" + std::to_string(port))
+  serverAssetManager(address, port)
 {
   transitionText.setScale(2, 2);
   transitionText.SetString("Connecting...");

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -188,6 +188,12 @@ void Overworld::OnlineArea::updateOtherPlayers(double elapsed) {
       continue;
     }
 
+    auto tile = map.GetTileFromWorld(newPos);
+
+    if(tile && TileType::FromString(map.GetTileMeta(tile->gid)->type) == TileType::conveyor) {
+      continue;
+    }
+
     Direction newHeading = Actor::MakeDirectionFromVector({ delta.x, delta.y });
     auto oldHeading = actor->GetHeading();
 

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -14,6 +14,7 @@
 
 #include "bnOverworldOnlineArea.h"
 #include "bnOverworldTileType.h"
+#include "bnOverworldObjectType.h"
 #include "../bnXmasBackground.h"
 #include "../bnNaviRegistration.h"
 #include "../netplay/battlescene/bnNetworkBattleScene.h"
@@ -265,11 +266,11 @@ void Overworld::OnlineArea::detectWarp(std::shared_ptr<Overworld::Actor>& player
 
     auto& command = teleportController.TeleportOut(player);
 
-    auto type = TileType::FromString(tileObject.type);
+    auto type = ObjectType::FromString(tileObject.type);
     auto interpolateTime = sf::seconds(0.5f);
     auto position3 = sf::Vector3f(tileObject.position.x, tileObject.position.y, float(layerIndex));
 
-    if (type == TileType::home_warp) {
+    if (type == ObjectType::home_warp) {
       warpCameraController.QueueMoveCamera(map.WorldToScreen(position3), interpolateTime);
 
       command.onFinish.Slot([=] {
@@ -278,7 +279,7 @@ void Overworld::OnlineArea::detectWarp(std::shared_ptr<Overworld::Actor>& player
         getController().pop<segue<BlackWashFade>>();
       });
     }
-    else if (type == TileType::server_warp) {
+    else if (type == ObjectType::server_warp) {
       warpCameraController.QueueMoveCamera(map.WorldToScreen(position3), interpolateTime);
 
       auto address = tileObject.customProperties.GetProperty("address");
@@ -290,7 +291,7 @@ void Overworld::OnlineArea::detectWarp(std::shared_ptr<Overworld::Actor>& player
         transferServer(address, port, data, false);
       });
     }
-    else if (type == TileType::position_warp) {
+    else if (type == ObjectType::position_warp) {
       auto targetTilePos = sf::Vector2f(
         tileObject.customProperties.GetPropertyFloat("x"),
         tileObject.customProperties.GetPropertyFloat("y")
@@ -1399,7 +1400,7 @@ void Overworld::OnlineArea::receiveMapSignal(BufferReader& reader, const Poco::B
     for (auto& tileObject : map.GetLayer(i).GetTileObjects()) {
       if (tileObject.type == "") continue;
 
-      auto type = TileType::FromString(tileObject.type);
+      auto type = ObjectType::FromString(tileObject.type);
 
       auto tileMeta = map.GetTileMeta(tileObject.tile.gid);
 
@@ -1411,26 +1412,26 @@ void Overworld::OnlineArea::receiveMapSignal(BufferReader& reader, const Poco::B
       auto objectCenterPos = tileObject.position + map.OrthoToIsometric(screenOffset);
       auto zOffset = sf::Vector2f(0, (float)(-i * tileSize.y / 2));
 
-      if (type == TileType::home_warp) {
+      if (type == ObjectType::home_warp) {
         bool isConcealed = map.IsConcealed(sf::Vector2i(map.WorldToTileSpace(objectCenterPos)), i);
         minimap.SetHomepagePosition(map.WorldToScreen(objectCenterPos) + zOffset, isConcealed);
         tileObject.solid = false;
         warpLayer.push_back(&tileObject);
       }
-      else if (TileType::IsWarp(type)) {
+      else if (ObjectType::IsWarp(type)) {
         bool isConcealed = map.IsConcealed(sf::Vector2i(map.WorldToTileSpace(objectCenterPos)), i);
         minimap.AddWarpPosition(map.WorldToScreen(objectCenterPos) + zOffset, isConcealed);
         tileObject.solid = false;
         warpLayer.push_back(&tileObject);
       }
-      else if (type == TileType::board) {
+      else if (type == ObjectType::board) {
         sf::Vector2f bottomPosition = objectCenterPos;
         bottomPosition += map.OrthoToIsometric({ 0.0f, tileObject.size.y / 2.0f });
 
         bool isConcealed = map.IsConcealed(sf::Vector2i(map.WorldToTileSpace(bottomPosition)), i);
         minimap.AddBoardPosition(map.WorldToScreen(bottomPosition) + zOffset, tileObject.tile.flippedHorizontal, isConcealed);
       }
-      else if (type == TileType::shop) {
+      else if (type == ObjectType::shop) {
         bool isConcealed = map.IsConcealed(sf::Vector2i(map.WorldToTileSpace(tileObject.position)), i);
         minimap.AddShopPosition(map.WorldToScreen(tileObject.position) + zOffset, isConcealed);
       }

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -336,8 +336,13 @@ void Overworld::OnlineArea::detectConveyor(std::shared_ptr<Overworld::Actor>& pl
 
   auto playerTilePos = map.WorldToTileSpace(player->getPosition());
   auto& layer = map.GetLayer(layerIndex);
-  auto& tile = layer.GetTile(int(playerTilePos.x), int(playerTilePos.y));
-  auto tileMeta = map.GetTileMeta(tile.gid);
+  auto tile = layer.GetTile(int(playerTilePos.x), int(playerTilePos.y));
+
+  if (!tile) {
+    return;
+  }
+
+  auto tileMeta = map.GetTileMeta(tile->gid);
 
   if (!tileMeta || tileMeta->type != "Conveyor") {
     return;
@@ -345,11 +350,11 @@ void Overworld::OnlineArea::detectConveyor(std::shared_ptr<Overworld::Actor>& pl
 
   auto direction = FromString(tileMeta->customProperties.GetProperty("Direction"));
 
-  if (tile.flippedHorizontal) {
+  if (tile->flippedHorizontal) {
     direction = FlipHorizontal(direction);
   }
 
-  if (tile.flippedVertical) {
+  if (tile->flippedVertical) {
     direction = FlipVertical(direction);
   }
 
@@ -379,8 +384,13 @@ void Overworld::OnlineArea::detectConveyor(std::shared_ptr<Overworld::Actor>& pl
   axisProperty.ease = Ease::linear;
 
   auto isConveyor = [&layer, &map](sf::Vector2f endTilePos) {
-    auto& tile = layer.GetTile(int(endTilePos.x), int(endTilePos.y));
-    auto tileMeta = map.GetTileMeta(tile.gid);
+    auto tile = layer.GetTile(int(endTilePos.x), int(endTilePos.y));
+
+    if (!tile) {
+      return false;
+    }
+
+    auto tileMeta = map.GetTileMeta(tile->gid);
 
     return tileMeta && tileMeta->type == "Conveyor";
   };

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -50,7 +50,6 @@ namespace Overworld {
     };
 
     std::string ticket; //!< How we are represented on the server
-    Poco::Net::SocketAddress remoteAddress; //!< server
     std::shared_ptr<PacketProcessor> packetProcessor;
     std::shared_ptr<Netplay::PacketProcessor> netBattleProcessor;
     std::string connectData;
@@ -58,7 +57,6 @@ namespace Overworld {
     bool isConnected{ false };
     bool transferringServers{ false };
     bool kicked{ false };
-    bool isEnteringBattle{ false };
     bool tryPopScene{ false };
     ActorPropertyAnimator propertyAnimator;
     SelectedNavi lastFrameNavi{};
@@ -74,7 +72,6 @@ namespace Overworld {
     Text transitionText;
     Text nameText;
     std::optional<std::string> trackedPlayer;
-    bool wasReadingTextBox{ false };
     CameraController serverCameraController;
     CameraController warpCameraController;
 
@@ -171,8 +168,7 @@ namespace Overworld {
       const std::string& address,
       uint16_t port,
       const std::string& connectData,
-      uint16_t maxPayloadSize,
-      bool guestAccount
+      uint16_t maxPayloadSize
     );
 
     /**

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -14,6 +14,7 @@
 #include "bnOverworldActorPropertyAnimator.h"
 #include "bnPacketHeaders.h"
 #include "bnServerAssetManager.h"
+#include "bnIdentityManager.h"
 
 namespace Overworld {
   struct OnlinePlayer {
@@ -62,6 +63,7 @@ namespace Overworld {
     ActorPropertyAnimator propertyAnimator;
     SelectedNavi lastFrameNavi{};
     ServerAssetManager serverAssetManager;
+    IdentityManager identityManager;
     AssetMeta incomingAsset;
     std::map<std::string, OnlinePlayer> onlinePlayers;
     std::map<unsigned, ExcludedObjectData> excludedObjects;

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -8,6 +8,7 @@
 
 #include "../bnBattleResults.h"
 #include "../netplay/bnBufferReader.h"
+#include "../netplay/bnNetPlayPacketProcessor.h"
 #include "bnOverworldSceneBase.h"
 #include "bnOverworldPacketProcessor.h"
 #include "bnOverworldActorPropertyAnimator.h"
@@ -50,6 +51,7 @@ namespace Overworld {
     std::string ticket; //!< How we are represented on the server
     Poco::Net::SocketAddress remoteAddress; //!< server
     std::shared_ptr<PacketProcessor> packetProcessor;
+    std::shared_ptr<Netplay::PacketProcessor> netBattleProcessor;
     std::string connectData;
     uint16_t maxPayloadSize;
     bool isConnected{ false };

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -73,6 +73,7 @@ namespace Overworld {
     CameraController serverCameraController;
     CameraController warpCameraController;
 
+    void updateOtherPlayers(double elapsed);
     void updatePlayer(double elapsed);
     void detectWarp(std::shared_ptr<Actor>& player);
     void detectConveyor(std::shared_ptr<Actor>& player);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -124,6 +124,8 @@ namespace Overworld {
     void receiveHealthSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveEmotionSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveMoneySignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveItemSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveRemoveItemSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receivePlaySoundSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveExcludeObjectSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveIncludeObjectSignal(BufferReader& reader, const Poco::Buffer<char>&);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <functional>
 
+#include "../bnBattleResults.h"
 #include "../netplay/bnBufferReader.h"
 #include "bnOverworldSceneBase.h"
 #include "bnOverworldPacketProcessor.h"
@@ -104,6 +105,7 @@ namespace Overworld {
     void sendBoardCloseSignal();
     void sendPostRequestSignal();
     void sendPostSelectSignal(const std::string& postId);
+    void sendBattleResultsSignal(const BattleResults& results);
 
     void receiveLoginSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveTransferWarpSignal(BufferReader& reader, const Poco::Buffer<char>&);
@@ -117,6 +119,8 @@ namespace Overworld {
     void receivePreloadSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveCustomEmotesPathSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveMapSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveHealthSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveEmotionSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveMoneySignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receivePlaySoundSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveExcludeObjectSignal(BufferReader& reader, const Poco::Buffer<char>&);

--- a/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.cpp
+++ b/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.cpp
@@ -1,0 +1,86 @@
+#include "bnOverworldPollingPacketProcessor.h"
+
+#include "bnPacketHeaders.h"
+#include "../netplay/bnBufferWriter.h"
+#include "../netplay/bnBufferReader.h"
+#include <optional>
+
+constexpr sf::Int32 PING_SERVER_MILI = 1000;
+
+namespace Overworld {
+  PollingPacketProcessor::PollingPacketProcessor(const Poco::Net::SocketAddress& remoteAddress, uint16_t maxPayloadSize, std::function<void(ServerStatus, uint16_t)> onResolve) :
+    packetShipper(remoteAddress, maxPayloadSize),
+    onResolve(onResolve)
+  {
+    pingServerTimer.reverse(true);
+    pingServerTimer.set(sf::milliseconds(PING_SERVER_MILI));
+    pingServerTimer.start();
+  }
+
+  bool PollingPacketProcessor::TimedOut() {
+    auto timeDifference = std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::steady_clock::now() - lastMessageTime
+      );
+
+    constexpr int64_t MAX_TIMEOUT_SECONDS = 5;
+
+    return timeDifference.count() > MAX_TIMEOUT_SECONDS;
+  }
+
+  void PollingPacketProcessor::Update(double elapsed) {
+    pingServerTimer.update(sf::seconds(static_cast<float>(elapsed)));
+
+    if (pingServerTimer.getElapsed().asSeconds() == 0.0f) {
+      Poco::Buffer<char> buffer{ 0 };
+      BufferWriter writer;
+      writer.Write(buffer, ClientEvents::ping);
+
+      packetShipper.Send(*client, Reliability::Unreliable, buffer);
+
+      pingServerTimer.set(sf::milliseconds(PING_SERVER_MILI));
+    }
+
+    if (TimedOut()) {
+      // set last message time to now to prevent resolve spam
+      lastMessageTime = std::chrono::steady_clock::now();
+      onResolve(ServerStatus::offline, 0);
+    }
+  }
+
+  void PollingPacketProcessor::OnPacket(char* buffer, int read, const Poco::Net::SocketAddress& sender) {
+    BufferReader reader;
+    auto data = Poco::Buffer<char>(buffer, read);
+    lastMessageTime = std::chrono::steady_clock::now();
+
+    if (reader.Read<Reliability>(data) != Reliability::Unreliable) {
+      // ignoring, might be for a previous processor
+      return;
+    }
+
+    if (reader.Read<ServerEvents>(data) != ServerEvents::pong) {
+      // ignoring, might be for a previous processor
+      return;
+    }
+
+    auto serverBranch = reader.ReadString<uint16_t>(data);
+
+    if (serverBranch != VERSION_ID) {
+      onResolve(ServerStatus::offline, 0);
+      return;
+    }
+    auto serverIteration = reader.Read<uint64_t>(data);
+
+    if (VERSION_ITERATION < serverIteration) {
+      onResolve(ServerStatus::newer_version, 0);
+      return;
+    }
+
+    if (VERSION_ITERATION > serverIteration) {
+      onResolve(ServerStatus::older_version, 0);
+      return;
+    }
+
+    auto serverMaxPayloadSize = reader.Read<uint16_t>(data);
+    onResolve(ServerStatus::online, serverMaxPayloadSize);
+  }
+}

--- a/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.h
+++ b/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "bnPacketHeaders.h"
+#include "../netplay/bnPacketShipper.h"
+#include "../bnIPacketProcessor.h"
+#include <Swoosh/Timer.h>
+#include <Poco/Net/SocketAddress.h>
+#include <chrono>
+#include <functional>
+
+namespace Overworld {
+  enum class ServerStatus {
+    older_version,
+    newer_version,
+    offline,
+    online
+  };
+
+  class PollingPacketProcessor : public IPacketProcessor {
+  public:
+    PollingPacketProcessor(const Poco::Net::SocketAddress& remoteAddress, uint16_t maxPayloadSize, std::function<void(ServerStatus, uint16_t)> onPacketBody);
+
+    bool TimedOut();
+    void Update(double elapsed) override;
+    void OnPacket(char* buffer, int read, const Poco::Net::SocketAddress& sender) override;
+
+  private:
+    std::function<void(ServerStatus, uint16_t)> onResolve;
+    PacketShipper packetShipper;
+    swoosh::Timer pingServerTimer;
+    std::chrono::time_point<std::chrono::steady_clock> lastMessageTime;
+  };
+}

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -923,7 +923,6 @@ void Overworld::SceneBase::LoadMap(const std::string& data)
     // add objects to layer
     if (objectLayerElements.size() > i) {
       auto& objectLayerElement = objectLayerElements[i];
-      float elevation = (float)i;
 
       for (auto& child : objectLayerElement.children) {
         if (child.name != "object") {
@@ -932,6 +931,9 @@ void Overworld::SceneBase::LoadMap(const std::string& data)
 
         if (child.HasAttribute("gid")) {
           auto tileObject = TileObject::From(child);
+          auto tilePosition = map.WorldToTileSpace(tileObject.position);
+          auto elevation = map.GetElevationAt(tilePosition.x, tilePosition.y, i);
+
           tileObject.GetWorldSprite()->SetElevation(elevation);
           layer.AddTileObject(tileObject);
         }

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -311,7 +311,7 @@ void Overworld::SceneBase::HandleCamera(float elapsed) {
   if (!cameraLocked) {
     // Follow the navi
     sf::Vector2f pos = playerActor->getPosition();
-    
+
     if (teleportedOut) {
       pos = { returnPoint.x, returnPoint.y };
     }
@@ -946,13 +946,10 @@ void Overworld::SceneBase::LoadMap(const std::string& data)
     }
   }
 
-  bool backgroundDiffers = map.GetBackgroundName() != this->map.GetBackgroundName() || (
-    map.GetBackgroundName() == "custom" && (
-      map.GetBackgroundCustomTexturePath() != this->map.GetBackgroundCustomTexturePath() ||
-      map.GetBackgroundCustomAnimationPath() != this->map.GetBackgroundCustomAnimationPath() ||
-      map.GetBackgroundCustomVelocity() != this->map.GetBackgroundCustomVelocity()
-      )
-    );
+  bool backgroundDiffers = map.GetBackgroundName() != this->map.GetBackgroundName() ||
+    map.GetBackgroundCustomTexturePath() != this->map.GetBackgroundCustomTexturePath() ||
+    map.GetBackgroundCustomAnimationPath() != this->map.GetBackgroundCustomAnimationPath() ||
+    map.GetBackgroundCustomVelocity() != this->map.GetBackgroundCustomVelocity();
 
   if (backgroundDiffers) {
     LoadBackground(map, map.GetBackgroundName());

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -19,7 +19,6 @@
 #include "../bnLibraryScene.h"
 #include "../bnConfigScene.h"
 #include "../bnFolderScene.h"
-#include "../bnKeyItemScene.h"
 #include "../bnVendorScene.h"
 #include "../bnCardFolderCollection.h"
 #include "../bnCustomBackground.h"
@@ -1326,14 +1325,6 @@ void Overworld::SceneBase::GotoKeyItems()
 
   using effect = segue<BlackWashFade, milliseconds<500>>;
 
-  std::vector<KeyItemScene::Item> items;
-  for (auto& item : webAccount.keyItems) {
-    items.push_back(KeyItemScene::Item{
-      item.name,
-      item.description
-      });
-  }
-
   getController().push<effect::to<KeyItemScene>>(items);
 }
 
@@ -1443,6 +1434,20 @@ void Overworld::SceneBase::OnEmoteSelected(Emotes emote)
 void Overworld::SceneBase::OnCustomEmoteSelected(unsigned emote)
 {
   emoteNode.CustomEmote(emote);
+}
+
+void Overworld::SceneBase::AddItem(const std::string& name, const std::string& description)
+{
+  items.push_back({ name, description });
+}
+
+void Overworld::SceneBase::RemoveItem(const std::string& name)
+{
+  auto iter = std::find_if(items.begin(), items.end(), [&name](auto& item) { return item.name == name; });
+
+  if (iter != items.end()) {
+    items.erase(iter);
+  }
 }
 
 std::pair<unsigned, unsigned> Overworld::SceneBase::PixelToRowCol(const sf::Vector2i& px, const sf::RenderWindow& window) const

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -542,10 +542,10 @@ void Overworld::SceneBase::DrawMapLayer(sf::RenderTarget& target, sf::RenderStat
       int row = tileSpaceStart.y + verticalStart - j + rowOffset;
       int col = tileSpaceStart.x + verticalStart + j;
 
-      auto& tile = layer.GetTile(col, row);
-      if (tile.gid == 0) continue;
+      auto tile = layer.GetTile(col, row);
+      if (!tile || tile->gid == 0) continue;
 
-      auto tileMeta = map.GetTileMeta(tile.gid);
+      auto tileMeta = map.GetTileMeta(tile->gid);
 
       // failed to load tile
       if (tileMeta == nullptr) continue;
@@ -567,10 +567,10 @@ void Overworld::SceneBase::DrawMapLayer(sf::RenderTarget& target, sf::RenderStat
       ));
 
       tileSprite.setPosition(ortho + tileMeta->drawingOffset + tileOffset);
-      tileSprite.setRotation(tile.rotated ? 90.0f : 0.0f);
+      tileSprite.setRotation(tile->rotated ? 90.0f : 0.0f);
       tileSprite.setScale(
-        tile.flippedHorizontal ? -1.0f : 1.0f,
-        tile.flippedVertical ? -1.0f : 1.0f
+        tile->flippedHorizontal ? -1.0f : 1.0f,
+        tile->flippedVertical ? -1.0f : 1.0f
       );
 
       sf::Color originalColor = tileSprite.getColor();

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -460,7 +460,9 @@ void Overworld::SceneBase::onDraw(sf::RenderTexture& surface) {
     return;
   }
 
-  surface.draw(*bg);
+  if (bg) {
+    surface.draw(*bg);
+  }
 
   DrawWorld(surface, sf::RenderStates::Default);
 

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -57,8 +57,7 @@ namespace {
   };
 }
 
-Overworld::SceneBase::SceneBase(swoosh::ActivityController& controller, bool guestAccount) :
-  guestAccount(guestAccount),
+Overworld::SceneBase::SceneBase(swoosh::ActivityController& controller) :
   lastIsConnectedState(false),
   personalMenu("Overworld", ::MakeOptions(this)),
   camera(controller.getWindow().getView()),
@@ -410,7 +409,7 @@ void Overworld::SceneBase::onEnter()
 
 void Overworld::SceneBase::onResume() {
 
-  guestAccount = !WEBCLIENT.IsLoggedIn();
+  auto guestAccount = !WEBCLIENT.IsLoggedIn();
 
   if (!guestAccount) {
     accountCommandResponse = WEBCLIENT.SendFetchAccountCommand();

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -18,6 +18,7 @@
 #include "../bnDrawWindow.h"
 #include "../bnAnimation.h"
 #include "../bnCardFolderCollection.h"
+#include "../bnKeyItemScene.h"
 
 // overworld
 #include "bnOverworldCameraController.h"
@@ -53,6 +54,7 @@ namespace Overworld {
     Overworld::PlayerController playerController{};
     Overworld::SpatialMap spatialMap{};
     std::vector<std::shared_ptr<Overworld::Actor>> actors;
+    std::vector<KeyItemScene::Item> items;
 
     double animElapsed{};
     bool showMinimap{ false };
@@ -189,6 +191,9 @@ namespace Overworld {
     void SetBackground(const std::shared_ptr<Background>&);
 
     void SetCustomEmotesTexture(const std::shared_ptr<sf::Texture>&);
+
+    void AddItem(const std::string& name, const std::string& description);
+    void RemoveItem(const std::string& name);
 
     /**
      * @brief Add a sprite

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -61,11 +61,8 @@ namespace Overworld {
     bool inputLocked{ false };
     bool cameraLocked{ false };
     bool teleportedOut{ false }; /*!< We may return to this area*/
-    bool cameraSmooth{ false }; /*!< Used if camera should lerp to a destination (via warps) */
-    bool clicked{ false }, scaledmap{ false };
     bool lastIsConnectedState; /*!< Set different animations if the connection has changed */
     bool gotoNextScene{ false }; /*!< If true, player cannot interact with screen yet */
-    bool guestAccount{ false };
 
     Camera camera;
     CameraController cameraController; /*!< camera in scene follows player */
@@ -126,7 +123,7 @@ namespace Overworld {
     /**
      * @brief Loads the player's library data and loads graphics
      */
-    SceneBase(swoosh::ActivityController&, bool guestAccount);
+    SceneBase(swoosh::ActivityController&);
 
     /**
      * @brief Checks input events and listens for select buttons. Segues to new screens.

--- a/BattleNetwork/overworld/bnOverworldShadowMap.cpp
+++ b/BattleNetwork/overworld/bnOverworldShadowMap.cpp
@@ -26,9 +26,9 @@ namespace Overworld {
 
         for (auto index = layerCount - 1; index >= 1; index--) {
           auto& layer = map.GetLayer(index);
-          auto& tile = layer.GetTile((int)x, (int)y);
+          auto tile = layer.GetTile((int)x, (int)y);
 
-          if (tile.gid == 0) {
+          if (tile->gid == 0) {
             continue;
           }
 

--- a/BattleNetwork/overworld/bnOverworldTile.cpp
+++ b/BattleNetwork/overworld/bnOverworldTile.cpp
@@ -10,7 +10,7 @@ namespace Overworld {
     unsigned int gid,
     sf::Vector2f drawingOffset,
     sf::Vector2f alignmentOffset,
-    const std::string& type,
+    const std::string& typeString,
     const CustomProperties& customProperties,
     std::vector<std::unique_ptr<Shape>> collisionShapes
   ) :
@@ -18,7 +18,9 @@ namespace Overworld {
     gid(gid),
     drawingOffset(drawingOffset),
     alignmentOffset(alignmentOffset),
-    type(type),
+    typeString(typeString),
+    type(TileType::FromString(typeString)),
+    direction(FromString(customProperties.GetProperty("direction"))),
     customProperties(customProperties),
     collisionShapes(std::move(collisionShapes))
   {

--- a/BattleNetwork/overworld/bnOverworldTile.h
+++ b/BattleNetwork/overworld/bnOverworldTile.h
@@ -4,8 +4,10 @@
 #include <vector>
 #include <memory>
 
+#include "bnOverworldTileType.h"
 #include "bnOverworldCustomProperties.h"
 #include "bnOverworldShapes.h"
+#include "../bnDirection.h"
 #include "../bnAnimation.h"
 
 namespace Overworld
@@ -31,7 +33,9 @@ namespace Overworld
     const unsigned int gid;
     const sf::Vector2f drawingOffset;
     const sf::Vector2f alignmentOffset;
-    const std::string type;
+    const std::string typeString;
+    const TileType::TileType type;
+    const Direction direction;
     const CustomProperties customProperties;
     const std::vector<std::unique_ptr<Shape>> collisionShapes;
     Animation animation;

--- a/BattleNetwork/overworld/bnOverworldTileType.h
+++ b/BattleNetwork/overworld/bnOverworldTileType.h
@@ -6,69 +6,22 @@ namespace Overworld {
   namespace TileType {
     enum TileType {
       conveyor,
-      custom_warp,
-      server_warp,
-      position_warp,
-      custom_server_warp,
-      home_warp,
-      board,
-      shop,
       stairs,
       undefined,
     };
 
     inline TileType FromString(const std::string_view& type_string) {
       constexpr std::string_view conveyor_string = "Conveyor";
-      constexpr std::string_view custom_warp_string = "Custom Warp";
-      constexpr std::string_view server_warp_string = "Server Warp";
-      constexpr std::string_view position_warp_string = "Position Warp";
-      constexpr std::string_view custom_server_warp_string = "Custom Server Warp";
-      constexpr std::string_view home_warp_string = "Home Warp";
-      constexpr std::string_view board_string = "Board";
-      constexpr std::string_view shop_string = "Shop";
       constexpr std::string_view stairs_string = "Stairs";
 
       if (stx::insensitive_equals(type_string, conveyor_string)) {
         return TileType::conveyor;
-      }
-      if (stx::insensitive_equals(type_string, custom_warp_string)) {
-        return TileType::custom_warp;
-      }
-      if (stx::insensitive_equals(type_string, server_warp_string)) {
-        return TileType::server_warp;
-      }
-      if (stx::insensitive_equals(type_string, position_warp_string)) {
-        return TileType::position_warp;
-      }
-      if (stx::insensitive_equals(type_string, custom_server_warp_string)) {
-        return TileType::custom_server_warp;
-      }
-      if (stx::insensitive_equals(type_string, home_warp_string)) {
-        return TileType::home_warp;
-      }
-      if (stx::insensitive_equals(type_string, board_string)) {
-        return TileType::board;
-      }
-      if (stx::insensitive_equals(type_string, shop_string)) {
-        return TileType::shop;
       }
       if (stx::insensitive_equals(type_string, stairs_string)) {
         return TileType::stairs;
       }
 
       return TileType::undefined;
-    }
-
-    inline bool IsWarp(TileType type) {
-      return type == custom_warp ||
-        type == server_warp ||
-        type == position_warp ||
-        type == custom_server_warp ||
-        type == home_warp;
-    }
-
-    inline bool IsCustomWarp(TileType type) {
-      return type == custom_warp || type == custom_server_warp;
     }
   };
 }

--- a/BattleNetwork/overworld/bnOverworldTileType.h
+++ b/BattleNetwork/overworld/bnOverworldTileType.h
@@ -1,0 +1,74 @@
+#pragma once
+#include <string_view>
+#include "../stx/string.h"
+
+namespace Overworld {
+  namespace TileType {
+    enum TileType {
+      conveyor,
+      custom_warp,
+      server_warp,
+      position_warp,
+      custom_server_warp,
+      home_warp,
+      board,
+      shop,
+      stairs,
+      undefined,
+    };
+
+    inline TileType FromString(const std::string_view& type_string) {
+      constexpr std::string_view conveyor_string = "Conveyor";
+      constexpr std::string_view custom_warp_string = "Custom Warp";
+      constexpr std::string_view server_warp_string = "Server Warp";
+      constexpr std::string_view position_warp_string = "Position Warp";
+      constexpr std::string_view custom_server_warp_string = "Custom Server Warp";
+      constexpr std::string_view home_warp_string = "Home Warp";
+      constexpr std::string_view board_string = "Board";
+      constexpr std::string_view shop_string = "Shop";
+      constexpr std::string_view stairs_string = "Stairs";
+
+      if (stx::insensitive_equals(type_string, conveyor_string)) {
+        return TileType::conveyor;
+      }
+      if (stx::insensitive_equals(type_string, custom_warp_string)) {
+        return TileType::custom_warp;
+      }
+      if (stx::insensitive_equals(type_string, server_warp_string)) {
+        return TileType::server_warp;
+      }
+      if (stx::insensitive_equals(type_string, position_warp_string)) {
+        return TileType::position_warp;
+      }
+      if (stx::insensitive_equals(type_string, custom_server_warp_string)) {
+        return TileType::custom_server_warp;
+      }
+      if (stx::insensitive_equals(type_string, home_warp_string)) {
+        return TileType::home_warp;
+      }
+      if (stx::insensitive_equals(type_string, board_string)) {
+        return TileType::board;
+      }
+      if (stx::insensitive_equals(type_string, shop_string)) {
+        return TileType::shop;
+      }
+      if (stx::insensitive_equals(type_string, stairs_string)) {
+        return TileType::stairs;
+      }
+
+      return TileType::undefined;
+    }
+
+    inline bool IsWarp(TileType type) {
+      return type == custom_warp ||
+        type == server_warp ||
+        type == position_warp ||
+        type == custom_server_warp ||
+        type == home_warp;
+    }
+
+    inline bool IsCustomWarp(TileType type) {
+      return type == custom_warp || type == custom_server_warp;
+    }
+  };
+}

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 23;
+  const uint64_t VERSION_ITERATION = 24;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -36,6 +36,7 @@ namespace Overworld
     board_close,
     post_request,
     post_selection,
+    battle_results,
     size,
     unknown = size
   };
@@ -64,6 +65,8 @@ namespace Overworld
     preload,
     custom_emotes_path,
     map,
+    health,
+    emotion,
     money,
     play_sound,
     exclude_object,

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 25;
+  const uint64_t VERSION_ITERATION = 26;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -68,6 +68,8 @@ namespace Overworld
     health,
     emotion,
     money,
+    add_item,
+    remove_item,
     play_sound,
     exclude_object,
     include_object,

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 24;
+  const uint64_t VERSION_ITERATION = 25;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 26;
+  const uint64_t VERSION_ITERATION = 27;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 

--- a/BattleNetwork/overworld/bnPacketHeaders.h
+++ b/BattleNetwork/overworld/bnPacketHeaders.h
@@ -5,7 +5,7 @@
 
 namespace Overworld
 {
-  const std::string VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
+  constexpr std::string_view VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
   const uint64_t VERSION_ITERATION = 27;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;

--- a/BattleNetwork/overworld/bnServerAssetManager.cpp
+++ b/BattleNetwork/overworld/bnServerAssetManager.cpp
@@ -3,12 +3,15 @@
 #include "../bnLogger.h"
 #include <fstream>
 #include <sstream>
+#include <string_view>
 #include <iterator>
 
 #ifndef __APPLE__
   // TODO: mac os < 10.15 file system support
   #include<filesystem>
 #endif
+
+constexpr std::string_view CACHE_FOLDER = "cache";
 
 static char encodeHexChar(char c) {
   if (c < 10) {
@@ -98,8 +101,8 @@ static std::tuple<std::string, uint64_t> decodeName(const std::string& name) {
 }
 
 
-Overworld::ServerAssetManager::ServerAssetManager(const std::string& parentFolder, const std::string& folderName) :
-  cachePath(parentFolder + '/' + URIEncode(folderName))
+Overworld::ServerAssetManager::ServerAssetManager(const std::string& address, uint16_t port) :
+  cachePath(std::string(CACHE_FOLDER) + '/' + URIEncode(address + "_p" + std::to_string(port)))
 {
   // prefix with cached- to avoid reserved names such as COM
   cachePrefix = cachePath + "/cached-";

--- a/BattleNetwork/overworld/bnServerAssetManager.cpp
+++ b/BattleNetwork/overworld/bnServerAssetManager.cpp
@@ -8,7 +8,7 @@
 
 #ifndef __APPLE__
   // TODO: mac os < 10.15 file system support
-  #include<filesystem>
+  #include <filesystem>
 #endif
 
 constexpr std::string_view CACHE_FOLDER = "cache";
@@ -23,7 +23,7 @@ static char encodeHexChar(char c) {
 
 // prevents a server from doing something dangerous by abusing special characters that we may be unaware of
 // also allows us to have a flat file structure for easy reading
-static std::string URIEncode(std::string name) {
+std::string Overworld::URIEncode(const std::string& name) {
   std::stringstream encodedName;
 
   for (auto i = 0; i < name.length(); i++) {
@@ -78,7 +78,7 @@ static std::string URIDecode(std::string encodedName) {
 }
 
 static std::string encodeName(const std::string& name, uint64_t lastModified) {
-  return std::to_string(lastModified) + "-" + URIEncode(name);
+  return std::to_string(lastModified) + "-" + Overworld::URIEncode(name);
 }
 
 static std::tuple<std::string, uint64_t> decodeName(const std::string& name) {

--- a/BattleNetwork/overworld/bnServerAssetManager.h
+++ b/BattleNetwork/overworld/bnServerAssetManager.h
@@ -25,7 +25,7 @@ namespace Overworld {
     void CacheAsset(const std::string& name, uint64_t lastModified, const char* data, size_t size);
     std::vector<char> LoadFromCache(const std::string& name);
   public:
-    ServerAssetManager(const std::string& parentFolder, const std::string& folderName);
+    ServerAssetManager(const std::string& address, uint16_t port);
 
     std::string GetPath(const std::string& name);
     const std::unordered_map<std::string, CacheMeta>& GetCachedAssetList();

--- a/BattleNetwork/overworld/bnServerAssetManager.h
+++ b/BattleNetwork/overworld/bnServerAssetManager.h
@@ -7,6 +7,8 @@
 #include <unordered_map>
 
 namespace Overworld {
+  std::string URIEncode(const std::string& name);
+
   class ServerAssetManager {
   private:
     struct CacheMeta {

--- a/BattleNetwork/stx/string.cpp
+++ b/BattleNetwork/stx/string.cpp
@@ -1,12 +1,26 @@
 #include "string.h"
 
 namespace stx {
-std::string replace(std::string str, const std::string& from, const std::string& to) {
-  size_t start_pos = 0;
-  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
-    str.replace(start_pos, from.length(), to);
-    start_pos += to.length(); // Handles case where 'to' is a substring of 'from'
+  std::string replace(std::string str, const std::string& from, const std::string& to) {
+    size_t start_pos = 0;
+    while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+      str.replace(start_pos, from.length(), to);
+      start_pos += to.length(); // Handles case where 'to' is a substring of 'from'
+    }
+    return str;
   }
-  return str;
-}
+
+  bool insensitive_equals(const std::string_view& a, const std::string_view& b) {
+    if (a.size() != b.size()) {
+      return false;
+    }
+
+    for (size_t i = 0; i < a.size(); i++) {
+      if (toupper(a[i]) != toupper(b[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }

--- a/BattleNetwork/stx/string.h
+++ b/BattleNetwork/stx/string.h
@@ -1,8 +1,9 @@
 #pragma once
 #include <string>
+#include <string_view>
 
 namespace stx {
-      /**
+  /**
    * @brief Replaces matching string `from` to `to` in source string `str`
    * @param str source string
    * @param from matching pattern
@@ -10,4 +11,12 @@ namespace stx {
    * @return modified string
    */
   std::string replace(std::string str, const std::string& from, const std::string& to);
+
+  /**
+   * @brief Compares two strings ignoring capitalization
+   * @param a
+   * @param b
+   * @return
+   */
+  bool insensitive_equals(const std::string_view& a, const std::string_view& b);
 }


### PR DESCRIPTION
Changes
- Fixed rare matchmaking limbo due to quick downloads
- 32 byte identity file generated for servers in a folder named identity
- Packets for key items from server
- Manage pvp packet processor in overworld (still needs download scene)
- Objects should have correct elevations on stairs now
- Skip animating other players if they're on a conveyor
- Enum comparisons instead of string comparisons for tiled Type and Directions
- Specialized packet processor for polling servers now used in Homepage (eventually will be used for transfers as well)
- Created BufferWriter
- More clean ups