### PR TITLE
Fix some leaks

### DIFF
--- a/BattleNetwork/bindings/bnScriptedMob.cpp
+++ b/BattleNetwork/bindings/bnScriptedMob.cpp
@@ -118,9 +118,9 @@ ScriptedMob::ScriptedMob(sol::state& script) :
   field = new Field(6, 3);
 }
 
-
 ScriptedMob::~ScriptedMob()
 {
+  delete field;
 }
 
 Mob* ScriptedMob::Build(Field* field) {

--- a/BattleNetwork/bnAI.h
+++ b/BattleNetwork/bnAI.h
@@ -43,7 +43,18 @@ public:
   /**
    * @brief Deletes the state machine object and Frees target
    */
-  ~AI() { if (stateMachine) { delete stateMachine; } ref = nullptr; FreeTarget(); }
+  ~AI() {
+    if (stateMachine) {
+      delete stateMachine;
+    }
+
+    if (queuedState) {
+      delete queuedState;
+    }
+
+    ref = nullptr;
+    FreeTarget();
+  }
 
   void InvokeDefaultState() {
     using DefaultState = typename CharacterT::DefaultState;

--- a/BattleNetwork/bnPlayer.cpp
+++ b/BattleNetwork/bnPlayer.cpp
@@ -77,6 +77,10 @@ Player::Player() :
 }
 
 Player::~Player() {
+  for (auto form : forms) {
+    delete form;
+  }
+
   delete superArmor;
   actionQueue.ClearQueue(ActionQueue::CleanupType::clear_and_reset);
 }

--- a/BattleNetwork/bnWebClientMananger.cpp
+++ b/BattleNetwork/bnWebClientMananger.cpp
@@ -49,7 +49,8 @@ void WebClientManager::QueuedTasksThreadHandler()
 
       char* error;
       while (client && client->GetNextError(&error)) {
-          Logger::Logf("Web Client encountered an error: %s", error);
+        Logger::Logf("Web Client encountered an error: %s", error);
+        delete[] error;
       }
 
       lock.lock();


### PR DESCRIPTION
Leak patches:
 - Package manager is no longer calling loadClass twice
 - Package manager is now deleting packages on failure
 - queuedState is now deleted in bnAI
 - field is now deleted in bnScriptedMob
 - Registered forms are now deleted in bnPlayer
 - WebClientManager now deletes error

I'm still seeing leaks after battles, leaving fixing that to the refactor
