### PR TITLE
Edited Game Over Scene

### DIFF
--- a/BattleNetwork/bnGameOverScene.cpp
+++ b/BattleNetwork/bnGameOverScene.cpp
@@ -8,8 +8,10 @@ using namespace swoosh::types;
 
 GameOverScene::GameOverScene(swoosh::ActivityController& controller) : Scene(controller) {
   fadeInCooldown = 2.0f;
-
-  gameOver.setTexture(*Textures().GetTexture(TextureType::GAME_OVER));
+  gameOverTexture = *Textures().LoadTextureFromFile("resources/scenes/game_over/game_over.png");
+  //Separating the texture into its own member allows the texture to live long enough to be drawn
+  //within the next function.
+  gameOver.setTexture(gameOverTexture);
   gameOver.setScale(2.f, 2.f);
   gameOver.setOrigin(gameOver.getLocalBounds().width / 2, gameOver.getLocalBounds().height / 2);
 
@@ -59,6 +61,7 @@ void GameOverScene::onUpdate(double elapsed) {
 void GameOverScene::onDraw(sf::RenderTexture& surface) {
   sf::Vector2f logoPos = (sf::Vector2f)((sf::Vector2i)getController().getVirtualWindowSize() / 2);
   gameOver.setPosition(logoPos);
-  gameOver.setColor(sf::Color(255, 255, 255, (sf::Uint32)(255 * (1.0f-(fadeInCooldown / 2.f)))));
+  //gameOver.setColor(sf::Color(255, 255, 255, (sf::Uint32)(255 * (1.0f-(fadeInCooldown / 2.f)))));
+  //Commented out because it fades in just fine without it. This causes it to flicker once.
   surface.draw(gameOver);
 }

--- a/BattleNetwork/bnGameOverScene.h
+++ b/BattleNetwork/bnGameOverScene.h
@@ -16,6 +16,7 @@ class GameOverScene : public Scene {
 private:
   float fadeInCooldown; /*!< Fade in time */
   sf::Sprite gameOver; /*!< GAME OVER */
+  sf::Texture gameOverTexture; /*< GAME OVER TEXTURE */
   bool leave; /*!< Scene state coming/going flag */
 
 public:


### PR DESCRIPTION
Game Over texture was rendering as a white box. Fixed by setting the texture to its own property of the Game Over Scene & assigning it to that member first, then assigning the texture to the sprite.

Not included but I'm studying resource imapct: if you call surface.create(x, y) in the draw code, it properly centers the Game Over sprite.