### PR TITLE
Lower shadow when jumping

### DIFF
--- a/BattleNetwork/bindings/bnScriptedObstacle.cpp
+++ b/BattleNetwork/bindings/bnScriptedObstacle.cpp
@@ -10,6 +10,7 @@ ScriptedObstacle::ScriptedObstacle(Team _team) :
   shadow->setTexture(LOAD_TEXTURE(MISC_SHADOW));
   shadow->SetLayer(1);
   shadow->Hide(); // default: hidden
+  shadow->setOrigin(shadow->getSprite().getLocalBounds().width * 0.5, shadow->getSprite().getLocalBounds().height * 0.5);
   AddNode(shadow);
 
   animComponent = CreateComponent<AnimationComponent>(this);
@@ -38,7 +39,8 @@ void ScriptedObstacle::OnUpdate(double _elapsed) {
   setPosition(tile->getPosition().x + Entity::tileOffset.x + ScriptedObstacle::scriptedOffset.x,
     tile->getPosition().y - this->height + Entity::tileOffset.y + ScriptedObstacle::scriptedOffset.y);
 
-  //shadow->setPosition(0, +GetHeight()); // counter offset the shadow node
+  // counter offset the shadow node
+  shadow->setPosition(0, Entity::GetCurrJumpHeight() / 2);
   ScriptedObstacle& so = *this;
   updateCallback ? updateCallback(so, _elapsed) : (void)0;
 

--- a/BattleNetwork/bindings/bnScriptedSpell.cpp
+++ b/BattleNetwork/bindings/bnScriptedSpell.cpp
@@ -9,6 +9,7 @@ ScriptedSpell::ScriptedSpell(Team _team) :
   shadow->setTexture(LOAD_TEXTURE(MISC_SHADOW));
   shadow->SetLayer(1);
   shadow->Hide(); // default: hidden
+  shadow->setOrigin(shadow->getSprite().getLocalBounds().width * 0.5, shadow->getSprite().getLocalBounds().height * 0.5);
   AddNode(shadow);
 
   animComponent = CreateComponent<AnimationComponent>(this);
@@ -27,7 +28,8 @@ void ScriptedSpell::OnUpdate(double _elapsed) {
   setPosition(tile->getPosition().x + Entity::tileOffset.x + ScriptedSpell::scriptedOffset.x,
     tile->getPosition().y - this->height + Entity::tileOffset.y + ScriptedSpell::scriptedOffset.y);
 
-  //shadow->setPosition(0, +GetHeight()); // counter offset the shadow node
+  // counter offset the shadow node
+  shadow->setPosition(0, Entity::GetCurrJumpHeight() / 2);
   ScriptedSpell& ss = *this;
   updateCallback ? updateCallback(ss, _elapsed) : (void)0;
 

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -121,7 +121,8 @@ void Entity::UpdateMovement(double elapsed)
 
       float heightElapsed = static_cast<float>(elapsedMoveTime - currMoveEvent.delayFrames.asSeconds().value);
       float heightDelta = swoosh::ease::wideParabola(heightElapsed, duration, 1.0f);
-      tileOffset.y -= (heightDelta * currMoveEvent.height);
+      currJumpHeight = (heightDelta * currMoveEvent.height);
+      tileOffset.y -= currJumpHeight;
       
       // When delta is 1.0, the slide duration is complete
       if (delta == 1.0f)
@@ -644,4 +645,9 @@ void Entity::ClearActionQueue()
 const float Entity::GetJumpHeight() const
 {
   return currMoveEvent.height;
+}
+
+const float Entity::GetCurrJumpHeight() const
+{
+    return currJumpHeight;
 }

--- a/BattleNetwork/bnEntity.h
+++ b/BattleNetwork/bnEntity.h
@@ -87,6 +87,7 @@ private:
   MoveEvent currMoveEvent{};
   unsigned moveEventFrame{};
   unsigned frame{};
+  float currJumpHeight{};
 
   /**
    * @brief Frees one component with the same ID
@@ -149,6 +150,12 @@ public:
   void ClearActionQueue();
   const float GetJumpHeight() const;
   virtual void FilterMoveEvent(MoveEvent& event) {};
+
+  /**
+  * @brief How high off the ground the entity currently is
+  * @return current height off ground
+  */
+  const float GetCurrJumpHeight() const;
 
   /**
    * @brief Virtual. Queries if an entity can move to a target tile.


### PR DESCRIPTION
When a spell or obstacle is jumping, it will check the current jump height and adjust its shadow accordingly.