### PR TITLE
VendorScene and bug fixes

### DIFF
--- a/BattleNetwork/bnKeyItemScene.h
+++ b/BattleNetwork/bnKeyItemScene.h
@@ -8,6 +8,7 @@
 class KeyItemScene : public Scene {
 public:
   struct Item {
+    std::string id;
     std::string name;
     std::string desc;
   };

--- a/BattleNetwork/bnVendorScene.cpp
+++ b/BattleNetwork/bnVendorScene.cpp
@@ -51,13 +51,21 @@ void VendorScene::ShowDefaultMessage()
   this->showDescription = false;
 }
 
-VendorScene::VendorScene(swoosh::ActivityController& controller, const std::vector<VendorScene::Item>& items, uint32_t& monies, 
-  const sf::Sprite& mugshot, const Animation& anim) :
+VendorScene::VendorScene(
+  swoosh::ActivityController& controller,
+  const std::vector<VendorScene::Item>& items,
+  uint32_t monies,
+  const std::shared_ptr<sf::Texture>& mugshotTexture,
+  const Animation& anim,
+  const VendorScene::PurchaseCallback& callback
+) :
+  callback(callback),
   monies(monies),
   items(items),
   label(Font::Style::thin),
   textbox({ 4, 255 }),
-  mugshot(mugshot),
+  mugshotTexture(mugshotTexture),
+  mugshot(*mugshotTexture),
   anim(anim),
   Scene(controller)
 {
@@ -215,6 +223,7 @@ void VendorScene::onUpdate(double elapsed)
                 Audio().Play(AudioType::ITEM_GET);
 
                 ShowDefaultMessage(); //enqueues default message
+                callback(itemName);
               }
               else {
                 message = new Message("Not enough monies!");

--- a/BattleNetwork/bnVendorScene.h
+++ b/BattleNetwork/bnVendorScene.h
@@ -8,6 +8,8 @@
 
 class VendorScene : public Scene {
 public:
+  typedef std::function<void(const std::string&)> PurchaseCallback;
+
   struct Item {
     std::string name;
     std::string desc;
@@ -34,7 +36,7 @@ private:
     sf::Sprite dummy;
   }*bg{ nullptr };
 
-  uint32_t& monies;
+  uint32_t monies;
   double totalElapsed{};
 
   std::vector<Item> items;
@@ -45,6 +47,7 @@ private:
   sf::Sprite cursor;
   sf::Sprite list;
   std::string defaultMessage;
+  std::shared_ptr<sf::Texture> mugshotTexture;
   sf::Sprite mugshot;
   Animation anim;
   AnimatedTextBox textbox;
@@ -53,14 +56,21 @@ private:
   float heldCooldown{};
   signed row{}, rowOffset{};
   bool showDescription{ false }; 
+  PurchaseCallback callback;
 
   const signed maxRows = 5;
 
   void ShowDefaultMessage();
 
 public:
-  VendorScene(swoosh::ActivityController& controller, const std::vector<VendorScene::Item>& items, uint32_t& monies, 
-    const sf::Sprite& mugshot, const Animation& anim);
+  VendorScene(
+    swoosh::ActivityController& controller,
+    const std::vector<VendorScene::Item>& items,
+    uint32_t monies, 
+    const std::shared_ptr<sf::Texture>& mugshotTexture,
+    const Animation& anim,
+    const PurchaseCallback& callback
+  );
 
   ~VendorScene();
 

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -2196,8 +2196,10 @@ void Overworld::OnlineArea::receiveActorMoveSignal(BufferReader& reader, const P
 
     // Do not attempt to animate the teleport over quick movements if already teleporting or animating position
     if (teleportController->IsComplete() && !animatingPos) {
+      auto expectedTime = onlinePlayer.lagWindow.GetEMA();
+
       // we can't possibly have moved this far away without teleporting
-      if (distance >= (onlinePlayer.actor->GetRunSpeed() * 2.f) * float(timeDifference)) {
+      if (distance >= (onlinePlayer.actor->GetRunSpeed() * 2.f) * expectedTime) {
         actor->Set3DPosition(endBroadcastPos);
         auto& action = teleportController->TeleportOut(actor);
         action.onFinish.Slot([=] {

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -60,6 +60,11 @@ Overworld::OnlineArea::OnlineArea(
     );
 
     Net().AddHandler(remoteAddress, packetProcessor);
+
+    sendLoginSignal();
+    sendAssetsFound();
+    sendAvatarChangeSignal();
+    sendRequestJoinSignal();
   }
   catch (...) {
     // invalid remote address
@@ -715,11 +720,6 @@ void Overworld::OnlineArea::onStart()
 {
   SceneBase::onStart();
   movementTimer.start();
-
-  sendLoginSignal();
-  sendAssetsFound();
-  sendAvatarChangeSignal();
-  sendRequestJoinSignal();
 }
 
 void Overworld::OnlineArea::onEnd()

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -113,8 +113,6 @@ void Overworld::OnlineArea::onUpdate(double elapsed)
     return;
   }
 
-  GetPersonalMenu().SetHealth(GetPlayerSession().health);
-
   // remove players before update, to prevent removed players from being added to sprite layers
   // players do not have a shared pointer to the emoteNode
   // a segfault would occur if this loop is placed after onUpdate due to emoteNode being deleted
@@ -261,8 +259,8 @@ void Overworld::OnlineArea::HandlePVPStep(const std::string& remoteAddress)
     Player* player = meta.GetNavi();
 
     int fullHealth = player->GetHealth();
-    player->SetHealth(GetPlayerSession().health);
-    player->SetEmotion(GetPlayerSession().emotion);
+    player->SetHealth(GetPlayerSession()->health);
+    player->SetEmotion(GetPlayerSession()->emotion);
 
     NetworkBattleSceneProps props = {
       { *player, GetProgramAdvance(), folder, new Field(6, 3), GetBackground() },
@@ -1571,9 +1569,8 @@ void Overworld::OnlineArea::receiveHealthSignal(BufferReader& reader, const Poco
   auto health = reader.Read<int>(buffer);
   auto maxHealth = reader.Read<int>(buffer);
 
-  GetPlayerSession().health = health;
-  GetPersonalMenu().SetHealth(health);
-  GetPersonalMenu().SetMaxHealth(maxHealth);
+  GetPlayerSession()->health = health;
+  GetPlayerSession()->maxHealth = maxHealth;
 }
 
 void Overworld::OnlineArea::receiveEmotionSignal(BufferReader& reader, const Poco::Buffer<char>& buffer)
@@ -1584,13 +1581,13 @@ void Overworld::OnlineArea::receiveEmotionSignal(BufferReader& reader, const Poc
     emotion = Emotion::normal;
   }
 
-  GetPlayerSession().emotion = emotion;
+  GetPlayerSession()->emotion = emotion;
 }
 
 void Overworld::OnlineArea::receiveMoneySignal(BufferReader& reader, const Poco::Buffer<char>& buffer)
 {
   auto balance = reader.Read<int>(buffer);
-  GetPersonalMenu().SetMonies(balance);
+  GetPlayerSession()->money = balance;
 }
 
 void Overworld::OnlineArea::receiveItemSignal(BufferReader& reader, const Poco::Buffer<char>& buffer)

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -1595,17 +1595,18 @@ void Overworld::OnlineArea::receiveMoneySignal(BufferReader& reader, const Poco:
 
 void Overworld::OnlineArea::receiveItemSignal(BufferReader& reader, const Poco::Buffer<char>& buffer)
 {
+  auto id = reader.ReadString<uint8_t>(buffer);
   auto name = reader.ReadString<uint8_t>(buffer);
   auto description = reader.ReadString<uint16_t>(buffer);
 
-  AddItem(name, description);
+  AddItem(id, name, description);
 }
 
 void Overworld::OnlineArea::receiveRemoveItemSignal(BufferReader& reader, const Poco::Buffer<char>& buffer)
 {
-  auto name = reader.ReadString<uint8_t>(buffer);
+  auto id = reader.ReadString<uint8_t>(buffer);
 
-  RemoveItem(name);
+  RemoveItem(id);
 }
 
 void Overworld::OnlineArea::receivePlaySoundSignal(BufferReader& reader, const Poco::Buffer<char>& buffer) {

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -7,6 +7,7 @@
 #include <functional>
 
 #include "../bnBattleResults.h"
+#include "../bnVendorScene.h"
 #include "../netplay/bnRollingWindow.h"
 #include "../netplay/bnBufferReader.h"
 #include "../netplay/bnNetPlayPacketProcessor.h"
@@ -35,6 +36,13 @@ namespace Overworld {
 
   class OnlineArea final : public SceneBase {
   private:
+    enum class ReturningScene {
+      DownloadScene,
+      BattleScene,
+      VendorScene,
+      Null
+    };
+
     struct ExcludedObjectData {
       bool visible;
       bool solid;
@@ -62,8 +70,8 @@ namespace Overworld {
     bool tryPopScene{ false };
     bool isPreparingForBattle{ false };
     bool canProceedToBattle{ false };
-    bool leftForBattle{ false };
     bool copyScreen{ false };
+    ReturningScene returningFrom{ ReturningScene::Null };
     ActorPropertyAnimator propertyAnimator;
     SelectedNavi lastFrameNavi{};
     ServerAssetManager serverAssetManager;
@@ -81,6 +89,7 @@ namespace Overworld {
     std::optional<std::string> trackedPlayer;
     CameraController serverCameraController;
     CameraController warpCameraController;
+    std::vector<VendorScene::Item> shopItems;
 
     void HandlePVPStep(const std::string& remoteAddress);
     void ResetPVPStep();
@@ -117,6 +126,8 @@ namespace Overworld {
     void sendBoardCloseSignal();
     void sendPostRequestSignal();
     void sendPostSelectSignal(const std::string& postId);
+    void sendShopCloseSignal();
+    void sendShopPurchaseSignal(const std::string& itemName);
     void sendBattleResultsSignal(const BattleResults& results);
 
     void receiveLoginSignal(BufferReader& reader, const Poco::Buffer<char>&);
@@ -154,6 +165,8 @@ namespace Overworld {
     void receiveAppendPostsSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveRemovePostSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveCloseBBSSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveShopInventorySignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveOpenShopSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receivePVPSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveActorConnectedSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveActorDisconnectedSignal(BufferReader& reader, const Poco::Buffer<char>&);

--- a/BattleNetwork/overworld/bnOverworldPacketHeaders.h
+++ b/BattleNetwork/overworld/bnOverworldPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   constexpr std::string_view VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 31;
+  const uint64_t VERSION_ITERATION = 32;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -37,6 +37,8 @@ namespace Overworld
     board_close,
     post_request,
     post_selection,
+    shop_close,
+    shop_purchase,
     battle_results,
     size,
     unknown = size
@@ -94,6 +96,8 @@ namespace Overworld
     remove_post,
     post_selection_ack,
     close_bbs,
+    shop_inventory,
+    open_shop,
     initiate_pvp,
     actor_connected,
     actor_disconnect,

--- a/BattleNetwork/overworld/bnOverworldPacketHeaders.h
+++ b/BattleNetwork/overworld/bnOverworldPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   constexpr std::string_view VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 30;
+  const uint64_t VERSION_ITERATION = 31;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 

--- a/BattleNetwork/overworld/bnOverworldPersonalMenu.cpp
+++ b/BattleNetwork/overworld/bnOverworldPersonalMenu.cpp
@@ -5,7 +5,8 @@
 #include "../bnAudioResourceManager.h"
 
 namespace Overworld {
-  PersonalMenu::PersonalMenu(const std::string& area, const PersonalMenu::OptionsList& options) :
+  PersonalMenu::PersonalMenu(const std::shared_ptr<PlayerSession>& session, const std::string& area, const PersonalMenu::OptionsList& options) :
+    session(session),
     optionsList(options),
     infoText(Font::Style::thin),
     areaLabel(Font::Style::thin),
@@ -438,7 +439,7 @@ namespace Overworld {
 
       if (IsOpen()) {
         // hp shadow
-        infoText.SetString(std::to_string(health));
+        infoText.SetString(std::to_string(session->health));
         infoText.setOrigin(infoText.GetLocalBounds().width, 0);
         infoText.SetColor(shadowColor);
         infoText.setPosition(174 + 1, 33 + 1);
@@ -462,7 +463,7 @@ namespace Overworld {
         target.draw(infoText, states);
 
         // max hp shadow
-        infoText.SetString(std::to_string(maxHealth));
+        infoText.SetString(std::to_string(session->maxHealth));
         infoText.setOrigin(infoText.GetLocalBounds().width, 0);
         infoText.SetColor(shadowColor);
         infoText.setOrigin(infoText.GetLocalBounds().width, 0);
@@ -476,7 +477,7 @@ namespace Overworld {
 
         // coins shadow
         infoText.SetColor(shadowColor);
-        infoText.SetString(std::to_string(monies) + "$");
+        infoText.SetString(std::to_string(session->money) + "$");
         infoText.setOrigin(infoText.GetLocalBounds().width, 0);
         infoText.setPosition(214 + 1, 57 + 1);
         target.draw(infoText, states);
@@ -502,21 +503,6 @@ namespace Overworld {
     areaLabelThick.SetString(printName);
     areaLabelThick.setOrigin(bounds.width, bounds.height);
     areaLabelThick.setPosition(240 - 1.f, 160 - 2.f);
-  }
-
-  void PersonalMenu::SetMonies(int amt)
-  {
-    PersonalMenu::monies = std::max(0, amt);
-  }
-
-  void PersonalMenu::SetHealth(int health)
-  {
-    PersonalMenu::health = health;
-  }
-
-  void PersonalMenu::SetMaxHealth(int maxHealth)
-  {
-    PersonalMenu::maxHealth = maxHealth;
   }
 
   void PersonalMenu::UseIconTexture(const std::shared_ptr<sf::Texture> iconTexture)

--- a/BattleNetwork/overworld/bnOverworldPersonalMenu.h
+++ b/BattleNetwork/overworld/bnOverworldPersonalMenu.h
@@ -2,6 +2,7 @@
 #include <Swoosh/Timer.h>
 #include <Swoosh/Ease.h>
 
+#include "bnOverworldPlayerSession.h"
 #include "../bnInputManager.h"
 #include "../bnSceneNode.h"
 #include "../bnSpriteProxyNode.h"
@@ -34,9 +35,8 @@ namespace Overworld {
     using OptionsList = std::vector<Options>;
 
   private:
+    std::shared_ptr<PlayerSession> session;
     int row{ 0 }; //!< Current row index
-    int health{}, maxHealth{}; //!< Health displayed by main character
-    int monies{}; //!< monies held by main character
     float opacity{}; //!< Background darkens
     double elapsedThisFrame{};
     bool selectExit{ false }; //!< If exit option is selected
@@ -74,7 +74,7 @@ namespace Overworld {
     /**
      * @brief Constructs main menu widget UI. The programmer must set info params using the public API
      */
-    PersonalMenu(const std::string& area, const OptionsList& options);
+    PersonalMenu(const std::shared_ptr<PlayerSession>& session, const std::string& area, const OptionsList& options);
 
     /**
      * @brief Deconstructor
@@ -107,26 +107,6 @@ namespace Overworld {
     * @param name String of the area name (limited to 12 chars)
     */
     void SetArea(const std::string& name);
-
-    /**
-    * @brief Set the numer of coins to display
-    * @param coins Positive integer of coins.
-    *
-    * If not positive, will cap at zero.
-    */
-    void SetMonies(int amt);
-
-    /**
-    * @brief Set the health to display e.g. (health / 100)
-    * @param health Integer of health
-    */
-    void SetHealth(int health);
-
-    /**
-    * @brief Set the max health to display e.g. ( 100 / maxHealth )
-    * @param maxHealth Integer of max health to display
-    */
-    void SetMaxHealth(int maxHealth);
 
     void UseIconTexture(const std::shared_ptr<sf::Texture> icon);
 

--- a/BattleNetwork/overworld/bnOverworldPlayerSession.h
+++ b/BattleNetwork/overworld/bnOverworldPlayerSession.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../bnEmotions.h"
+#include "../bnInbox.h"
+
+namespace Overworld {
+  struct PlayerSession {
+    int health{};
+    int maxHealth{};
+    int money{};
+    Emotion emotion{};
+    Inbox inbox;
+  };
+}

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -1096,14 +1096,14 @@ void Overworld::SceneBase::OnCustomEmoteSelected(unsigned emote)
   emoteNode.CustomEmote(emote);
 }
 
-void Overworld::SceneBase::AddItem(const std::string& name, const std::string& description)
+void Overworld::SceneBase::AddItem(const std::string& id, const std::string& name, const std::string& description)
 {
-  items.push_back({ name, description });
+  items.push_back({ id, name, description });
 }
 
-void Overworld::SceneBase::RemoveItem(const std::string& name)
+void Overworld::SceneBase::RemoveItem(const std::string& id)
 {
-  auto iter = std::find_if(items.begin(), items.end(), [&name](auto& item) { return item.name == name; });
+  auto iter = std::find_if(items.begin(), items.end(), [&id](auto& item) { return item.id == id; });
 
   if (iter != items.end()) {
     items.erase(iter);

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -63,7 +63,8 @@ namespace {
 
 Overworld::SceneBase::SceneBase(swoosh::ActivityController& controller) :
   lastIsConnectedState(false),
-  personalMenu("Overworld", ::MakeOptions(this)),
+  playerSession(std::make_shared<PlayerSession>()),
+  personalMenu(playerSession, "Overworld", ::MakeOptions(this)),
   camera(controller.getWindow().getView()),
   Scene(controller),
   map(0, 0, 0, 0),
@@ -168,7 +169,7 @@ void Overworld::SceneBase::onStart() {
   gotoNextScene = false;
 
   // TODO: Take out after endpoints are added to server @Konst
-  Inbox& inbox = playerSession.inbox;
+  Inbox& inbox = playerSession->inbox;
 
   sf::Texture mugshot = *Textures().LoadTextureFromFile("resources/ow/prog/prog_mug.png");
   inbox.AddMail(Inbox::Mail{ Inbox::Icons::announcement, "Welcome", "NO-TITLE", "This is your first email!", mugshot });
@@ -682,10 +683,8 @@ void Overworld::SceneBase::RefreshNaviSprite()
   auto& meta = NAVIS.At(currentNavi);
 
   // refresh menu widget too
-  int hp = std::atoi(meta.GetHPString().c_str());
-  GetPlayerSession().health = hp;
-  personalMenu.SetHealth(hp);
-  personalMenu.SetMaxHealth(hp);
+  playerSession->health = meta.GetHP();
+  playerSession->maxHealth = meta.GetHP();
 
   // If coming back from navi select, the navi has changed, update it
   const auto& owPath = meta.GetOverworldAnimationPath();
@@ -974,7 +973,7 @@ void Overworld::SceneBase::GotoMail()
   Audio().Play(AudioType::CHIP_DESC);
 
   using effect = segue<BlackWashFade, milliseconds<500>>;
-  getController().push<effect::to<MailScene>>(playerSession.inbox);
+  getController().push<effect::to<MailScene>>(playerSession->inbox);
 }
 
 void Overworld::SceneBase::GotoKeyItems()
@@ -1018,7 +1017,7 @@ Overworld::Map& Overworld::SceneBase::GetMap()
   return map;
 }
 
-Overworld::PlayerSession& Overworld::SceneBase::GetPlayerSession()
+std::shared_ptr<Overworld::PlayerSession>& Overworld::SceneBase::GetPlayerSession()
 {
   return playerSession;
 }

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -22,6 +22,7 @@
 #include "../bnInbox.h"
 
 // overworld
+#include "bnOverworldPlayerSession.h"
 #include "bnOverworldInteraction.h"
 #include "bnOverworldCameraController.h"
 #include "bnOverworldSprite.h"
@@ -40,15 +41,9 @@
 class Background; // forward decl
 
 namespace Overworld {
-  struct PlayerSession {
-    int health{};
-    Emotion emotion{};
-    Inbox inbox;
-  };
-
   class SceneBase : public Scene {
   private:
-    PlayerSession playerSession;
+    std::shared_ptr<PlayerSession> playerSession;
     std::shared_ptr<Actor> playerActor;
     std::shared_ptr<sf::Texture> customEmotesTexture;
     Overworld::EmoteWidget emote;
@@ -261,7 +256,7 @@ namespace Overworld {
     std::vector<std::shared_ptr<Actor>>& GetActors();
     Camera& GetCamera();
     Map& GetMap();
-    PlayerSession& GetPlayerSession();
+    std::shared_ptr<PlayerSession>& GetPlayerSession();
     std::shared_ptr<Actor> GetPlayer();
     PlayerController& GetPlayerController();
     TeleportController& GetTeleportController();

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -186,8 +186,8 @@ namespace Overworld {
 
     void SetCustomEmotesTexture(const std::shared_ptr<sf::Texture>&);
 
-    void AddItem(const std::string& name, const std::string& description);
-    void RemoveItem(const std::string& name);
+    void AddItem(const std::string& id, const std::string& name, const std::string& description);
+    void RemoveItem(const std::string& id);
 
     /**
      * @brief Add a sprite


### PR DESCRIPTION
Requires new server build from development branch

Changes:
 - VendorScene is now connected to packets
 - Increased accuracy of other player warp detection
 - Joining a down server will no longer crash the client
 - PersonalMenu uses player session instead of tracking player information separately