### PR TITLE
Fix charge cancel

### DIFF
--- a/BattleNetwork/bnCardUsePublisher.h
+++ b/BattleNetwork/bnCardUsePublisher.h
@@ -38,7 +38,7 @@ public:
   /**
    * @brief Must implement
    */
-  virtual void UseNextCard() = 0;
+  virtual bool UseNextCard() = 0;
 
   void DropSubscribers();
 };

--- a/BattleNetwork/bnPlayerControlledState.cpp
+++ b/BattleNetwork/bnPlayerControlledState.cpp
@@ -76,9 +76,10 @@ void PlayerControlledState::OnUpdate(double _elapsed, Player& player) {
   if (InputQueueHas(InputEvents::pressed_use_chip)) {
     auto cardsUI = player.GetFirstComponent<PlayerSelectedCardsUI>();
     if (cardsUI && player.CanAttack()) {
-      cardsUI->UseNextCard();
-      player.chargeEffect.SetCharging(false);
-      isChargeHeld = false;
+      if (cardsUI->UseNextCard()) {
+        player.chargeEffect.SetCharging(false);
+        isChargeHeld = false;
+      }
     }
     // If the card used was successful, we may have a card in queue
   }

--- a/BattleNetwork/bnSelectedCardsUI.cpp
+++ b/BattleNetwork/bnSelectedCardsUI.cpp
@@ -88,10 +88,10 @@ void SelectedCardsUI::LoadCards(Battle::Card ** incoming, int size) {
   curr = 0;
 }
 
-void SelectedCardsUI::UseNextCard() {
+bool SelectedCardsUI::UseNextCard() {
   Character* owner = this->GetOwnerAs<Character>();
 
-  if (!owner) return;
+  if (!owner) return false;
 
   const auto actions = owner->AsyncActionList();
   bool hasNextCard = curr < cardCount;
@@ -106,7 +106,7 @@ void SelectedCardsUI::UseNextCard() {
   canUseCard = canUseCard && hasNextCard;
 
   if (!canUseCard) {
-    return;
+    return false;
   }
 
   auto card = selectedCards[curr];
@@ -119,6 +119,7 @@ void SelectedCardsUI::UseNextCard() {
 
   // add a peek event to the action queue
   owner->AddAction(PeekCardEvent{ this }, ActionOrder::voluntary);
+  return true;
 }
 
 void SelectedCardsUI::Broadcast(const Battle::Card& card, Character& user)

--- a/BattleNetwork/bnSelectedCardsUI.h
+++ b/BattleNetwork/bnSelectedCardsUI.h
@@ -50,7 +50,7 @@ public:
    * @brief Broadcasts the card at the cursor curr. Increases curr.
    * @return True if there was a card to use
    */
-  void UseNextCard() override;
+  bool UseNextCard() override;
 
   /**
  * @brief Broadcasts the card information to all listeners


### PR DESCRIPTION
When attempting to use a card while charging, the charge will only cancel if there's a card to use