### PR TITLE
add root

### DIFF
--- a/BattleNetwork/bnCharacter.h
+++ b/BattleNetwork/bnCharacter.h
@@ -79,6 +79,7 @@ private:
 
   sf::Shader* whiteout{ nullptr }; /*!< Flash white when hit */
   sf::Shader* stun{ nullptr };     /*!< Flicker yellow with luminance values when stun */
+  sf::Shader* root{ nullptr };     /*!< Flicker black with luminance values when root */
   std::shared_ptr<CardAction> currCardAction{ nullptr };
   frame_time_t cardActionStartDelay{0};
 
@@ -191,6 +192,12 @@ public:
   bool IsStunned();
 
   /**
+   * @brief Query the character's state is Rooted
+   * @return true if character is currently rooted, false otherwise
+   */
+  bool IsRooted();
+
+  /**
    * @brief Get the rank of this character
    * @return const Rank
    */
@@ -290,6 +297,14 @@ protected:
   void Stun(double maxCooldown);
 
   /**
+  * @brief Stop a character from moving for maxCooldown seconds
+  * @param maxCooldown
+  * Used internally by class
+  *
+  */
+  void Root(double maxCooldown);
+
+  /**
   * @brief Query if an attack successfully countered a Character
   * @return true if character is currently countered, false otherwise
   * Used internally by class
@@ -302,6 +317,7 @@ protected:
   bool canTilePush{};
   std::string name;
   double stunCooldown{ 0 }; /*!< Timer until stun is over */
+  double rootCooldown{ 0 }; /*!< Timer until root is over */
   double invincibilityCooldown{ 0 }; /*!< Timer until invincibility is over */
   Character::Rank rank;
 };

--- a/BattleNetwork/bnDefenseIndestructable.cpp
+++ b/BattleNetwork/bnDefenseIndestructable.cpp
@@ -16,7 +16,7 @@ DefenseIndestructable::~DefenseIndestructable()
 
 Hit::Properties& DefenseIndestructable::FilterStatuses(Hit::Properties& statuses)
 {
-  statuses.flags &= ~(Hit::flash|Hit::freeze|Hit::stun|Hit::flinch|Hit::pierce|Hit::shake);
+  statuses.flags &= ~(Hit::flash|Hit::freeze|Hit::stun|Hit::flinch|Hit::pierce|Hit::shake|Hit::root);
   return statuses;
 }
 

--- a/BattleNetwork/bnDefenseObstacleBody.cpp
+++ b/BattleNetwork/bnDefenseObstacleBody.cpp
@@ -12,6 +12,7 @@ Hit::Properties& DefenseObstacleBody::FilterStatuses(Hit::Properties& statuses)
   statuses.flags &= ~Hit::flinch;
   statuses.flags &= ~Hit::stun;
   statuses.flags &= ~Hit::freeze;
+  statuses.flags &= ~Hit::root;
 
   return statuses;
 }

--- a/BattleNetwork/bnDefenseStatusGuard.cpp
+++ b/BattleNetwork/bnDefenseStatusGuard.cpp
@@ -15,7 +15,7 @@ DefenseStatusGuard::~DefenseStatusGuard()
 
 Hit::Properties& DefenseStatusGuard::FilterStatuses(Hit::Properties& statuses)
 {
-  statuses.flags &= ~(Hit::bubble | Hit::freeze | Hit::stun);
+  statuses.flags &= ~(Hit::bubble | Hit::freeze | Hit::stun | Hit::root);
   return statuses;
 }
 

--- a/BattleNetwork/bnHitProperties.h
+++ b/BattleNetwork/bnHitProperties.h
@@ -4,26 +4,26 @@
 #include "bnEntity.h"
 
 namespace Hit {
-  using Flags = uint16_t;
+  using Flags = uint32_t;
 
   // These are in order!
   // Hitboxes properties will be inserted in queue
   // based on priority (A < B) where the highest priority
   // is the lowest value
-  const Flags none = 0x0000;
-  const Flags retangible = 0x0001;
-  const Flags freeze = 0x0002;
-  const Flags pierce = 0x0004;
-  const Flags flinch = 0x0008;
-  const Flags shake = 0x0010;
-  const Flags stun = 0x0020;
-  const Flags flash = 0x0040;
-  const Flags breaking = 0x0080;
-  const Flags impact = 0x0100;
-  const Flags drag = 0x0200;
-  const Flags bubble = 0x0400;
-  const Flags no_counter = 0x0800;
-  // 0x1000 - 0x8000 remaining = 4 remaining
+  const Flags none = 0x00000000;
+  const Flags retangible = 0x00000001;
+  const Flags freeze = 0x00000002;
+  const Flags pierce = 0x00000004;
+  const Flags flinch = 0x00000008;
+  const Flags shake = 0x00000010;
+  const Flags stun = 0x00000020;
+  const Flags flash = 0x00000040;
+  const Flags breaking = 0x00000080;
+  const Flags impact = 0x00000100;
+  const Flags drag = 0x00000200;
+  const Flags bubble = 0x00000400;
+  const Flags no_counter = 0x00000800;
+  const Flags root = 0x00001000;
 
 
   struct Drag {

--- a/BattleNetwork/bnPlayerControlledState.cpp
+++ b/BattleNetwork/bnPlayerControlledState.cpp
@@ -128,7 +128,7 @@ void PlayerControlledState::OnUpdate(double _elapsed, Player& player) {
     direction = Direction::right;
   }
 
-  if(direction != Direction::none && actionable) {
+  if(direction != Direction::none && actionable && !player.IsRooted()) {
     auto next_tile = player.GetTile() + direction;
     auto anim = player.GetFirstComponent<AnimationComponent>();
 

--- a/BattleNetwork/bnScriptResourceManager.cpp
+++ b/BattleNetwork/bnScriptResourceManager.cpp
@@ -794,6 +794,7 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
         "Flinch", Hit::flinch,
         "Flash", Hit::flash,
         "Stun", Hit::stun,
+        "Root", Hit::root,
         "Impact", Hit::impact,
         "Shake", Hit::shake,
         "Pierce", Hit::pierce,

--- a/BattleNetwork/bnShaderResourceManager.cpp
+++ b/BattleNetwork/bnShaderResourceManager.cpp
@@ -107,6 +107,7 @@ ShaderResourceManager::ShaderResourceManager() {
   paths[(int)ShaderType::ADDITIVE] = std::string() + "resources/shaders/" + version + "/additive";
   paths[(int)ShaderType::PALETTE_SWAP] = std::string() + "resources/shaders/" + version + "/palette_swap";
   paths[(int)ShaderType::GRADIENT] = std::string() + "resources/shaders/" + version + "/color_oscillate";
+  paths[(int)ShaderType::BLACK] = std::string() + "resources/shaders/" + version + "/black";
 }
 
 ShaderResourceManager::~ShaderResourceManager() {

--- a/BattleNetwork/bnShaderType.h
+++ b/BattleNetwork/bnShaderType.h
@@ -43,6 +43,7 @@
         WHITE,
         WHITE_FADE,
         YELLOW,
+        BLACK,
         DISTORTION,
         SPOT_DISTORTION,
         SPOT_REFLECTION,

--- a/BattleNetwork/resources/shaders/glsl_110/black.frag
+++ b/BattleNetwork/resources/shaders/glsl_110/black.frag
@@ -1,0 +1,24 @@
+#version 120
+
+uniform sampler2D texture;
+
+void main()
+{
+    vec4 pixel = texture2D(texture, vec2(gl_TexCoord[0].x, gl_TexCoord[0].y));
+    vec4 color = gl_Color * pixel;
+    vec3 luminances = vec3(0.2126, 0.7152, 0.0722);
+
+    float luminance = dot(luminances, color.rgb);
+    float threshold = 0.5;
+
+    luminance = max(0.0, luminance - threshold);
+
+    color.rgb *= sign(luminance);
+
+    if(color.a > 0.0) {
+        if(color.rgb == vec3(0,0,0)) {  color.rgb = vec3(0,0,0); }
+        else { color.rgb = vec3(1,1,1); }
+    }
+
+    gl_FragColor = color;
+}

--- a/BattleNetwork/resources/shaders/glsl_110/black.frag
+++ b/BattleNetwork/resources/shaders/glsl_110/black.frag
@@ -5,20 +5,5 @@ uniform sampler2D texture;
 void main()
 {
     vec4 pixel = texture2D(texture, vec2(gl_TexCoord[0].x, gl_TexCoord[0].y));
-    vec4 color = gl_Color * pixel;
-    vec3 luminances = vec3(0.2126, 0.7152, 0.0722);
-
-    float luminance = dot(luminances, color.rgb);
-    float threshold = 0.5;
-
-    luminance = max(0.0, luminance - threshold);
-
-    color.rgb *= sign(luminance);
-
-    if(color.a > 0.0) {
-        if(color.rgb == vec3(0,0,0)) {  color.rgb = vec3(0,0,0); }
-        else { color.rgb = vec3(1,1,1); }
-    }
-
-    gl_FragColor = color;
-}
+    gl_FragColor = vec4(0,0,0,pixel.a);
+} 

--- a/BattleNetwork/resources/shaders/glsl_150/black.frag
+++ b/BattleNetwork/resources/shaders/glsl_150/black.frag
@@ -8,20 +8,5 @@ uniform sampler2D texture;
 void main()
 {
     vec4 pixel = texture2D(texture, vec2(vTexCoord.x, vTexCoord.y));
-    vec4 color = vColor * pixel;
-    vec3 luminances = vec3(0.2126, 0.7152, 0.0722);
-
-    float luminance = dot(luminances, color.rgb);
-    float threshold = 0.5;
-
-    luminance = max(0.0, luminance - threshold);
-
-    color.rgb *= sign(luminance);
-
-    if(color.a > 0.0) {
-        if(color.rgb == vec3(0,0,0)) {  color.rgb = vec3(0,0,0); }
-        else { color.rgb = vec3(1,1,1); }
-    }
-
-    gl_FragColor = color;
-}
+    gl_FragColor = vec4(0,0,0,pixel.a);
+} 

--- a/BattleNetwork/resources/shaders/glsl_150/black.frag
+++ b/BattleNetwork/resources/shaders/glsl_150/black.frag
@@ -1,0 +1,27 @@
+precision lowp float;
+precision lowp int;
+
+varying vec4 vColor;
+varying vec2 vTexCoord;
+uniform sampler2D texture;
+
+void main()
+{
+    vec4 pixel = texture2D(texture, vec2(vTexCoord.x, vTexCoord.y));
+    vec4 color = vColor * pixel;
+    vec3 luminances = vec3(0.2126, 0.7152, 0.0722);
+
+    float luminance = dot(luminances, color.rgb);
+    float threshold = 0.5;
+
+    luminance = max(0.0, luminance - threshold);
+
+    color.rgb *= sign(luminance);
+
+    if(color.a > 0.0) {
+        if(color.rgb == vec3(0,0,0)) {  color.rgb = vec3(0,0,0); }
+        else { color.rgb = vec3(1,1,1); }
+    }
+
+    gl_FragColor = color;
+}


### PR DESCRIPTION
Root is added as a hit property and status condition.  Rooted players cannot move, but can end root early when flashing.