### PR TITLE
Online Area Scene Queue, mob package cleanup, faster server polling, transfer only to online servers

### DIFF
--- a/BattleNetwork/bnGame.h
+++ b/BattleNetwork/bnGame.h
@@ -154,6 +154,11 @@ public:
 
     return T{};
   }
+
+  // todo: remove when this is public from swoosh
+  const swoosh::Activity* getCurrentActivity() const {
+    return ActivityController::getCurrentActivity();
+  }
 private:
   DrawWindow::WindowMode windowMode{};
 

--- a/BattleNetwork/bnShaderResourceManager.cpp
+++ b/BattleNetwork/bnShaderResourceManager.cpp
@@ -67,6 +67,8 @@ sf::Shader* ShaderResourceManager::GetShader(ShaderType _stype) {
   if (shaders.size()) {
     return shaders.at(_stype);
   }
+
+  return nullptr;
 }
 
 const bool ShaderResourceManager::IsEnabled() const

--- a/BattleNetwork/overworld/bnMinimap.cpp
+++ b/BattleNetwork/overworld/bnMinimap.cpp
@@ -248,7 +248,7 @@ void Overworld::Minimap::FindObjectMarkers(Map& map) {
   }
 }
 
-void Overworld::Minimap::DrawLayer(sf::RenderTarget& target, sf::Shader& shader, sf::RenderStates states, Overworld::Map& map, size_t index) {
+void Overworld::Minimap::DrawLayer(sf::RenderTarget& target, const sf::Shader& shader, sf::RenderStates states, Overworld::Map& map, size_t index) {
   auto& layer = map.GetLayer(index);
 
   // TODO: render SOME objects that are overlaying the map

--- a/BattleNetwork/overworld/bnMinimap.h
+++ b/BattleNetwork/overworld/bnMinimap.h
@@ -20,7 +20,7 @@ namespace Overworld {
     std::vector<std::shared_ptr<SpriteProxyNode>> playerMarkers;
     std::vector<std::shared_ptr<SpriteProxyNode>> mapMarkers;
     void EnforceTextureSizeLimits();
-    void DrawLayer(sf::RenderTarget& target, sf::Shader& shader, sf::RenderStates states, Map& map, size_t index);
+    void DrawLayer(sf::RenderTarget& target, const sf::Shader& shader, sf::RenderStates states, Map& map, size_t index);
     void FindMapMarkers(Map& map);
     void FindTileMarkers(Map& map);
     void FindObjectMarkers(Map& map);

--- a/BattleNetwork/overworld/bnOverworldHomepage.cpp
+++ b/BattleNetwork/overworld/bnOverworldHomepage.cpp
@@ -353,14 +353,12 @@ void Overworld::Homepage::onStart()
   SceneBase::onStart();
 
   Audio().Stream("resources/loops/loop_overworld.ogg", false);
-  infocus = true;
 }
 
 void Overworld::Homepage::onResume()
 {
   SceneBase::onResume();
   Audio().Stream("resources/loops/loop_overworld.ogg", false);
-  infocus = true;
 
   if (packetProcessor) {
     Net().AddHandler(remoteAddress, packetProcessor);
@@ -369,7 +367,7 @@ void Overworld::Homepage::onResume()
 
 void Overworld::Homepage::onLeave()
 {
-  infocus = false;
+  SceneBase::onLeave();
 
   if (packetProcessor) {
     Net().DropProcessor(packetProcessor);

--- a/BattleNetwork/overworld/bnOverworldHomepage.h
+++ b/BattleNetwork/overworld/bnOverworldHomepage.h
@@ -8,7 +8,6 @@ namespace Overworld {
   class Homepage final : public SceneBase {
   private:
     bool scaledmap{ false }, clicked{ false };
-    bool infocus{ false };
     Poco::Net::SocketAddress remoteAddress; //!< server
     std::string host; // need to store host string to retain domain names
     std::shared_ptr<PollingPacketProcessor> packetProcessor;

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -70,7 +70,6 @@ namespace Overworld {
 
     Overworld::EmoteNode emoteNode;
     std::shared_ptr<sf::Texture> customEmotesTexture;
-    std::string pvpRemoteAddress; // remember who we want to connect to after download scene
     std::string ticket; //!< How we are represented on the server
     std::shared_ptr<PacketProcessor> packetProcessor;
     std::shared_ptr<Netplay::PacketProcessor> netBattleProcessor;
@@ -105,11 +104,12 @@ namespace Overworld {
     CameraController serverCameraController;
     CameraController warpCameraController;
     std::vector<VendorScene::Item> shopItems;
+    std::queue<std::function<void()>> sceneChangeTasks;
 
-    void HandlePVPStep(const std::string& remoteAddress);
     void ResetPVPStep(bool failed = false);
 
     std::optional<AbstractUser> GetAbstractUser(const std::string& id);
+    void AddSceneChangeTask(const std::function<void()>& task);
     void onInteract(Interaction type);
     void updateOtherPlayers(double elapsed);
     void updatePlayer(double elapsed);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -110,13 +110,14 @@ namespace Overworld {
 
     std::optional<AbstractUser> GetAbstractUser(const std::string& id);
     void AddSceneChangeTask(const std::function<void()>& task);
+    void SetAvatarAsSpeaker();
     void onInteract(Interaction type);
     void updateOtherPlayers(double elapsed);
     void updatePlayer(double elapsed);
     void detectWarp();
     bool positionIsInWarp(sf::Vector3f position);
     Overworld::TeleportController::Command& teleportIn(sf::Vector3f position, Direction direction);
-    void transferServer(const std::string& host, uint16_t port, const std::string& data, bool warpOut);
+    void transferServer(const std::string& host, uint16_t port, std::string data, bool warpOut);
     void processPacketBody(const Poco::Buffer<char>& data);
 
     void sendAssetFoundSignal(const std::string& path, uint64_t lastModified);

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -82,7 +82,6 @@ namespace Overworld {
     bool transferringServers{ false };
     bool kicked{ false };
     bool tryPopScene{ false };
-    bool isPreparingForBattle{ false };
     bool canProceedToBattle{ false };
     bool copyScreen{ false };
     ReturningScene returningFrom{ ReturningScene::Null };
@@ -104,9 +103,11 @@ namespace Overworld {
     CameraController serverCameraController;
     CameraController warpCameraController;
     std::vector<VendorScene::Item> shopItems;
+    std::vector<std::string> downloadedMobPackages;
     std::queue<std::function<void()>> sceneChangeTasks;
 
     void ResetPVPStep(bool failed = false);
+    void RemovePackages();
 
     std::optional<AbstractUser> GetAbstractUser(const std::string& id);
     void AddSceneChangeTask(const std::function<void()>& task);

--- a/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.cpp
+++ b/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.cpp
@@ -5,7 +5,7 @@
 #include "../netplay/bnBufferReader.h"
 #include <optional>
 
-constexpr sf::Int32 PING_SERVER_MILI = 1000;
+constexpr sf::Int32 POLL_SERVER_MILI = 500;
 
 namespace Overworld {
   PollingPacketProcessor::PollingPacketProcessor(const Poco::Net::SocketAddress& remoteAddress, uint16_t maxPayloadSize, const std::function<void(ServerStatus, uint16_t)>& onResolve) :
@@ -13,7 +13,6 @@ namespace Overworld {
     onResolve(onResolve)
   {
     pingServerTimer.reverse(true);
-    pingServerTimer.set(sf::milliseconds(PING_SERVER_MILI));
     pingServerTimer.start();
   }
 
@@ -26,7 +25,7 @@ namespace Overworld {
       std::chrono::steady_clock::now() - lastMessageTime
       );
 
-    constexpr int64_t MAX_TIMEOUT_SECONDS = 5;
+    constexpr int64_t MAX_TIMEOUT_SECONDS = 3;
 
     return timeDifference.count() > MAX_TIMEOUT_SECONDS;
   }
@@ -41,7 +40,7 @@ namespace Overworld {
 
       packetShipper.Send(*client, Reliability::Unreliable, buffer);
 
-      pingServerTimer.set(sf::milliseconds(PING_SERVER_MILI));
+      pingServerTimer.set(sf::milliseconds(POLL_SERVER_MILI));
     }
 
     if (TimedOut()) {

--- a/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.cpp
+++ b/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.cpp
@@ -8,13 +8,17 @@
 constexpr sf::Int32 PING_SERVER_MILI = 1000;
 
 namespace Overworld {
-  PollingPacketProcessor::PollingPacketProcessor(const Poco::Net::SocketAddress& remoteAddress, uint16_t maxPayloadSize, std::function<void(ServerStatus, uint16_t)> onResolve) :
+  PollingPacketProcessor::PollingPacketProcessor(const Poco::Net::SocketAddress& remoteAddress, uint16_t maxPayloadSize, const std::function<void(ServerStatus, uint16_t)>& onResolve) :
     packetShipper(remoteAddress, maxPayloadSize),
     onResolve(onResolve)
   {
     pingServerTimer.reverse(true);
     pingServerTimer.set(sf::milliseconds(PING_SERVER_MILI));
     pingServerTimer.start();
+  }
+
+  void PollingPacketProcessor::SetStatusHandler(const std::function<void(ServerStatus, uint16_t)>& onResolve) {
+    this->onResolve = onResolve;
   }
 
   bool PollingPacketProcessor::TimedOut() {
@@ -45,6 +49,10 @@ namespace Overworld {
       lastMessageTime = std::chrono::steady_clock::now();
       onResolve(ServerStatus::offline, 0);
     }
+  }
+
+  void PollingPacketProcessor::OnListen(const Poco::Net::SocketAddress& sender) {
+    lastMessageTime = std::chrono::steady_clock::now();
   }
 
   void PollingPacketProcessor::OnPacket(char* buffer, int read, const Poco::Net::SocketAddress& sender) {

--- a/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.h
+++ b/BattleNetwork/overworld/bnOverworldPollingPacketProcessor.h
@@ -18,10 +18,16 @@ namespace Overworld {
 
   class PollingPacketProcessor : public IPacketProcessor {
   public:
-    PollingPacketProcessor(const Poco::Net::SocketAddress& remoteAddress, uint16_t maxPayloadSize, std::function<void(ServerStatus, uint16_t)> onPacketBody);
+    PollingPacketProcessor(
+      const Poco::Net::SocketAddress& remoteAddress,
+      uint16_t maxPayloadSize,
+      const std::function<void(ServerStatus, uint16_t)>& onResolve = [](auto, auto) {}
+    );
 
+    void SetStatusHandler(const std::function<void(ServerStatus, uint16_t)>& onResolve);
     bool TimedOut();
     void Update(double elapsed) override;
+    void OnListen(const Poco::Net::SocketAddress& sender) override;
     void OnPacket(char* buffer, int read, const Poco::Net::SocketAddress& sender) override;
 
   private:

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -55,7 +55,6 @@ namespace Overworld {
     bool cameraLocked{ false };
     bool teleportedOut{ false }; /*!< We may return to this area*/
     bool lastIsConnectedState; /*!< Set different animations if the connection has changed */
-    bool gotoNextScene{ false }; /*!< If true, player cannot interact with screen yet */
 
     Camera camera;
     CameraController cameraController; /*!< camera in scene follows player */
@@ -260,7 +259,7 @@ namespace Overworld {
     std::optional<CardFolder*> GetSelectedFolder();
     Overworld::MenuSystem& GetMenuSystem();
     bool IsInputLocked();
-    bool IsInFocus() const;
+    bool IsInFocus();
     virtual std::string GetPath(const std::string& path);
     virtual std::string GetText(const std::string& path);
     virtual std::shared_ptr<sf::Texture> GetTexture(const std::string& path);


### PR DESCRIPTION
Changes:
 - Scene change queue for online area
 - Faster polling
 - Transfers to offline/out of date servers will no longer kick players back to homepage
   - If the transfer was caused by the server and not client/link, then the player will still disconnect as the server currently kicks the player during a server-initiated transfer.