### PR TITLE
Refactor overworld menus

### DIFF
--- a/BattleNetwork/overworld/bnEmotes.cpp
+++ b/BattleNetwork/overworld/bnEmotes.cpp
@@ -19,7 +19,7 @@ Overworld::EmoteNode::EmoteNode() : ResourceHandle()
 {
   defaultEmotes = Textures().LoadTextureFromFile("resources/ow/emotes/emotes_48x48.png");
   setTexture(defaultEmotes);
-  setOrigin(EMOJI_PX*0.5f, EMOJI_PX*0.5f);
+  setOrigin(EMOJI_PX * 0.5f, EMOJI_PX * 0.5f);
   Reset();
 }
 
@@ -36,7 +36,7 @@ void Overworld::EmoteNode::Reset()
 
 void Overworld::EmoteNode::Emote(Overworld::Emotes type)
 {
-  size_t idx = std::min(static_cast<size_t>(type), static_cast<size_t>(Overworld::Emotes::size)-1);
+  size_t idx = std::min(static_cast<size_t>(type), static_cast<size_t>(Overworld::Emotes::size) - 1);
 
   sf::IntRect rect = sf::IntRect(static_cast<int>(48 * idx), 0, 48, 48);
 
@@ -80,10 +80,8 @@ void Overworld::EmoteNode::Update(double elapsed)
   }
 }
 
-Overworld::EmoteWidget::EmoteWidget() : 
-  radius(CIRCLE_RADIUS_PX),
-  sf::Drawable(), 
-  sf::Transformable()
+Overworld::EmoteWidget::EmoteWidget() :
+  radius(CIRCLE_RADIUS_PX)
 {
   size_t idx = 0;
   size_t max = static_cast<size_t>(Emotes::size);
@@ -91,7 +89,7 @@ Overworld::EmoteWidget::EmoteWidget() :
   while (idx < max) {
     auto& e = emoteSprites[idx];
     e.setTexture(Textures().LoadTextureFromFile("resources/ow/emotes/emotes_48x48.png"));
-    e.setOrigin(EMOJI_PX*0.5f, EMOJI_PX*0.5f);
+    e.setOrigin(EMOJI_PX * 0.5f, EMOJI_PX * 0.5f);
 
     sf::IntRect rect = sf::IntRect(static_cast<int>(idx * 48), 0, 48, 48);
     e.setTextureRect(rect);
@@ -135,12 +133,12 @@ void Overworld::EmoteWidget::Update(double elapsed)
     emoteSprites[idx].setScale(s, s);
     idx++;
   }
+}
 
-  if (IsClosed()) return;
-
+void Overworld::EmoteWidget::HandleInput(InputManager& input, sf::Vector2f mousePos) {
   Emotes end = static_cast<Emotes>(static_cast<size_t>(Emotes::size) - 1);
 
-  if (Input().Has(InputEvents::pressed_shoulder_left)) {
+  if (input.Has(InputEvents::pressed_shoulder_left)) {
     if (currEmote == Emotes{ 0 }) {
       currEmote = end;
     }
@@ -149,7 +147,7 @@ void Overworld::EmoteWidget::Update(double elapsed)
     }
   }
 
-  if (Input().Has(InputEvents::pressed_shoulder_right)) {
+  if (input.Has(InputEvents::pressed_shoulder_right)) {
     if (currEmote == end) {
       currEmote = Emotes{ 0 };
     }
@@ -158,15 +156,17 @@ void Overworld::EmoteWidget::Update(double elapsed)
     }
   }
 
-  if (Input().Has(InputEvents::pressed_confirm)) {
+  if (input.Has(InputEvents::pressed_confirm)) {
     callback ? callback(currEmote) : void(0);
+  }
+
+  if (input.Has(InputEvents::pressed_option)) {
+    Close();
   }
 }
 
 void Overworld::EmoteWidget::draw(sf::RenderTarget& surface, sf::RenderStates states) const
 {
-  if (state == State::closed) return;
-
   states.transform *= getTransform();
 
   sf::CircleShape circle = sf::CircleShape(this->radius, static_cast<size_t>(Emotes::size));
@@ -175,9 +175,9 @@ void Overworld::EmoteWidget::draw(sf::RenderTarget& surface, sf::RenderStates st
   circle.setOrigin(this->radius, this->radius);
 
   surface.draw(circle, states);
-  
+
   const SpriteProxyNode* selected = nullptr;
-  for(size_t i = 0; i < static_cast<size_t>(Emotes::size); i++) {
+  for (size_t i = 0; i < static_cast<size_t>(Emotes::size); i++) {
     if (static_cast<size_t>(currEmote) == i && IsOpen()) {
       selected = &emoteSprites[i];
     }
@@ -192,27 +192,7 @@ void Overworld::EmoteWidget::draw(sf::RenderTarget& surface, sf::RenderStates st
   }
 }
 
-void Overworld::EmoteWidget::Open()
-{
-  state = State::open;
-}
-
-void Overworld::EmoteWidget::Close()
-{
-  state = State::closed;
-}
-
 void Overworld::EmoteWidget::OnSelect(const std::function<void(Overworld::Emotes)>& callback)
 {
   this->callback = callback;
-}
-
-const bool Overworld::EmoteWidget::IsOpen() const
-{
-  return state == State::open;
-}
-
-const bool Overworld::EmoteWidget::IsClosed() const
-{
-  return state == State::closed;
 }

--- a/BattleNetwork/overworld/bnEmotes.h
+++ b/BattleNetwork/overworld/bnEmotes.h
@@ -1,9 +1,11 @@
 #pragma once
-#include <Swoosh/Timer.h>
+
+#include "bnOverworldMenu.h"
 #include "../bnInputHandle.h"
 #include "../bnResourceHandle.h"
 #include "../bnSpriteProxyNode.h"
 #include "../bnCallback.h"
+#include <Swoosh/Timer.h>
 
 namespace Overworld {
   enum class Emotes : uint8_t {
@@ -48,29 +50,21 @@ namespace Overworld {
     void Update(double elapsed);
   };
 
-  class EmoteWidget : 
-    public sf::Drawable, 
-    public sf::Transformable, 
-    public ResourceHandle, 
-    public InputHandle {
+  class EmoteWidget :
+    public Menu,
+    public sf::Transformable,
+    public ResourceHandle {
     float radius{ 25.0f }; //!< in pixels
     Emotes currEmote{};
     SpriteProxyNode emoteSprites[static_cast<size_t>(Emotes::size)];
     std::function<void(Emotes)> callback;
-
-    enum class State : unsigned {
-      closed = 0,
-      open
-    } state{State::closed};
   public:
     EmoteWidget();
     ~EmoteWidget();
-    void Update(double elapsed);
+    bool LocksInput() override { return false; }
+    void Update(double elapsed) override;
+    void HandleInput(InputManager& input, sf::Vector2f mousePos) override;
     void draw(sf::RenderTarget& surface, sf::RenderStates states) const override;
-    void Open();
-    void Close();
     void OnSelect(const std::function<void(Emotes)>& callback);
-    const bool IsOpen() const;
-    const bool IsClosed() const;
   };
 }

--- a/BattleNetwork/overworld/bnMinimap.cpp
+++ b/BattleNetwork/overworld/bnMinimap.cpp
@@ -590,6 +590,40 @@ void Overworld::Minimap::AddMarker(const std::shared_ptr<SpriteProxyNode>& marke
   bakedMap.AddNode(markers.back().get());
 }
 
+void Overworld::Minimap::Open() {
+  ResetPanning();
+  Menu::Open();
+}
+
+void Overworld::Minimap::HandleInput(InputManager& input, sf::Vector2f mousePos) {
+  if (input.Has(InputEvents::held_ui_left)) {
+    panning.x -= 1.f;
+  }
+
+  if (input.Has(InputEvents::held_ui_right)) {
+    panning.x += 1.f;
+  }
+
+  if (input.Has(InputEvents::held_ui_up)) {
+    panning.y -= 1.f;
+  }
+
+  if (input.Has(InputEvents::held_ui_down)) {
+    panning.y += 1.f;
+  }
+
+  if (input.GetConfigSettings().GetInvertMinimap()) {
+    panning.x *= -1.f;
+    panning.y *= -1.f;
+  }
+
+  if (input.Has(InputEvents::pressed_map)) {
+    Close();
+  }
+
+  Pan(panning);
+}
+
 void Overworld::Minimap::draw(sf::RenderTarget& surface, sf::RenderStates states) const
 {
   states.transform *= getTransform();

--- a/BattleNetwork/overworld/bnMinimap.h
+++ b/BattleNetwork/overworld/bnMinimap.h
@@ -2,11 +2,12 @@
 #include "../bnResourceHandle.h"
 #include "../bnDirection.h"
 #include "bnOverworldMap.h"
+#include "bnOverworldMenu.h"
 #include <SFML/Graphics.hpp>
 #include <memory>
 
 namespace Overworld {
-  class Minimap : public ResourceHandle, public sf::Transformable, public sf::Drawable {
+  class Minimap : public Menu, public sf::Transformable, public ResourceHandle {
   private:
     bool largeMapControls{};
     float scaling{}; //!< scaling used to fit everything on the screen
@@ -39,6 +40,9 @@ namespace Overworld {
     void AddShopPosition(const sf::Vector2f& pos, bool isConcealed);
     void AddBoardPosition(const sf::Vector2f& pos, bool flip, bool isConcealed);
     void AddConveyorPosition(const sf::Vector2f& pos, Direction direction, bool isConcealed);
+    bool IsFullscreen() override { return true; };
+    void Open() override;
+    void HandleInput(InputManager& input, sf::Vector2f mousePos) override;
     void draw(sf::RenderTarget& surface, sf::RenderStates states) const override final;
   };
 }

--- a/BattleNetwork/overworld/bnOverworldMenu.h
+++ b/BattleNetwork/overworld/bnOverworldMenu.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "../bnInputManager.h"
+#include "../bnSceneNode.h"
+#include <SFML/Graphics.hpp>
+
+namespace Overworld {
+  class Menu : public sf::Drawable {
+  protected:
+    bool open = false;
+  public:
+    /**
+    * @brief Query if the menu is should lock input when open
+    * @return true if the menu locks input
+    */
+    virtual bool LocksInput() { return true; }
+
+    /**
+    * @brief Query if the menu is fullscreen when open
+    * @return true if the menu is fullscreen when open
+    */
+    virtual bool IsFullscreen() { return false; }
+
+    /**
+    * @brief Query if the menu is open
+    * @return true if the menu is open, false if any other state
+    */
+    bool IsOpen() const { return open; };
+
+    /**
+    * @brief Query if the menu is fully closed
+    * @return true if the menu is fully closed, false if any other state
+    */
+    bool IsClosed() const { return !open; }
+
+    /**
+    * @brief Open the menu and begin the open animations
+    */
+    virtual void Open() { open = true; };
+
+    /**
+    * @brief Close the menu and begin the close animations
+    */
+    virtual void Close() { open = false; };
+
+    virtual void Update(double elapsed) { };
+
+    virtual void HandleInput(InputManager& input, sf::Vector2f mousePos) = 0;
+
+    virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const = 0;
+  };
+}

--- a/BattleNetwork/overworld/bnOverworldMenuSystem.h
+++ b/BattleNetwork/overworld/bnOverworldMenuSystem.h
@@ -2,6 +2,7 @@
 
 #include "../bnResourceHandle.h"
 #include "../bnInputManager.h"
+#include "bnOverworldMenu.h"
 #include "bnOverworldTextBox.h"
 #include "bnBBS.h"
 #include <SFML/Graphics/Drawable.hpp>
@@ -12,6 +13,11 @@ namespace Overworld {
   class MenuSystem : public sf::Drawable, ResourceHandle {
   public:
     MenuSystem();
+
+    /**
+     * @brief Binds an input event to open a menu, avoids opening menus while other menus are open
+     */
+    void BindMenu(InputEvent event, std::shared_ptr<Menu> menu);
 
     // grabs the latest BBS
     std::optional<std::reference_wrapper<BBS>> GetBBS();
@@ -34,9 +40,10 @@ namespace Overworld {
     bool IsOpen();
     bool IsClosed();
     bool IsFullscreen();
+    bool ShouldLockInput();
 
     void Update(float elapsed);
-    void HandleInput(InputManager& input, const sf::RenderWindow& window);
+    void HandleInput(InputManager& input, sf::Vector2f mousePos);
 
     void draw(sf::RenderTarget& target, sf::RenderStates states) const;
 
@@ -46,6 +53,8 @@ namespace Overworld {
       size_t remainingMessages{};
     };
 
+    std::vector<std::pair<InputEvent, std::shared_ptr<Menu>>> bindedMenus;
+    std::shared_ptr<Menu> activeBindedMenu;
     std::queue<PendingBBS> pendingBbs;
     size_t totalRemainingMessagesForBBS{};
     std::vector<std::unique_ptr<BBS>> bbs;

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -2435,27 +2435,20 @@ void Overworld::OnlineArea::receiveActorEmoteSignal(BufferReader& reader, const 
   auto emote = reader.Read<uint8_t>(buffer);
   auto custom = reader.Read<bool>(buffer);
 
-  if (user == ticket) {
-    if (custom) {
-      emoteNode.CustomEmote(emote);
-    }
-    else {
-      emoteNode.Emote((Emotes)emote);
-    }
+  auto optionalAbstractUser = GetAbstractUser(user);
+
+  if (!optionalAbstractUser) {
     return;
   }
 
-  auto userIter = onlinePlayers.find(user);
+  auto abstractUser = *optionalAbstractUser;
+  auto& emoteNode = abstractUser.emoteNode;
 
-  if (userIter != onlinePlayers.end()) {
-    auto& onlinePlayer = userIter->second;
-
-    if (custom) {
-      onlinePlayer.emoteNode.CustomEmote(emote);
-    }
-    else {
-      onlinePlayer.emoteNode.Emote((Emotes)emote);
-    }
+  if (custom) {
+    emoteNode.CustomEmote(emote);
+  }
+  else {
+    emoteNode.Emote((Emotes)emote);
   }
 }
 

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.cpp
@@ -76,45 +76,25 @@ Overworld::OnlineArea::OnlineArea(
 
   lastFrameNavi = this->GetCurrentNavi();
   
-  auto windowSize = getController().getVirtualWindowSize();
-  emote.setPosition(windowSize.x / 2.f, windowSize.y / 2.f);
   // emotes
-  GetPlayer()->AddNode(&emoteNode);
+  auto windowSize = getController().getVirtualWindowSize();
+  auto emoteWidget = std::make_shared<EmoteWidget>();
+  emoteWidget->setPosition(windowSize.x / 2.f, windowSize.y / 2.f);
+  emoteWidget->OnSelect(std::bind(&Overworld::OnlineArea::sendEmoteSignal, this, std::placeholders::_1));
+  GetMenuSystem().BindMenu(InputEvents::pressed_option, emoteWidget);
+
+  auto player = GetPlayer();
+  // move the emote above the player's head
+  float emoteY = -player->getSprite().getOrigin().y - 10;
+  emoteNode.setPosition(0, emoteY);
   emoteNode.SetLayer(-100);
   emoteNode.setScale(0.5f, 0.5f);
-  emote.OnSelect(std::bind(&Overworld::OnlineArea::OnEmoteSelected, this, std::placeholders::_1));
+  player->AddNode(&emoteNode);
+
   propertyAnimator.OnComplete([this] {
     // todo: this may cause issues when leaving the scene through Home and Server Warps
     GetPlayerController().ControlActor(GetPlayer());
   });
-}
-
-const std::shared_ptr<sf::Texture>& Overworld::OnlineArea::GetCustomEmotesTexture() const {
-    return customEmotesTexture;
-}
-
-void Overworld::OnlineArea::SetCustomEmotesTexture(const std::shared_ptr<sf::Texture>& texture) {
-    emoteNode.LoadCustomEmotes(texture);
-}
-
-void Overworld::OnlineArea::OnEmoteSelectedCL(Emotes emote)
-{
-    emoteNode.Emote(emote);
-}
-
-void Overworld::OnlineArea::OnCustomEmoteSelected(unsigned emote)
-{
-    emoteNode.CustomEmote(emote);
-}
-
-Overworld::EmoteNode& Overworld::OnlineArea::GetEmoteNode()
-{
-    return emoteNode;
-}
-
-Overworld::EmoteWidget& Overworld::OnlineArea::GetEmoteWidget()
-{
-    return emote;
 }
 
 Overworld::OnlineArea::~OnlineArea()
@@ -126,7 +106,7 @@ std::optional<Overworld::OnlineArea::AbstractUser> Overworld::OnlineArea::GetAbs
   if (id == ticket) {
     return AbstractUser {
       GetPlayer(),
-      GetEmoteNode(),
+      emoteNode,
       GetTeleportController(),
       propertyAnimator
     };
@@ -171,11 +151,9 @@ void Overworld::OnlineArea::onUpdate(double elapsed)
   }
 
   if (this->pvpRemoteAddress.size()) {
-      HandlePVPStep(pvpRemoteAddress);
-      return;
+    HandlePVPStep(pvpRemoteAddress);
+    return;
   }
-
-
 
   // remove players before update, to prevent removed players from being added to sprite layers
   // players do not have a shared pointer to the emoteNode
@@ -196,12 +174,6 @@ void Overworld::OnlineArea::onUpdate(double elapsed)
   }
 
   removePlayers.clear();
-
-  auto currentNavi = GetCurrentNavi();
-  if (lastFrameNavi != currentNavi) {
-    sendAvatarChangeSignal();
-    lastFrameNavi = currentNavi;
-  }
 
   updateOtherPlayers(elapsed);
   updatePlayer(elapsed);
@@ -240,16 +212,6 @@ void Overworld::OnlineArea::onUpdate(double elapsed)
   warpCameraController.UpdateCamera(float(elapsed), camera);
   serverCameraController.UpdateCamera(float(elapsed), camera);
   UnlockCamera(); // reset lock, we'll lock it later if we need to
-
-  if (!emote.IsClosed()) {
-      if (Input().Has(InputEvents::pressed_option)) {
-          emote.Close();
-      }
-      return;
-  }
-  else if (Input().Has(InputEvents::pressed_option)) {
-      emote.Open();
-  }
 }
 
 void Overworld::OnlineArea::HandlePVPStep(const std::string& remoteAddress)
@@ -427,9 +389,20 @@ void Overworld::OnlineArea::updatePlayer(double elapsed) {
   auto playerPos = player->Get3DPosition();
 
   propertyAnimator.Update(*player, elapsed);
-  GetEmoteWidget().Update(elapsed);
+  emoteNode.Update(elapsed);
+
+  auto currentNavi = GetCurrentNavi();
+  if (lastFrameNavi != currentNavi) {
+    sendAvatarChangeSignal();
+    lastFrameNavi = currentNavi;
+
+    // move the emote above the player's head
+    float emoteY = -GetPlayer()->getSprite().getOrigin().y - 10;
+    emoteNode.setPosition(0, emoteY);
+  }
+
   if (!IsInputLocked()) {
-    if (Input().Has(InputEvents::pressed_shoulder_right) && GetEmoteWidget().IsClosed()) {
+    if (Input().Has(InputEvents::pressed_shoulder_right)) {
       auto& meta = NAVIS.At(GetCurrentNavi());
       const std::string& image = meta.GetMugshotTexturePath();
       const std::string& anim = meta.GetMugshotAnimationPath();
@@ -458,10 +431,6 @@ void Overworld::OnlineArea::updatePlayer(double elapsed) {
   detectConveyor(player);
 
   lastPosition = playerPos;
-
-  // move the emote above the player's head
-  float emoteY = -player->getSprite().getOrigin().y - 10;
-  emoteNode.setPosition(0, emoteY);
 }
 
 void Overworld::OnlineArea::detectWarp(std::shared_ptr<Overworld::Actor>& player) {
@@ -798,7 +767,6 @@ void Overworld::OnlineArea::onDraw(sf::RenderTexture& surface)
   nameText.SetString(topName);
   nameText.setOrigin(-10.0f, 0);
   surface.draw(nameText);
-  surface.draw(emote);
 }
 
 void Overworld::OnlineArea::onStart()
@@ -900,12 +868,6 @@ void Overworld::OnlineArea::OnInteract(Interaction type) {
     playerActor->GetElevation(),
     type
   );
-}
-
-void Overworld::OnlineArea::OnEmoteSelected(Overworld::Emotes emote)
-{
-  OnlineArea::OnEmoteSelectedCL(emote);
-  sendEmoteSignal(emote);
 }
 
 bool Overworld::OnlineArea::positionIsInWarp(sf::Vector3f position) {
@@ -1638,7 +1600,7 @@ void Overworld::OnlineArea::receivePreloadSignal(BufferReader& reader, const Poc
 void Overworld::OnlineArea::receiveCustomEmotesPathSignal(BufferReader& reader, const Poco::Buffer<char>& buffer) {
   auto path = reader.ReadString<uint16_t>(buffer);
 
-  SetCustomEmotesTexture(serverAssetManager.GetTexture(path));
+  emoteNode.LoadCustomEmotes(serverAssetManager.GetTexture(path));
 }
 
 void Overworld::OnlineArea::receiveMapSignal(BufferReader& reader, const Poco::Buffer<char>& buffer)
@@ -2284,7 +2246,7 @@ void Overworld::OnlineArea::receiveActorConnectedSignal(BufferReader& reader, co
   float emoteY = -actor->getSprite().getOrigin().y - 10;
   emoteNode.setPosition(0, emoteY);
   emoteNode.setScale(0.5f, 0.5f);
-  emoteNode.LoadCustomEmotes(GetCustomEmotesTexture());
+  emoteNode.LoadCustomEmotes(customEmotesTexture);
 
   auto& teleportController = onlinePlayer.teleportController;
 
@@ -2475,10 +2437,10 @@ void Overworld::OnlineArea::receiveActorEmoteSignal(BufferReader& reader, const 
 
   if (user == ticket) {
     if (custom) {
-      OnlineArea::OnCustomEmoteSelected(emote);
+      emoteNode.CustomEmote(emote);
     }
     else {
-      OnlineArea::OnEmoteSelected((Emotes)emote);
+      emoteNode.Emote((Emotes)emote);
     }
     return;
   }

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -66,7 +66,6 @@ namespace Overworld {
       Poco::Buffer<char> buffer{ 0 };
     };
 
-    Overworld::EmoteWidget emote;
     Overworld::EmoteNode emoteNode;
     std::shared_ptr<sf::Texture> customEmotesTexture;
     std::string pvpRemoteAddress; // remember who we want to connect to after download scene
@@ -105,16 +104,6 @@ namespace Overworld {
 
     void HandlePVPStep(const std::string& remoteAddress);
     void ResetPVPStep();
-
-
-    //emote additions, from SceneBase.
-    void SetCustomEmotesTexture(const std::shared_ptr<sf::Texture>&);
-    const std::shared_ptr<sf::Texture>& GetCustomEmotesTexture() const;
-    EmoteNode& GetEmoteNode();
-    EmoteWidget& GetEmoteWidget();
-    virtual void OnEmoteSelected(Emotes emote);
-    virtual void OnEmoteSelectedCL(Emotes emote);
-    virtual void OnCustomEmoteSelected(unsigned emote);
 
     std::optional<AbstractUser> GetAbstractUser(const std::string& id);
     void onInteract(Interaction type);

--- a/BattleNetwork/overworld/bnOverworldPersonalMenu.h
+++ b/BattleNetwork/overworld/bnOverworldPersonalMenu.h
@@ -1,15 +1,15 @@
 #pragma once
-#include <Swoosh/Timer.h>
-#include <Swoosh/Ease.h>
 
+#include "bnOverworldMenu.h"
 #include "bnOverworldPlayerSession.h"
 #include "../bnInputManager.h"
-#include "../bnSceneNode.h"
 #include "../bnSpriteProxyNode.h"
 #include "../bnAnimation.h"
 #include "../bnResourceHandle.h"
 #include "../bnFont.h"
 #include "../bnText.h"
+#include <Swoosh/Timer.h>
+#include <Swoosh/Ease.h>
 
 namespace Overworld {
   /**
@@ -18,7 +18,7 @@ namespace Overworld {
    * @date 11/04/20
    * @brief PersonalMenu used in over-world hub. Can be interacted through public API.
    */
-  class PersonalMenu : public SceneNode, public ResourceHandle {
+  class PersonalMenu : public Menu, public SceneNode, public ResourceHandle {
   public:
     enum class state : unsigned {
       closed = 0,
@@ -48,6 +48,7 @@ namespace Overworld {
     Text areaLabel; //!< Area name displayed by widget
     mutable Text areaLabelThick; //!< Thick area name displayed outside of widget
     mutable Text infoText; //!< Text obj used for all other info
+    mutable Text time; //!< Text obj displaying the time both inside and outside of the widget
     swoosh::Timer easeInTimer; //!< Timer used for animations
     SpriteProxyNode banner;
     SpriteProxyNode symbol;
@@ -69,6 +70,7 @@ namespace Overworld {
 
     void QueueAnimTasks(const state& state);
     void CreateOptions();
+    void DrawTime(sf::RenderTarget& target) const;
 
   public:
     /**
@@ -85,20 +87,20 @@ namespace Overworld {
     * @brief Animators cursors and all animations
     * @param elapsed in seconds
     */
-    void Update(double elapsed);
+    void Update(double elapsed) override;
 
     /**
     * @brief handles specific key presses to interact with this widget
     * @param 
     */
-    void HandleInput(InputManager&, AudioResourceManager&);
+    void HandleInput(InputManager&, sf::Vector2f mousePos) override;
 
     /**
      * @brief Draws GUI and all child graphics on it
      * @param target
      * @param states
      */
-    void draw(sf::RenderTarget& target, sf::RenderStates states) const;
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
 
     /// Set data
 
@@ -148,26 +150,12 @@ namespace Overworld {
 
     /**
     * @brief Open the widget and begin the open animations
-    * @return true if the widget has beguin opening, false if already opening or opened
     */
-    bool Open();
+    virtual void Open();
 
     /**
     * @brief Close the widget and begin the close animations
-    * @return true if the widget has beguin closing, false if already closing or closed
     */
-    bool Close();
-
-    /**
-    * @brief Query if the widget is fully opened
-    * @return true if the widget is fully opened, false if any other state
-    */
-    bool IsOpen() const;
-
-    /**
-    * @brief Query if the widget is fully closed
-    * @return true if the widget is fully closed, false if any other state
-    */
-    bool IsClosed() const;
+    virtual void Close();
   };
 }

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -51,7 +51,6 @@ namespace Overworld {
     std::vector<KeyItemScene::Item> items;
 
     double animElapsed{};
-    bool showMinimap{ false };
     bool inputLocked{ false };
     bool cameraLocked{ false };
     bool teleportedOut{ false }; /*!< We may return to this area*/
@@ -60,12 +59,11 @@ namespace Overworld {
 
     Camera camera;
     CameraController cameraController; /*!< camera in scene follows player */
-    Text time;
 
     sf::Vector3f returnPoint{};
     sf::Vector3f cameraTrackPoint{}; // used for smooth cameras
-    PersonalMenu personalMenu;
-    Minimap minimap;
+    std::shared_ptr<PersonalMenu> personalMenu;
+    std::shared_ptr<Minimap> minimap;
     SpriteProxyNode webAccountIcon; /*!< Status icon if connected to web server*/
     Animation webAccountAnimator; /*!< Use animator to represent different statuses */
 

--- a/BattleNetwork/overworld/bnOverworldTextBox.cpp
+++ b/BattleNetwork/overworld/bnOverworldTextBox.cpp
@@ -25,7 +25,7 @@ namespace Overworld {
     object->ShowEndMessageCursor(true);
     textbox.EnqueMessage(nextSpeaker, nextAnimation, object);
 
-    handlerQueue.push([=](InputManager& input, const sf::RenderWindow& window) {
+    handlerQueue.push([=](InputManager& input, sf::Vector2f mousePos) {
       if (input.Has(InputEvents::pressed_run)) {
           turboScroll = true;
           turboTimer = 0;
@@ -74,7 +74,7 @@ namespace Overworld {
     textbox.EnqueMessage(nextSpeaker, nextAnimation, question);
 
 
-    handlerQueue.push([=](InputManager& input, const sf::RenderWindow& window) {
+    handlerQueue.push([=](InputManager& input, sf::Vector2f mousePos) {
       bool left = input.Has(InputEvents::pressed_ui_left);
       bool right = input.Has(InputEvents::pressed_ui_right);
       bool confirm = input.Has(InputEvents::pressed_confirm);
@@ -117,7 +117,7 @@ namespace Overworld {
     auto quiz = new Quiz(optionA, optionB, optionC, onResponse);
     textbox.EnqueMessage(nextSpeaker, nextAnimation, quiz);
 
-    handlerQueue.push([=](InputManager& input, const sf::RenderWindow& window) {
+    handlerQueue.push([=](InputManager& input, sf::Vector2f mousePos) {
       bool up = input.Has(InputEvents::pressed_ui_up);
       bool down = input.Has(InputEvents::pressed_ui_down);
       bool confirm = input.Has(InputEvents::pressed_confirm);
@@ -158,11 +158,9 @@ namespace Overworld {
     Animation animation;
     textbox.EnqueMessage(sprite, animation, messageInput);
 
-    handlerQueue.push([=](InputManager& input, const sf::RenderWindow& window) {
+    handlerQueue.push([=](InputManager& input, sf::Vector2f mousePos) {
       if (input.HasFocus() && sf::Mouse::isButtonPressed(sf::Mouse::Button::Left)) {
-        auto mousei = sf::Mouse::getPosition(window);
-        auto mousef = window.mapPixelToCoords(mousei);
-        messageInput->HandleClick(mousef);
+        messageInput->HandleClick(mousePos);
       }
 
       if (messageInput->IsDone()) {
@@ -188,9 +186,9 @@ namespace Overworld {
     textbox.Update(elapsed);
   }
 
-  void TextBox::HandleInput(InputManager& input, const sf::RenderWindow& window) {
+  void TextBox::HandleInput(InputManager& input, sf::Vector2f mousePos) {
     if (!handlerQueue.empty()) {
-      handlerQueue.front()(input, window);
+      handlerQueue.front()(input, mousePos);
     }
 
     if (!textbox.HasMessage()) {

--- a/BattleNetwork/overworld/bnOverworldTextBox.h
+++ b/BattleNetwork/overworld/bnOverworldTextBox.h
@@ -29,7 +29,7 @@ namespace Overworld {
     size_t GetRemainingMessages();
 
     void Update(float elapsed);
-    void HandleInput(InputManager& input, const sf::RenderWindow& window);
+    void HandleInput(InputManager& input, sf::Vector2f mousePos);
 
     void draw(sf::RenderTarget& target, sf::RenderStates states) const;
 
@@ -37,7 +37,7 @@ namespace Overworld {
     AnimatedTextBox textbox;
     sf::Sprite nextSpeaker;
     Animation nextAnimation;
-    std::queue<std::function<void(InputManager& input, const sf::RenderWindow&)>> handlerQueue;
+    std::queue<std::function<void(InputManager& input, sf::Vector2f mousePos)>> handlerQueue;
     bool turboScroll;
     int turboTimer;
   };

--- a/cmake/Compiler.cmake
+++ b/cmake/Compiler.cmake
@@ -9,6 +9,6 @@ endif()
 
 if(NOT MSVC)
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-value -Wno-inconsistent-missing-override -Wno-switch -g3")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-value -Wno-inconsistent-missing-override -Wno-switch")
 
 endif()


### PR DESCRIPTION
Changes:
 - Manage opening PersonalMenu, Minimap, and EmoteWidget (dynamically added from OnlineArea) from Overworld::MenuSystem
   - Allows us to also extract Minimap out of SceneBase
   - Fixes emote widget overlapping minimap and PersonalMenu
 - Call Update on the player's emote node to allow it to expire
 - One of the above changes fixes odd emote related memory leak
 - Removed -g3 debug symbols flag from Compiler.cmake (previously set on non MSVC compilers)