### PR TITLE
Only play menu close sound once

### DIFF
--- a/BattleNetwork/overworld/bnOverworldPersonalMenu.cpp
+++ b/BattleNetwork/overworld/bnOverworldPersonalMenu.cpp
@@ -323,8 +323,9 @@ namespace Overworld {
   void PersonalMenu::HandleInput(InputManager& input, AudioResourceManager& audio) {
     // menu widget
     if (input.Has(InputEvents::pressed_pause) && !input.Has(InputEvents::pressed_cancel)) {
-      Close();
-      audio.Play(AudioType::CHIP_DESC_CLOSE);
+      if (Close()) {
+        audio.Play(AudioType::CHIP_DESC_CLOSE);
+      }
     }
 
     if (!IsOpen()) {


### PR DESCRIPTION
If the user repeatedly presses the menu button before the menu fully
closes, it will only play the sound effect the first time.