### PR TITLE
API Suggestions

### DIFF
--- a/BattleNetwork/bindings/bnScriptedArtifact.cpp
+++ b/BattleNetwork/bindings/bnScriptedArtifact.cpp
@@ -54,7 +54,7 @@ void ScriptedArtifact::OnDelete()
     }
   }
 
-  Remove();
+  Erase();
 }
 
 bool ScriptedArtifact::CanMoveTo(Battle::Tile* next)

--- a/BattleNetwork/bindings/bnScriptedCharacter.cpp
+++ b/BattleNetwork/bindings/bnScriptedCharacter.cpp
@@ -140,13 +140,4 @@ void ScriptedCharacter::SetExplosionBehavior(int num, double speed, bool isBoss)
   bossExplosion = isBoss;
 }
 
-void ScriptedCharacter::SimpleCardActionEvent(std::shared_ptr<ScriptedCardAction> action, ActionOrder order)
-{
-  Character::AddAction(CardEvent{ action }, order);
-}
-
-void ScriptedCharacter::SimpleCardActionEvent(std::shared_ptr<CardAction> action, ActionOrder order)
-{
-  Character::AddAction(CardEvent{ action }, order);
-}
 #endif

--- a/BattleNetwork/bindings/bnScriptedCharacter.h
+++ b/BattleNetwork/bindings/bnScriptedCharacter.h
@@ -47,8 +47,6 @@ public:
   void ShakeCamera(double power, float duration);
   Animation& GetAnimationObject();
   void SetExplosionBehavior(int num, double speed, bool isBoss);
-  void SimpleCardActionEvent(std::shared_ptr<ScriptedCardAction> action, ActionOrder order);
-  void SimpleCardActionEvent(std::shared_ptr<CardAction> action, ActionOrder order);
 
   sol::object update_func;
   sol::object delete_func;

--- a/BattleNetwork/bindings/bnScriptedObstacle.cpp
+++ b/BattleNetwork/bindings/bnScriptedObstacle.cpp
@@ -73,7 +73,7 @@ void ScriptedObstacle::OnDelete() {
     }
   }
 
-  Remove();
+  Erase();
 }
 
 void ScriptedObstacle::Attack(std::shared_ptr<Entity> other) {

--- a/BattleNetwork/bindings/bnScriptedSpell.cpp
+++ b/BattleNetwork/bindings/bnScriptedSpell.cpp
@@ -53,7 +53,7 @@ void ScriptedSpell::OnDelete() {
     }
   }
 
-  Remove();
+  Erase();
 }
 
 void ScriptedSpell::OnCollision(const std::shared_ptr<Entity> other)

--- a/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
@@ -185,6 +185,12 @@ void DefineBasicCharacterUserType(sol::table& battle_namespace) {
     "remove_defense_rule", [](WeakWrapper<Character>& character, DefenseRule* defenseRule) {
       character.Unwrap()->RemoveDefenseRule(defenseRule);
     },
+    "get_offset", [](WeakWrapper<Character>& character) -> sf::Vector2f {
+      return character.Unwrap()->GetDrawOffset();
+    },
+    "set_offset", [](WeakWrapper<Character>& character, float x, float y) {
+      character.Unwrap()->SetDrawOffset(x, y);
+    },
     "set_height", [](WeakWrapper<Character>& character, float height) {
       character.Unwrap()->SetHeight(height);
     },

--- a/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
@@ -185,12 +185,6 @@ void DefineBasicCharacterUserType(sol::table& battle_namespace) {
     "remove_defense_rule", [](WeakWrapper<Character>& character, DefenseRule* defenseRule) {
       character.Unwrap()->RemoveDefenseRule(defenseRule);
     },
-    "get_position", [](WeakWrapper<Character>& character) -> sf::Vector2f {
-      return character.Unwrap()->GetDrawOffset();
-    },
-    "set_position", [](WeakWrapper<Character>& character, float x, float y) {
-      character.Unwrap()->SetDrawOffset(x, y);
-    },
     "set_height", [](WeakWrapper<Character>& character, float height) {
       character.Unwrap()->SetHeight(height);
     },

--- a/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
@@ -136,7 +136,7 @@ void DefineBasicCharacterUserType(sol::table& battle_namespace) {
     },
     "will_erase_eof", [](WeakWrapper<Character>& character) -> bool {
       auto ptr = character.Lock();
-      return !ptr || ptr->WillRemoveLater();
+      return !ptr || ptr->WillEraseEOF();
     },
     "get_team", [](WeakWrapper<Character>& character) -> Team {
       return character.Unwrap()->GetTeam();

--- a/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
@@ -131,9 +131,10 @@ void DefineBasicCharacterUserType(sol::table& battle_namespace) {
       return character.Unwrap()->IsMoving();
     },
     "is_deleted", [](WeakWrapper<Character>& character) -> bool {
-      return character.Unwrap()->IsDeleted();
+      auto ptr = character.Lock();
+      return !ptr || ptr->IsDeleted();
     },
-    "will_remove_eof", [](WeakWrapper<Character>& character) -> bool {
+    "will_erase_eof", [](WeakWrapper<Character>& character) -> bool {
       auto ptr = character.Lock();
       return !ptr || ptr->WillRemoveLater();
     },

--- a/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeBasicCharacter.cpp
@@ -4,6 +4,7 @@
 #include "bnWeakWrapper.h"
 #include "bnUserTypeAnimation.h"
 #include "bnScriptedComponent.h"
+#include "bnScriptedCardAction.h"
 #include "../bnCharacter.h"
 #include <optional>
 
@@ -115,6 +116,14 @@ void DefineBasicCharacterUserType(sol::table& battle_namespace) {
     "raw_move_event", [](WeakWrapper<Character>& character, const MoveEvent& event, ActionOrder order) -> bool {
       return character.Unwrap()->RawMoveEvent(event, order);
     },
+    "card_action_event", sol::overload(
+      [](WeakWrapper<Character>& character, WeakWrapper<ScriptedCardAction>& cardAction, ActionOrder order) {
+        character.Unwrap()->AddAction(CardEvent{ cardAction.Release() }, order);
+      },
+      [](WeakWrapper<Character>& character, WeakWrapper<CardAction>& cardAction, ActionOrder order) {
+        character.Unwrap()->AddAction(CardEvent{ cardAction.Release() }, order);
+      }
+    ),
     "is_sliding", [](WeakWrapper<Character>& character) -> bool {
       return character.Unwrap()->IsSliding();
     },

--- a/BattleNetwork/bindings/bnUserTypeEntity.cpp
+++ b/BattleNetwork/bindings/bnUserTypeEntity.cpp
@@ -129,9 +129,10 @@ void DefineEntityUserType(sol::table& battle_namespace) {
       return entity.Unwrap()->IsMoving();
     },
     "is_deleted", [](WeakWrapper<Entity>& entity) -> bool {
-      return entity.Unwrap()->IsDeleted();
+      auto ptr = entity.Lock();
+      return !ptr || ptr->IsDeleted();
     },
-    "will_remove_eof", [](WeakWrapper<Entity>& entity) -> bool {
+    "will_erase_eof", [](WeakWrapper<Entity>& entity) -> bool {
       auto ptr = entity.Lock();
       return !ptr || ptr->WillRemoveLater();
     },
@@ -141,7 +142,7 @@ void DefineEntityUserType(sol::table& battle_namespace) {
     "get_team", [](WeakWrapper<Entity>& entity) -> Team {
       return entity.Unwrap()->GetTeam();
     },
-    "remove", [](WeakWrapper<Entity>& entity) {
+    "erase", [](WeakWrapper<Entity>& entity) {
       entity.Unwrap()->Remove();
     },
     "delete", [](WeakWrapper<Entity>& entity) {

--- a/BattleNetwork/bindings/bnUserTypeEntity.cpp
+++ b/BattleNetwork/bindings/bnUserTypeEntity.cpp
@@ -134,7 +134,7 @@ void DefineEntityUserType(sol::table& battle_namespace) {
     },
     "will_erase_eof", [](WeakWrapper<Entity>& entity) -> bool {
       auto ptr = entity.Lock();
-      return !ptr || ptr->WillRemoveLater();
+      return !ptr || ptr->WillEraseEOF();
     },
     "is_team", [](WeakWrapper<Entity>& entity, Team team) -> bool {
       return entity.Unwrap()->Teammate(team);
@@ -143,7 +143,7 @@ void DefineEntityUserType(sol::table& battle_namespace) {
       return entity.Unwrap()->GetTeam();
     },
     "erase", [](WeakWrapper<Entity>& entity) {
-      entity.Unwrap()->Remove();
+      entity.Unwrap()->Erase();
     },
     "delete", [](WeakWrapper<Entity>& entity) {
       entity.Unwrap()->Delete();

--- a/BattleNetwork/bindings/bnUserTypeEntity.cpp
+++ b/BattleNetwork/bindings/bnUserTypeEntity.cpp
@@ -184,10 +184,10 @@ void DefineEntityUserType(sol::table& battle_namespace) {
     "show_shadow", [](WeakWrapper<Entity>& entity, bool show) {
       entity.Unwrap()->ShowShadow(show);
     },
-    "get_position", [](WeakWrapper<Entity>& entity) -> sf::Vector2f {
+    "get_offset", [](WeakWrapper<Entity>& entity) -> sf::Vector2f {
       return entity.Unwrap()->GetDrawOffset();
     },
-    "set_position", [](WeakWrapper<Entity>& entity, float x, float y) {
+    "set_offset", [](WeakWrapper<Entity>& entity, float x, float y) {
       entity.Unwrap()->SetDrawOffset(x, y);
     }
   );

--- a/BattleNetwork/bindings/bnUserTypeSceneNode.cpp
+++ b/BattleNetwork/bindings/bnUserTypeSceneNode.cpp
@@ -40,7 +40,7 @@ void DefineSceneNodeUserType(sol::table& engine_namespace) {
     "remove_tags", [](WeakWrapper<SceneNode>& node, std::initializer_list<std::string> tags) {
       node.Unwrap()->RemoveTags(tags);
     },
-    "has_tags", [](WeakWrapper<SceneNode>& node, const std::string& tag) -> bool{
+    "has_tag", [](WeakWrapper<SceneNode>& node, const std::string& tag) -> bool{
       return node.Unwrap()->HasTag(tag);
     },
     "find_child_nodes_with_tags", [](WeakWrapper<SceneNode>& node, std::initializer_list<std::string> tags) {

--- a/BattleNetwork/bindings/bnUserTypeSceneNode.cpp
+++ b/BattleNetwork/bindings/bnUserTypeSceneNode.cpp
@@ -54,10 +54,10 @@ void DefineSceneNodeUserType(sol::table& engine_namespace) {
 
       return sol::as_table(result);
     },
-    "get_position", [](WeakWrapper<SceneNode>& node) -> sf::Vector2f {
+    "get_offset", [](WeakWrapper<SceneNode>& node) -> sf::Vector2f {
       return node.Unwrap()->getPosition();
     },
-    "set_position", [](WeakWrapper<SceneNode>& node, float x, float y) {
+    "set_offset", [](WeakWrapper<SceneNode>& node, float x, float y) {
       node.Unwrap()->setPosition(x, y);
     },
     "enable_parent_shader", [](WeakWrapper<SceneNode>& node, bool enable) {

--- a/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
@@ -171,6 +171,12 @@ void DefineScriptedArtifactUserType(sol::table& battle_namespace) {
     "set_height", [](WeakWrapper<ScriptedArtifact>& artifact, float height) {
       artifact.Unwrap()->SetHeight(height);
     },
+    "get_offset", [](WeakWrapper<ScriptedArtifact>& artifact) -> sf::Vector2f {
+      return artifact.Unwrap()->GetDrawOffset();
+    },
+    "set_offset", [](WeakWrapper<ScriptedArtifact>& artifact, float x, float y) {
+      artifact.Unwrap()->SetDrawOffset(x, y);
+    },
     "never_flip", [](WeakWrapper<ScriptedArtifact>& artifact, bool enabled) {
       artifact.Unwrap()->NeverFlip(enabled);
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
@@ -171,9 +171,6 @@ void DefineScriptedArtifactUserType(sol::table& battle_namespace) {
     "set_height", [](WeakWrapper<ScriptedArtifact>& artifact, float height) {
       artifact.Unwrap()->SetHeight(height);
     },
-    "set_position", [](WeakWrapper<ScriptedArtifact>& artifact, float x, float y) {
-      artifact.Unwrap()->SetDrawOffset(x, y);
-    },
     "never_flip", [](WeakWrapper<ScriptedArtifact>& artifact, bool enabled) {
       artifact.Unwrap()->NeverFlip(enabled);
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
@@ -140,16 +140,17 @@ void DefineScriptedArtifactUserType(sol::table& battle_namespace) {
       return artifact.Unwrap()->IsMoving();
     },
     "is_deleted", [](WeakWrapper<ScriptedArtifact>& artifact) -> bool {
-      return artifact.Unwrap()->IsDeleted();
+      auto ptr = artifact.Lock();
+      return !ptr || ptr->IsDeleted();
     },
-    "will_remove_eof", [](WeakWrapper<ScriptedArtifact>& artifact) -> bool {
+    "will_erase_eof", [](WeakWrapper<ScriptedArtifact>& artifact) -> bool {
       auto ptr = artifact.Lock();
       return !ptr || ptr->WillRemoveLater();
     },
     "get_team", [](WeakWrapper<ScriptedArtifact>& artifact) -> Team {
       return artifact.Unwrap()->GetTeam();
     },
-    "remove", [](WeakWrapper<ScriptedArtifact>& artifact) {
+    "erase", [](WeakWrapper<ScriptedArtifact>& artifact) {
       artifact.Unwrap()->Remove();
     },
     "delete", [](WeakWrapper<ScriptedArtifact>& artifact) {

--- a/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
@@ -145,13 +145,13 @@ void DefineScriptedArtifactUserType(sol::table& battle_namespace) {
     },
     "will_erase_eof", [](WeakWrapper<ScriptedArtifact>& artifact) -> bool {
       auto ptr = artifact.Lock();
-      return !ptr || ptr->WillRemoveLater();
+      return !ptr || ptr->WillEraseEOF();
     },
     "get_team", [](WeakWrapper<ScriptedArtifact>& artifact) -> Team {
       return artifact.Unwrap()->GetTeam();
     },
     "erase", [](WeakWrapper<ScriptedArtifact>& artifact) {
-      artifact.Unwrap()->Remove();
+      artifact.Unwrap()->Erase();
     },
     "delete", [](WeakWrapper<ScriptedArtifact>& artifact) {
       artifact.Unwrap()->Delete();

--- a/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
@@ -9,10 +9,9 @@
 
 void DefineScriptedArtifactUserType(sol::table& battle_namespace) {
   battle_namespace.new_usertype<WeakWrapper<ScriptedArtifact>>("Artifact",
-    sol::factories([](Team team) -> WeakWrapper<ScriptedArtifact> {
+    sol::factories([]() -> WeakWrapper<ScriptedArtifact> {
       auto artifact = std::make_shared<ScriptedArtifact>();
       artifact->Init();
-      artifact->SetTeam(team);
 
       auto wrappedArtifact = WeakWrapper<ScriptedArtifact>(artifact);
       wrappedArtifact.Own();

--- a/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
@@ -157,7 +157,7 @@ void DefineScriptedCharacterUserType(sol::table& battle_namespace) {
     },
     "will_erase_eof", [](WeakWrapper<ScriptedCharacter>& character) -> bool {
       auto ptr = character.Lock();
-      return !ptr || ptr->WillRemoveLater();
+      return !ptr || ptr->WillEraseEOF();
     },
     "get_team", [](WeakWrapper<ScriptedCharacter>& character) -> Team {
       return character.Unwrap()->GetTeam();
@@ -166,7 +166,7 @@ void DefineScriptedCharacterUserType(sol::table& battle_namespace) {
       character.Unwrap()->Teammate(team);
     },
     "erase", [](WeakWrapper<ScriptedCharacter>& character) {
-      character.Unwrap()->Remove();
+      character.Unwrap()->Erase();
     },
     "delete", [](WeakWrapper<ScriptedCharacter>& character) {
       character.Unwrap()->Delete();

--- a/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
@@ -130,10 +130,10 @@ void DefineScriptedCharacterUserType(sol::table& battle_namespace) {
     },
     "card_action_event", sol::overload(
       [](WeakWrapper<ScriptedCharacter>& character, WeakWrapper<ScriptedCardAction>& cardAction, ActionOrder order) {
-        character.Unwrap()->SimpleCardActionEvent(cardAction.Release(), order);
+        character.Unwrap()->AddAction(CardEvent{ cardAction.Release() }, order);
       },
       [](WeakWrapper<ScriptedCharacter>& character, WeakWrapper<CardAction>& cardAction, ActionOrder order) {
-        character.Unwrap()->SimpleCardActionEvent(cardAction.Release(), order);
+        character.Unwrap()->AddAction(CardEvent{ cardAction.Release() }, order);
       }
     ),
     "is_sliding", [](WeakWrapper<ScriptedCharacter>& character) -> bool {

--- a/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
@@ -226,6 +226,12 @@ void DefineScriptedCharacterUserType(sol::table& battle_namespace) {
     "remove_defense_rule", [](WeakWrapper<ScriptedCharacter>& character, DefenseRule* defenseRule) {
       character.Unwrap()->RemoveDefenseRule(defenseRule);
     },
+    "get_offset", [](WeakWrapper<ScriptedCharacter>& character) -> sf::Vector2f {
+      return character.Unwrap()->GetDrawOffset();
+    },
+    "set_offset", [](WeakWrapper<ScriptedCharacter>& character, float x, float y) {
+      character.Unwrap()->SetDrawOffset(x, y);
+    },
     "set_height", [](WeakWrapper<ScriptedCharacter>& character, float height) {
       character.Unwrap()->SetHeight(height);
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
@@ -226,12 +226,6 @@ void DefineScriptedCharacterUserType(sol::table& battle_namespace) {
     "remove_defense_rule", [](WeakWrapper<ScriptedCharacter>& character, DefenseRule* defenseRule) {
       character.Unwrap()->RemoveDefenseRule(defenseRule);
     },
-    "get_position", [](WeakWrapper<ScriptedCharacter>& character) -> sf::Vector2f {
-      return character.Unwrap()->GetDrawOffset();
-    },
-    "set_position", [](WeakWrapper<ScriptedCharacter>& character, float x, float y) {
-      character.Unwrap()->SetDrawOffset(x, y);
-    },
     "set_height", [](WeakWrapper<ScriptedCharacter>& character, float height) {
       character.Unwrap()->SetHeight(height);
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedCharacter.cpp
@@ -152,9 +152,10 @@ void DefineScriptedCharacterUserType(sol::table& battle_namespace) {
       return character.Unwrap()->IsMoving();
     },
     "is_deleted", [](WeakWrapper<ScriptedCharacter>& character) -> bool {
-      return character.Unwrap()->IsDeleted();
+      auto ptr = character.Lock();
+      return !ptr || ptr->IsDeleted();
     },
-    "will_remove_eof", [](WeakWrapper<ScriptedCharacter>& character) -> bool {
+    "will_erase_eof", [](WeakWrapper<ScriptedCharacter>& character) -> bool {
       auto ptr = character.Lock();
       return !ptr || ptr->WillRemoveLater();
     },
@@ -164,7 +165,7 @@ void DefineScriptedCharacterUserType(sol::table& battle_namespace) {
     "is_team", [](WeakWrapper<ScriptedCharacter>& character, Team team) {
       character.Unwrap()->Teammate(team);
     },
-    "remove", [](WeakWrapper<ScriptedCharacter>& character) {
+    "erase", [](WeakWrapper<ScriptedCharacter>& character) {
       character.Unwrap()->Remove();
     },
     "delete", [](WeakWrapper<ScriptedCharacter>& character) {

--- a/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
@@ -137,22 +137,22 @@ void DefineScriptedObstacleUserType(sol::table& battle_namespace) {
           }
         });
     },
-      "raw_move_event", [](WeakWrapper<ScriptedObstacle>& obstacle, const MoveEvent& event, ActionOrder order) -> bool {
+    "raw_move_event", [](WeakWrapper<ScriptedObstacle>& obstacle, const MoveEvent& event, ActionOrder order) -> bool {
       return obstacle.Unwrap()->RawMoveEvent(event, order);
     },
-      "is_sliding", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
+    "is_sliding", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
       return obstacle.Unwrap()->IsSliding();
     },
-      "is_jumping", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
+    "is_jumping", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
       return obstacle.Unwrap()->IsJumping();
     },
-      "is_teleporting", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
+    "is_teleporting", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
       return obstacle.Unwrap()->IsTeleporting();
     },
-      "is_moving", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
+    "is_moving", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
       return obstacle.Unwrap()->IsMoving();
     },
-      "is_passthrough", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
+    "is_passthrough", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
       return obstacle.Unwrap()->IsPassthrough();
     },
     "is_deleted", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
@@ -163,74 +163,74 @@ void DefineScriptedObstacleUserType(sol::table& battle_namespace) {
       auto ptr = obstacle.Lock();
       return !ptr || ptr->WillRemoveLater();
     },
-      "is_team", [](WeakWrapper<ScriptedObstacle>& obstacle, Team team) -> bool {
+    "is_team", [](WeakWrapper<ScriptedObstacle>& obstacle, Team team) -> bool {
       return obstacle.Unwrap()->Teammate(team);
     },
-      "get_team", [](WeakWrapper<ScriptedObstacle>& obstacle) -> Team {
+    "get_team", [](WeakWrapper<ScriptedObstacle>& obstacle) -> Team {
       return obstacle.Unwrap()->GetTeam();
     },
     "erase", [](WeakWrapper<ScriptedObstacle>& obstacle) {
       obstacle.Unwrap()->Remove();
     },
-      "delete", [](WeakWrapper<ScriptedObstacle>& obstacle) {
+    "delete", [](WeakWrapper<ScriptedObstacle>& obstacle) {
       obstacle.Unwrap()->Delete();
     },
-      "get_name", [](WeakWrapper<ScriptedObstacle>& obstacle) -> std::string {
+    "get_name", [](WeakWrapper<ScriptedObstacle>& obstacle) -> std::string {
       return obstacle.Unwrap()->GetName();
     },
-      "set_name", [](WeakWrapper<ScriptedObstacle>& obstacle, std::string name) {
+    "set_name", [](WeakWrapper<ScriptedObstacle>& obstacle, std::string name) {
       obstacle.Unwrap()->SetName(name);
     },
-      "get_health", [](WeakWrapper<ScriptedObstacle>& obstacle) -> int {
+    "get_health", [](WeakWrapper<ScriptedObstacle>& obstacle) -> int {
       return obstacle.Unwrap()->GetHealth();
     },
-      "get_max_health", [](WeakWrapper<ScriptedObstacle>& obstacle) -> int {
+    "get_max_health", [](WeakWrapper<ScriptedObstacle>& obstacle) -> int {
       return obstacle.Unwrap()->GetMaxHealth();
     },
-      "set_health", [](WeakWrapper<ScriptedObstacle>& obstacle, int health) {
+    "set_health", [](WeakWrapper<ScriptedObstacle>& obstacle, int health) {
       obstacle.Unwrap()->SetHealth(health);
     },
-      "share_tile", [](WeakWrapper<ScriptedObstacle>& obstacle, bool share) {
+    "share_tile", [](WeakWrapper<ScriptedObstacle>& obstacle, bool share) {
       obstacle.Unwrap()->ShareTileSpace(share);
     },
-      "add_defense_rule", [](WeakWrapper<ScriptedObstacle>& obstacle, DefenseRule* defenseRule) {
+    "add_defense_rule", [](WeakWrapper<ScriptedObstacle>& obstacle, DefenseRule* defenseRule) {
       obstacle.Unwrap()->AddDefenseRule(defenseRule->shared_from_this());
     },
-      "remove_defense_rule", [](WeakWrapper<ScriptedObstacle>& obstacle, DefenseRule* defenseRule) {
+    "remove_defense_rule", [](WeakWrapper<ScriptedObstacle>& obstacle, DefenseRule* defenseRule) {
       obstacle.Unwrap()->RemoveDefenseRule(defenseRule);
     },
-      "get_texture", [](WeakWrapper<ScriptedObstacle>& obstacle) -> std::shared_ptr<Texture> {
+    "get_texture", [](WeakWrapper<ScriptedObstacle>& obstacle) -> std::shared_ptr<Texture> {
       return obstacle.Unwrap()->getTexture();
     },
-      "set_texture", [](WeakWrapper<ScriptedObstacle>& obstacle, std::shared_ptr<Texture> texture) {
+    "set_texture", [](WeakWrapper<ScriptedObstacle>& obstacle, std::shared_ptr<Texture> texture) {
       obstacle.Unwrap()->setTexture(texture);
     },
-      "set_animation", [](WeakWrapper<ScriptedObstacle>& obstacle, std::string animation) {
+    "set_animation", [](WeakWrapper<ScriptedObstacle>& obstacle, std::string animation) {
       obstacle.Unwrap()->SetAnimation(animation);
     },
-      "get_animation", [](WeakWrapper<ScriptedObstacle>& obstacle) -> AnimationWrapper {
+    "get_animation", [](WeakWrapper<ScriptedObstacle>& obstacle) -> AnimationWrapper {
       auto& animation = obstacle.Unwrap()->GetAnimationObject();
       return AnimationWrapper(obstacle.GetWeak(), animation);
     },
-      "create_node", [](WeakWrapper<ScriptedObstacle>& obstacle) -> WeakWrapper<SpriteProxyNode> {
+    "create_node", [](WeakWrapper<ScriptedObstacle>& obstacle) -> WeakWrapper<SpriteProxyNode> {
       auto child = std::make_shared<SpriteProxyNode>();
       obstacle.Unwrap()->AddNode(child);
 
       return WeakWrapper(child);
     },
-      "highlight_tile", [](WeakWrapper<ScriptedObstacle>& obstacle, Battle::TileHighlight mode) {
+    "highlight_tile", [](WeakWrapper<ScriptedObstacle>& obstacle, Battle::TileHighlight mode) {
       obstacle.Unwrap()->HighlightTile(mode);
     },
-      "copy_hit_props", [](WeakWrapper<ScriptedObstacle>& obstacle) -> Hit::Properties {
+    "copy_hit_props", [](WeakWrapper<ScriptedObstacle>& obstacle) -> Hit::Properties {
       return obstacle.Unwrap()->GetHitboxProperties();
     },
-      "set_hit_props", [](WeakWrapper<ScriptedObstacle>& obstacle, Hit::Properties props) {
+    "set_hit_props", [](WeakWrapper<ScriptedObstacle>& obstacle, Hit::Properties props) {
       obstacle.Unwrap()->SetHitboxProperties(props);
     },
-      "ignore_common_aggressor", [](WeakWrapper<ScriptedObstacle>& obstacle, bool enable) {
+    "ignore_common_aggressor", [](WeakWrapper<ScriptedObstacle>& obstacle, bool enable) {
       obstacle.Unwrap()->IgnoreCommonAggressor(enable);
     },
-      "set_height", [](WeakWrapper<ScriptedObstacle>& obstacle, float height) {
+    "set_height", [](WeakWrapper<ScriptedObstacle>& obstacle, float height) {
       obstacle.Unwrap()->SetHeight(height);
     },
     "set_shadow", sol::overload(

--- a/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
@@ -249,6 +249,12 @@ void DefineScriptedObstacleUserType(sol::table& battle_namespace) {
     "register_component", [](WeakWrapper<ScriptedObstacle>& obstacle, WeakWrapper<ScriptedComponent>& component) {
       obstacle.Unwrap()->RegisterComponent(component.Release());
     },
+    "get_offset", [](WeakWrapper<ScriptedObstacle>& obstacle) -> sf::Vector2f {
+      return obstacle.Unwrap()->GetDrawOffset();
+    },
+    "set_offset", [](WeakWrapper<ScriptedObstacle>& obstacle, float x, float y) {
+      obstacle.Unwrap()->SetDrawOffset(x, y);
+    },
     "never_flip", [](WeakWrapper<ScriptedObstacle>& obstacle, bool enabled) {
       obstacle.Unwrap()->NeverFlip(enabled);
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
@@ -155,10 +155,11 @@ void DefineScriptedObstacleUserType(sol::table& battle_namespace) {
       "is_passthrough", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
       return obstacle.Unwrap()->IsPassthrough();
     },
-      "is_deleted", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
-      return obstacle.Unwrap()->IsDeleted();
+    "is_deleted", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
+      auto ptr = obstacle.Lock();
+      return !ptr || ptr->IsDeleted();
     },
-      "will_remove_eof", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
+    "will_erase_eof", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
       auto ptr = obstacle.Lock();
       return !ptr || ptr->WillRemoveLater();
     },
@@ -168,7 +169,7 @@ void DefineScriptedObstacleUserType(sol::table& battle_namespace) {
       "get_team", [](WeakWrapper<ScriptedObstacle>& obstacle) -> Team {
       return obstacle.Unwrap()->GetTeam();
     },
-      "remove", [](WeakWrapper<ScriptedObstacle>& obstacle) {
+    "erase", [](WeakWrapper<ScriptedObstacle>& obstacle) {
       obstacle.Unwrap()->Remove();
     },
       "delete", [](WeakWrapper<ScriptedObstacle>& obstacle) {

--- a/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
@@ -249,12 +249,6 @@ void DefineScriptedObstacleUserType(sol::table& battle_namespace) {
     "register_component", [](WeakWrapper<ScriptedObstacle>& obstacle, WeakWrapper<ScriptedComponent>& component) {
       obstacle.Unwrap()->RegisterComponent(component.Release());
     },
-    "get_position", [](WeakWrapper<ScriptedObstacle>& obstacle) -> sf::Vector2f {
-      return obstacle.Unwrap()->GetDrawOffset();
-    },
-    "set_position", [](WeakWrapper<ScriptedObstacle>& obstacle, float x, float y) {
-      obstacle.Unwrap()->SetDrawOffset(x, y);
-    },
     "never_flip", [](WeakWrapper<ScriptedObstacle>& obstacle, bool enabled) {
       obstacle.Unwrap()->NeverFlip(enabled);
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedObstacle.cpp
@@ -161,7 +161,7 @@ void DefineScriptedObstacleUserType(sol::table& battle_namespace) {
     },
     "will_erase_eof", [](WeakWrapper<ScriptedObstacle>& obstacle) -> bool {
       auto ptr = obstacle.Lock();
-      return !ptr || ptr->WillRemoveLater();
+      return !ptr || ptr->WillEraseEOF();
     },
     "is_team", [](WeakWrapper<ScriptedObstacle>& obstacle, Team team) -> bool {
       return obstacle.Unwrap()->Teammate(team);
@@ -170,7 +170,7 @@ void DefineScriptedObstacleUserType(sol::table& battle_namespace) {
       return obstacle.Unwrap()->GetTeam();
     },
     "erase", [](WeakWrapper<ScriptedObstacle>& obstacle) {
-      obstacle.Unwrap()->Remove();
+      obstacle.Unwrap()->Erase();
     },
     "delete", [](WeakWrapper<ScriptedObstacle>& obstacle) {
       obstacle.Unwrap()->Delete();

--- a/BattleNetwork/bindings/bnUserTypeScriptedPlayer.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedPlayer.cpp
@@ -161,7 +161,7 @@ void DefineScriptedPlayerUserType(sol::table& battle_namespace) {
     "is_deleted", [](WeakWrapper<ScriptedPlayer>& player) -> bool {
       return player.Unwrap()->IsDeleted();
     },
-    "will_remove_eof", [](WeakWrapper<ScriptedPlayer>& player) -> bool {
+    "will_erase_eof", [](WeakWrapper<ScriptedPlayer>& player) -> bool {
       auto ptr = player.Lock();
       return !ptr || ptr->WillRemoveLater();
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedPlayer.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedPlayer.cpp
@@ -163,7 +163,7 @@ void DefineScriptedPlayerUserType(sol::table& battle_namespace) {
     },
     "will_erase_eof", [](WeakWrapper<ScriptedPlayer>& player) -> bool {
       auto ptr = player.Lock();
-      return !ptr || ptr->WillRemoveLater();
+      return !ptr || ptr->WillEraseEOF();
     },
     "get_team", [](WeakWrapper<ScriptedPlayer>& player) -> Team {
       return player.Unwrap()->GetTeam();

--- a/BattleNetwork/bindings/bnUserTypeScriptedPlayer.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedPlayer.cpp
@@ -229,6 +229,12 @@ void DefineScriptedPlayerUserType(sol::table& battle_namespace) {
     "remove_defense_rule", [](WeakWrapper<ScriptedPlayer>& player, DefenseRule* defenseRule) {
       player.Unwrap()->RemoveDefenseRule(defenseRule);
     },
+    "get_offset", [](WeakWrapper<ScriptedPlayer>& player) -> sf::Vector2f {
+      return player.Unwrap()->GetDrawOffset();
+    },
+    "set_offset", [](WeakWrapper<ScriptedPlayer>& player, float x, float y) {
+      player.Unwrap()->SetDrawOffset(x, y);
+    },
     "get_current_palette",  [](WeakWrapper<ScriptedPlayer>& player) -> std::shared_ptr<Texture> {
       return player.Unwrap()->GetPalette();
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedPlayer.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedPlayer.cpp
@@ -7,6 +7,7 @@
 #include "bnScriptedPlayer.h"
 #include "bnScriptedComponent.h"
 #include "bnScriptedPlayerForm.h"
+#include "bnScriptedCardAction.h"
 #include "../bnSolHelpers.h"
 
 void DefineScriptedPlayerUserType(sol::table& battle_namespace) {
@@ -143,6 +144,14 @@ void DefineScriptedPlayerUserType(sol::table& battle_namespace) {
     "raw_move_event", [](WeakWrapper<ScriptedPlayer>& player, const MoveEvent& event, ActionOrder order) -> bool {
       return player.Unwrap()->RawMoveEvent(event, order);
     },
+    "card_action_event", sol::overload(
+      [](WeakWrapper<ScriptedPlayer>& player, WeakWrapper<ScriptedCardAction>& cardAction, ActionOrder order) {
+        player.Unwrap()->AddAction(CardEvent{ cardAction.Release() }, order);
+      },
+      [](WeakWrapper<ScriptedPlayer>& player, WeakWrapper<CardAction>& cardAction, ActionOrder order) {
+        player.Unwrap()->AddAction(CardEvent{ cardAction.Release() }, order);
+      }
+    ),
     "is_sliding", [](WeakWrapper<ScriptedPlayer>& player) -> bool {
       return player.Unwrap()->IsSliding();
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedSpell.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedSpell.cpp
@@ -200,6 +200,12 @@ void DefineScriptedSpellUserType(sol::table& battle_namespace) {
     "shake_camera", [](WeakWrapper<ScriptedSpell>& spell, double power, float duration) {
       spell.Unwrap()->ShakeCamera(power, duration);
     },
+    "get_offset", [](WeakWrapper<ScriptedSpell>& spell) -> sf::Vector2f {
+      return spell.Unwrap()->GetDrawOffset();
+    },
+    "set_offset", [](WeakWrapper<ScriptedSpell>& spell, float x, float y) {
+      spell.Unwrap()->SetDrawOffset(x, y);
+    },
     "never_flip", [](WeakWrapper<ScriptedSpell>& spell, bool enabled) {
       spell.Unwrap()->NeverFlip(enabled);
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedSpell.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedSpell.cpp
@@ -200,12 +200,6 @@ void DefineScriptedSpellUserType(sol::table& battle_namespace) {
     "shake_camera", [](WeakWrapper<ScriptedSpell>& spell, double power, float duration) {
       spell.Unwrap()->ShakeCamera(power, duration);
     },
-    "get_position", [](WeakWrapper<ScriptedSpell>& spell) -> sf::Vector2f {
-      return spell.Unwrap()->GetDrawOffset();
-    },
-    "set_position", [](WeakWrapper<ScriptedSpell>& spell, float x, float y) {
-      spell.Unwrap()->SetDrawOffset(x, y);
-    },
     "never_flip", [](WeakWrapper<ScriptedSpell>& spell, bool enabled) {
       spell.Unwrap()->NeverFlip(enabled);
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedSpell.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedSpell.cpp
@@ -145,9 +145,10 @@ void DefineScriptedSpellUserType(sol::table& battle_namespace) {
       return spell.Unwrap()->IsMoving();
     },
     "is_deleted", [](WeakWrapper<ScriptedSpell>& spell) -> bool {
-      return spell.Unwrap()->IsDeleted();
+      auto ptr = spell.Lock();
+      return !ptr || ptr->IsDeleted();
     },
-    "will_remove_eof", [](WeakWrapper<ScriptedSpell>& spell) -> bool {
+    "will_erase_eof", [](WeakWrapper<ScriptedSpell>& spell) -> bool {
       auto ptr = spell.Lock();
       return !ptr || ptr->WillRemoveLater();
     },
@@ -157,7 +158,7 @@ void DefineScriptedSpellUserType(sol::table& battle_namespace) {
     "get_team", [](WeakWrapper<ScriptedSpell>& spell) -> Team {
       return spell.Unwrap()->GetTeam();
     },
-    "remove", [](WeakWrapper<ScriptedSpell>& spell) {
+    "erase", [](WeakWrapper<ScriptedSpell>& spell) {
       spell.Unwrap()->Remove();
     },
     "delete", [](WeakWrapper<ScriptedSpell>& spell) {

--- a/BattleNetwork/bindings/bnUserTypeScriptedSpell.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedSpell.cpp
@@ -150,7 +150,7 @@ void DefineScriptedSpellUserType(sol::table& battle_namespace) {
     },
     "will_erase_eof", [](WeakWrapper<ScriptedSpell>& spell) -> bool {
       auto ptr = spell.Lock();
-      return !ptr || ptr->WillRemoveLater();
+      return !ptr || ptr->WillEraseEOF();
     },
     "is_team", [](WeakWrapper<ScriptedSpell>& spell, Team team) -> bool {
       return spell.Unwrap()->Teammate(team);
@@ -159,7 +159,7 @@ void DefineScriptedSpellUserType(sol::table& battle_namespace) {
       return spell.Unwrap()->GetTeam();
     },
     "erase", [](WeakWrapper<ScriptedSpell>& spell) {
-      spell.Unwrap()->Remove();
+      spell.Unwrap()->Erase();
     },
     "delete", [](WeakWrapper<ScriptedSpell>& spell) {
       spell.Unwrap()->Delete();

--- a/BattleNetwork/bindings/bnUserTypeSpriteNode.cpp
+++ b/BattleNetwork/bindings/bnUserTypeSpriteNode.cpp
@@ -46,7 +46,7 @@ void DefineSpriteNodeUserType(sol::table& engine_namespace) {
     "remove_tags", [](WeakWrapper<SpriteProxyNode>& node, std::initializer_list<std::string> tags) {
       node.Unwrap()->RemoveTags(tags);
     },
-    "has_tags", [](WeakWrapper<SpriteProxyNode>& node, const std::string& tag) -> bool{
+    "has_tag", [](WeakWrapper<SpriteProxyNode>& node, const std::string& tag) -> bool{
       return node.Unwrap()->HasTag(tag);
     },
     "find_child_nodes_with_tags", [](WeakWrapper<SpriteProxyNode>& node, std::vector<std::string> tags) {

--- a/BattleNetwork/bindings/bnUserTypeSpriteNode.cpp
+++ b/BattleNetwork/bindings/bnUserTypeSpriteNode.cpp
@@ -60,10 +60,10 @@ void DefineSpriteNodeUserType(sol::table& engine_namespace) {
 
       return sol::as_table(result);
     },
-    "get_position", [](WeakWrapper<SpriteProxyNode>& node) -> sf::Vector2f {
+    "get_offset", [](WeakWrapper<SpriteProxyNode>& node) -> sf::Vector2f {
       return node.Unwrap()->getPosition();
     },
-    "set_position", [](WeakWrapper<SpriteProxyNode>& node, float x, float y) {
+    "set_offset", [](WeakWrapper<SpriteProxyNode>& node, float x, float y) {
       node.Unwrap()->setPosition(x, y);
     },
     "get_origin", [](WeakWrapper<SpriteProxyNode>& node) -> sf::Vector2f {

--- a/BattleNetwork/bnBuster.cpp
+++ b/BattleNetwork/bnBuster.cpp
@@ -83,7 +83,7 @@ bool Buster::CanMoveTo(Battle::Tile * next)
 
 void Buster::OnDelete()
 {
-  Remove();
+  Erase();
 }
 
 void Buster::OnCollision(const std::shared_ptr<Entity> entity)

--- a/BattleNetwork/bnBusterHit.cpp
+++ b/BattleNetwork/bnBusterHit.cpp
@@ -41,7 +41,7 @@ void BusterHit::OnUpdate(double _elapsed) {
 
 void BusterHit::OnDelete()
 {
-  Remove();
+  Erase();
 }
 
 BusterHit::~BusterHit()

--- a/BattleNetwork/bnDelayedAttack.cpp
+++ b/BattleNetwork/bnDelayedAttack.cpp
@@ -31,5 +31,5 @@ void DelayedAttack::Attack(std::shared_ptr<Entity> _entity)
 
 void DelayedAttack::OnDelete()
 {
-  Remove();
+  Erase();
 }

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -672,18 +672,18 @@ void Entity::Delete()
   OnDelete();
 }
 
-void Entity::Remove()
+void Entity::Erase()
 {
-  flagForRemove = true;
+  flagForErase = true;
 }
 
 bool Entity::IsDeleted() const {
   return deleted;
 }
 
-bool Entity::WillRemoveLater() const
+bool Entity::WillEraseEOF() const
 {
-    return flagForRemove;
+    return flagForErase;
 }
 
 void Entity::SetElement(Element _elem)

--- a/BattleNetwork/bnEntity.h
+++ b/BattleNetwork/bnEntity.h
@@ -150,7 +150,7 @@ public:
   * @brief Performs some user-specified deletion behavior before removing from play
   *
   * Deleted entities are excluded from all battle attack steps however they 
-  * will be visually present and must be removed from field by calling Remove()
+  * will be visually present and must be erased from field by calling Erase()
   */
   virtual void OnDelete() { };
 
@@ -410,10 +410,10 @@ public:
   /**
   * @brief Flags the entity to be pruned from the field 
   */
-  void Remove();
+  void Erase();
   
   /**
-   * @brief Query if an entity has been deleted but not removed this frame
+   * @brief Query if an entity has been deleted but not erased this frame
    * @return true if flagged for deletion, false otherwise
    */
   bool IsDeleted() const;
@@ -422,7 +422,7 @@ public:
   * @brief Query if an entity has been marked for removal
   * @return true if flagged, false otherwise
   */
-  bool WillRemoveLater() const;
+  bool WillEraseEOF() const;
 
   /**
    * @brief Changes the element of the entity
@@ -798,7 +798,7 @@ private:
   bool airShoe{};
   bool slidesOnTiles{true}; /* by default everything responds to tile push/slide events */
   bool deleted{}; /*!< Used to trigger OnDelete() callback and exclude entity from most update routines*/
-  bool flagForRemove{}; /*!< Used to remove this entity from the field immediately */
+  bool flagForErase{}; /*!< Used to erase this entity from the field immediately */
   int moveCount{}; /*!< Used by battle results */
   double elapsedMoveTime{}; /*!< delta time since recent move event began */
   Direction direction{};

--- a/BattleNetwork/bnExplodeState.h
+++ b/BattleNetwork/bnExplodeState.h
@@ -104,7 +104,7 @@ void ExplodeState<Any>::OnUpdate(double _elapsed, Any& e) {
     explosion->Update(_elapsed);
 
     if (explosion->IsSequenceComplete()) {
-      e.Remove();
+      e.Erase();
     }
   }
 }

--- a/BattleNetwork/bnExplosion.cpp
+++ b/BattleNetwork/bnExplosion.cpp
@@ -94,7 +94,7 @@ void Explosion::OnUpdate(double _elapsed) {
 
 void Explosion::OnDelete()
 {
-  Remove();
+  Erase();
 }
 
 void Explosion::OnSpawn(Battle::Tile& start)

--- a/BattleNetwork/bnHitboxSpell.cpp
+++ b/BattleNetwork/bnHitboxSpell.cpp
@@ -47,5 +47,5 @@ void HitboxSpell::AddCallback(std::function<void(std::shared_ptr<Entity>)> attac
 
 void HitboxSpell::OnDelete()
 {
-  Remove();
+  Erase();
 }

--- a/BattleNetwork/bnMob.h
+++ b/BattleNetwork/bnMob.h
@@ -217,7 +217,7 @@ public:
 
   /**
    * @brief Query if all the enemies have been deleted
-   * @return true if all mobs are marked for removal from play via WillRemoveLater() == true
+   * @return true if all mobs are marked for removal from play via WillEraseEOF() == true
    */
   const bool IsCleared();
 

--- a/BattleNetwork/bnMobMoveEffect.cpp
+++ b/BattleNetwork/bnMobMoveEffect.cpp
@@ -40,7 +40,7 @@ void MobMoveEffect::OnUpdate(double _elapsed) {
 
 void MobMoveEffect::OnDelete()
 {
-  Remove();
+  Erase();
 }
 
 void MobMoveEffect::SetOffset(const sf::Vector2f& offset)

--- a/BattleNetwork/bnNaviExplodeState.h
+++ b/BattleNetwork/bnNaviExplodeState.h
@@ -93,7 +93,7 @@ void NaviExplodeState<Any>::OnUpdate(double _elapsed, Any& e) {
   ExplodeState<Any>::OnUpdate(_elapsed, e);
 
   if (ExplodeState<Any>::explosion->IsSequenceComplete()) {
-    shine->Remove();
+    shine->Erase();
   }
 }
 

--- a/BattleNetwork/bnNaviWhiteoutState.h
+++ b/BattleNetwork/bnNaviWhiteoutState.h
@@ -81,7 +81,7 @@ void NaviWhiteoutState<Any>::OnEnter(Any& e) {
     auto animComponent = shine->GetFirstComponent<AnimationComponent>();
     std::string animStr = animComponent->GetAnimationString();
     animComponent->SetAnimation(animStr, [this]() {
-        shine->Remove();
+        shine->Erase();
         fadeout = true;
         ResourceHandle().Audio().Play(AudioType::DELETED);
     });
@@ -112,7 +112,7 @@ void NaviWhiteoutState<Any>::OnUpdate(double _elapsed, Any& e) {
 
     if (factor <= 0.f) {
         factor = 0.f;
-        e.Remove();
+        e.Erase();
     }
 }
 

--- a/BattleNetwork/bnParticlePoof.cpp
+++ b/BattleNetwork/bnParticlePoof.cpp
@@ -40,7 +40,7 @@ void ParticlePoof::OnUpdate(double _elapsed) {
 
 void ParticlePoof::OnDelete()
 {
-  Remove();
+  Erase();
 }
 
 ParticlePoof::~ParticlePoof()

--- a/BattleNetwork/bnPlayerHealthUI.cpp
+++ b/BattleNetwork/bnPlayerHealthUI.cpp
@@ -65,7 +65,7 @@ void PlayerHealthUI::OnUpdate(double elapsed) {
   isBattleOver = this->Injected()? this->Scene()->IsCleared() : true;
 
   if (auto player = GetOwnerAs<Player>()) {
-    if (player->WillRemoveLater()) {
+    if (player->WillEraseEOF()) {
       this->Eject();
       player = nullptr;
       return;

--- a/BattleNetwork/bnScriptResourceManager.cpp
+++ b/BattleNetwork/bnScriptResourceManager.cpp
@@ -712,6 +712,9 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
   );
 
   const auto& hitbox_props_record = state.new_usertype<Hit::Properties>("HitProps",
+    sol::factories([](int damage, Hit::Flags flags, Element element, Entity::ID_t aggressor, Hit::Drag drag) {
+      return Hit::Properties{ damage, flags, element, aggressor, drag };
+    }),
     "aggressor", &Hit::Properties::aggressor,
     "damage", &Hit::Properties::damage,
     "drag", &Hit::Properties::drag,
@@ -754,12 +757,6 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
   const auto& colormode_record = state.new_enum("ColorMode",
     "Multiply", ColorMode::multiply,
     "Additive", ColorMode::additive
-  );
-
-  state.set_function("make_hit_props",
-    [](int damage, Hit::Flags flags, Element element, Entity::ID_t aggressor, Hit::Drag drag) {
-        return Hit::Properties{ damage, flags, element, aggressor, drag };
-    }
   );
 
   const auto& move_event_record = state.new_usertype<MoveEvent>("MoveEvent",

--- a/BattleNetwork/bnScriptResourceManager.cpp
+++ b/BattleNetwork/bnScriptResourceManager.cpp
@@ -554,6 +554,10 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
   );
 
   const auto& direction_table = state.new_enum("Direction",
+    "flip_x", [](Direction direction) { return FlipHorizontal(direction); },
+    "flip_y", [](Direction direction) { return FlipVertical(direction); },
+    "reverse", [](Direction direction) { return Reverse(direction); },
+    "join", [](Direction a, Direction b) { return Join(a, b); },
     "None", Direction::none,
     "Up", Direction::up,
     "Down", Direction::down,
@@ -714,6 +718,11 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
   );
 
   const auto& hitbox_drag_prop_record = state.new_usertype<Hit::Drag>("Drag",
+    sol::factories(
+      [] (Direction dir, unsigned count) { return Hit::Drag{ dir, count }; },
+      [] { return Hit::Drag{ Direction::none, 0 }; }
+    ),
+    "None", sol::property([] { return Hit::Drag{ Direction::none, 0 }; }),
     sol::meta_function::index, []( sol::table table, const std::string key ) { 
       ScriptResourceManager::PrintInvalidAccessMessage( table, "Drag", key );
     },
@@ -745,23 +754,16 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
     "Additive", ColorMode::additive
   );
 
-  state.set_function("drag",
-    [](Direction dir, unsigned count) { return Hit::Drag{ dir, count }; }
-  );
-
-  state.set_function("no_drag",
-    []() { return Hit::Drag{ Direction::none, 0 }; }
-  );
-
   state.set_function("make_hit_props",
     [](int damage, Hit::Flags flags, Element element, Entity::ID_t aggressor, Hit::Drag drag) {
         return Hit::Properties{ damage, flags, element, aggressor, drag };
     }
   );
 
-  state.set_function("create_move_event", []() { return MoveEvent{}; } );
-
   const auto& move_event_record = state.new_usertype<MoveEvent>("MoveEvent",
+    sol::factories([] {
+      return MoveEvent{};
+    }),
     "delta_frames", &MoveEvent::deltaFrames,
     "delay_frames", &MoveEvent::delayFrames,
     "endlag_frames",&MoveEvent::endlagFrames,
@@ -813,18 +815,6 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
   );
 
   state.set_function( "make_frame_data", &CreateFrameData );
-
-  state.set_function("reverse_dir",
-    [](Direction dir) { return Reverse(dir); }
-  );
-
-  state.set_function("flip_x_dir",
-    [](Direction dir) { return FlipHorizontal(dir);  }
-  );
-
-  state.set_function("flip_y_dir",
-    [](Direction dir) { return FlipVertical(dir);  }
-  );
 
   engine_namespace.set_function("define_library",
     [this]( const std::string& fqn, const std::string& path )

--- a/BattleNetwork/bnSharedHitbox.cpp
+++ b/BattleNetwork/bnSharedHitbox.cpp
@@ -21,7 +21,7 @@ void SharedHitbox::OnUpdate(double _elapsed) {
   tile->AffectEntities(*this);
 
   if (auto owner = this->owner.lock()) {
-    if (owner->IsDeleted() || owner->WillRemoveLater()) {
+    if (owner->IsDeleted() || owner->WillEraseEOF()) {
       Delete();
     }
     else if (!keepAlive && cooldown <= 0.f ) {
@@ -48,7 +48,7 @@ void SharedHitbox::Attack(std::shared_ptr<Entity> _entity) {
 
 void SharedHitbox::OnDelete()
 {
-  Remove();
+  Erase();
 }
 
 void SharedHitbox::OnSpawn(Battle::Tile& start)

--- a/BattleNetwork/bnTile.cpp
+++ b/BattleNetwork/bnTile.cpp
@@ -897,7 +897,7 @@ namespace Battle {
         if (character && deletingCharacters.find(character) == deletingCharacters.end()) {
           field.CharacterDeletePublisher::Broadcast(*character);
 
-          if (ptr->WillRemoveLater()) {
+          if (ptr->WillEraseEOF()) {
             // prevent this entity from being broadcast again while any deletion animations take place
             // TODO: this could be written better
             deletingCharacters.insert(character);
@@ -906,7 +906,7 @@ namespace Battle {
       }
 
       // If the entity is marked for removal
-      if (ptr->WillRemoveLater()) {
+      if (ptr->WillEraseEOF()) {
         if (RemoveEntityByID(ID)) {
           // Don't track this entity anymore
           field.ForgetEntity(ID);

--- a/BattleNetwork/bnVolcanoErupt.cpp
+++ b/BattleNetwork/bnVolcanoErupt.cpp
@@ -7,7 +7,7 @@ VolcanoErupt::VolcanoErupt() :
 {
   eruptAnim = Animation("resources/tiles/volcano.animation");
   eruptAnim << "ERUPT"  << [this]() {
-    this->Remove();
+    this->Erase();
   };;
   
   setScale(2.f, 2.f);

--- a/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
+++ b/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
@@ -252,7 +252,7 @@ void NetworkBattleScene::onUpdate(double elapsed) {
     packetTime += elapsed_frames;
   }
 
-  if (remotePlayer && remotePlayer->WillRemoveLater()) {
+  if (remotePlayer && remotePlayer->WillEraseEOF()) {
     auto iter = std::find(players.begin(), players.end(), remotePlayer);
     if (iter != players.end()) {
       players.erase(iter);


### PR DESCRIPTION
Feel free to reject this PR, the goal is to get these suggestions out of the way in any form so they don't pop up later.

Changes:
- Removed `get_position` and `set_position` from entities
  - `get_position` + `set_position` are easily confused with tile position and make more sense in the context of working with the sprite
  - Did not seem as useful as other shorthands such as `set_texture` and `get_texture`
 - Reduced floating functions
   - Moved *_dir functions onto Direction. ex: `flip_x_dir` is `Direction.flip_x(direction)`
   - Replaced `create_move_event` with `MoveEvent.new()`
   - Replaced `drag(direction, count)` with `Drag.new(direction, count)`
   - Replaced `no_drag()` with `Drag.new()` and `Drag.None`

 Remaining issues I don't really mind leaving in:
 - `delete`/`is_deleted` is very confusing. Does not tell you if the entity is deleted from memory, just that it's in a dying state/exploding. `kill`/`was_killed` makes more sense to me.
 - `remove` is very confusing. Sounds as if I am removing the entity from the field temporarily, rather than queuing deleting/freeing.
 - `set_animation` does not mirror `get_animation`. Seems fine, it seems to replace the animation anyway. We could also just add taking in an actual animation as an overload if we ever wanted to.
 - `make_hit_props` could be a constructor/`HitProps.new`
 - `entity:shake_camera` might make more sense somewhere else.