### PR TITLE
Fixes and scripting additions

### DIFF
--- a/BattleNetwork/bindings/bnUserTypeAnimation.cpp
+++ b/BattleNetwork/bindings/bnUserTypeAnimation.cpp
@@ -76,7 +76,7 @@ void DefineAnimationUserType(sol::state& state, sol::table& engine_namespace) {
         }
       };
     },
-    "on_frame", [](AnimationWrapper& animation, int frame, sol::stack_object callbackObject, bool doOnce) {
+    "on_frame", [](AnimationWrapper& animation, int frame, sol::stack_object callbackObject, std::optional<bool> doOnce) {
       sol::protected_function callback = callbackObject;
       animation.Unwrap().AddCallback(frame, [callback] {
         auto result = callback();
@@ -85,7 +85,7 @@ void DefineAnimationUserType(sol::state& state, sol::table& engine_namespace) {
           sol::error error = result;
           Logger::Log(error.what());
         }
-      }, doOnce);
+      }, doOnce.value_or(false));
     },
     "on_interrupt", [](AnimationWrapper& animation, sol::stack_object callbackObject) {
       sol::protected_function callback = callbackObject;

--- a/BattleNetwork/bindings/bnUserTypeField.cpp
+++ b/BattleNetwork/bindings/bnUserTypeField.cpp
@@ -11,7 +11,7 @@
 #include "bnScriptedObstacle.h"
 #include "bnScriptedArtifact.h"
 
-static sol::as_table_t<std::vector<WeakWrapper<Character>>> FindNearestCharacters(WeakWrapper<Field>& field, std::shared_ptr<Character> test, sol::stack_object queryObject) {
+static sol::as_table_t<std::vector<WeakWrapper<Character>>> FindNearestCharacters(WeakWrapper<Field>& field, std::shared_ptr<Entity> test, sol::stack_object queryObject) {
   sol::protected_function query = queryObject;
 
   auto results = field.Unwrap()->FindNearestCharacters(test, [query] (std::shared_ptr<Character>& character) -> bool {
@@ -118,6 +118,9 @@ void DefineFieldUserType(sol::table& battle_namespace) {
       return sol::as_table(wrappedResults);
     },
     "find_nearest_characters", sol::overload(
+      [] (WeakWrapper<Field>& field, WeakWrapper<Entity>& test, sol::stack_object queryObject) {
+        return FindNearestCharacters(field, test.Unwrap(), queryObject);
+      },
       [] (WeakWrapper<Field>& field, WeakWrapper<Character>& test, sol::stack_object queryObject) {
         return FindNearestCharacters(field, test.Unwrap(), queryObject);
       },
@@ -125,6 +128,15 @@ void DefineFieldUserType(sol::table& battle_namespace) {
         return FindNearestCharacters(field, test.Unwrap(), queryObject);
       },
       [] (WeakWrapper<Field>& field, WeakWrapper<ScriptedPlayer>& test, sol::stack_object queryObject) {
+        return FindNearestCharacters(field, test.Unwrap(), queryObject);
+      },
+      [] (WeakWrapper<Field>& field, WeakWrapper<ScriptedObstacle>& test, sol::stack_object queryObject) {
+        return FindNearestCharacters(field, test.Unwrap(), queryObject);
+      },
+      [] (WeakWrapper<Field>& field, WeakWrapper<ScriptedSpell>& test, sol::stack_object queryObject) {
+        return FindNearestCharacters(field, test.Unwrap(), queryObject);
+      },
+      [] (WeakWrapper<Field>& field, WeakWrapper<ScriptedArtifact>& test, sol::stack_object queryObject) {
         return FindNearestCharacters(field, test.Unwrap(), queryObject);
       }
     ),

--- a/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedArtifact.cpp
@@ -168,6 +168,12 @@ void DefineScriptedArtifactUserType(sol::table& battle_namespace) {
       auto& animation = artifact.Unwrap()->GetAnimationObject();
       return AnimationWrapper(artifact.GetWeak(), animation);
     },
+    "create_node", [](WeakWrapper<ScriptedArtifact>& artifact) -> WeakWrapper<SpriteProxyNode> {
+      auto child = std::make_shared<SpriteProxyNode>();
+      artifact.Unwrap()->AddNode(child);
+
+      return WeakWrapper(child);
+    },
     "set_height", [](WeakWrapper<ScriptedArtifact>& artifact, float height) {
       artifact.Unwrap()->SetHeight(height);
     },

--- a/BattleNetwork/bindings/bnUserTypeScriptedCardAction.cpp
+++ b/BattleNetwork/bindings/bnUserTypeScriptedCardAction.cpp
@@ -57,9 +57,16 @@ void DefineScriptedCardActionUserType(sol::table& battle_namespace) {
       auto& attachment = cardActionPtr->AddAttachment(point);
       return CardActionAttachmentWrapper(cardAction.GetWeak(), attachment);
     },
-    "add_anim_action", [](WeakWrapper<ScriptedCardAction>& cardAction, int frame, sol::stack_object actionObject) {
-      sol::protected_function action = actionObject;
-      cardAction.Unwrap()->AddAnimAction(frame, [action]{ action(); });
+    "add_anim_action", [](WeakWrapper<ScriptedCardAction>& cardAction, int frame, sol::stack_object callbackObject) {
+      sol::protected_function callback = callbackObject;
+      cardAction.Unwrap()->AddAnimAction(frame, [callback] {
+        auto result = callback();
+
+        if (!result.valid()) {
+          sol::error error = result;
+          Logger::Log(error.what());
+        }
+      });
     },
     "add_step", [](WeakWrapper<ScriptedCardAction>& cardAction, const CardAction::Step& step) {
       cardAction.Unwrap()->AddStep(step);

--- a/BattleNetwork/bindings/bnUserTypeSpriteNode.cpp
+++ b/BattleNetwork/bindings/bnUserTypeSpriteNode.cpp
@@ -76,9 +76,19 @@ void DefineSpriteNodeUserType(sol::table& engine_namespace) {
       auto self = node.Unwrap();
       return self->getLocalBounds().width * self->getScale().x;
     },
+    "set_width", [](WeakWrapper<SpriteProxyNode>& node, float width) {
+      auto self = node.Unwrap();
+      auto scaleX = width / self->getLocalBounds().width;
+      self->setScale(scaleX, self->getScale().y);
+    },
     "get_height", [](WeakWrapper<SpriteProxyNode>& node) -> float {
       auto self = node.Unwrap();
       return self->getLocalBounds().height * self->getScale().y;
+    },
+    "set_height", [](WeakWrapper<SpriteProxyNode>& node, float height) {
+      auto self = node.Unwrap();
+      auto scaleY = height / self->getLocalBounds().height;
+      self->setScale(self->getScale().x, scaleY);
     },
     "get_color", [](WeakWrapper<SpriteProxyNode>& node) -> sf::Color {
       return node.Unwrap()->getColor();

--- a/BattleNetwork/bnAnimation.cpp
+++ b/BattleNetwork/bnAnimation.cpp
@@ -240,20 +240,8 @@ void Animation::LoadWithData(const string& data)
         currentHeight = GetIntValue(line, "h");
         originX = (float)GetIntValue(line, "originx");
         originY = (float)GetIntValue(line, "originy");
-
-        if (GetBoolValue(line, "flipy")) {
-          flipY = true;
-        }
-        else {
-          flipY = false;
-        }
-
-        if (GetBoolValue(line, "flipx")) {
-          flipX = true;
-        }
-        else {
-          flipX = false;
-        }
+        flipX = GetBoolValue(line, "flipx");
+        flipY = GetBoolValue(line, "flipy");
       }
 
       currentAnimationDuration += currentFrameDuration;

--- a/BattleNetwork/bnAnimation.cpp
+++ b/BattleNetwork/bnAnimation.cpp
@@ -95,6 +95,13 @@ static std::string_view GetValue(std::string_view line, std::string_view key) {
     }
 
     size_t posAfterKey = keyPos + key.size();
+
+    if (keyPos > 0 && line[keyPos - 1] != ' ') {
+      // space or start of line must be before the key
+      keySearchStart += posAfterKey;
+      continue;
+    }
+
     size_t equalPos = GetNextCharPos(line, posAfterKey);
 
     if (equalPos == std::string::npos || line[equalPos] != '=') {

--- a/BattleNetwork/bnAnimation.h
+++ b/BattleNetwork/bnAnimation.h
@@ -203,13 +203,6 @@ public:
   }
 
 private:
-  /**
-   * @brief Strips the key-value from a file format
-   * @param _key to look for value of
-   * @param _line string input
-   * @return value as string or empty string
-   */
-  string ValueOf(string _key, string _line);
   void HandleInterrupted();
 protected:
   bool noAnim{ false }; /*!< If the requested state was not found, hide the sprite when updating */

--- a/BattleNetwork/bnCardAction.cpp
+++ b/BattleNetwork/bnCardAction.cpp
@@ -44,6 +44,11 @@ CardAction::CardAction(std::weak_ptr<Character> actor, const std::string& animat
         RecallPreviousState();
       });
 
+      // add animation callbacks
+      for (auto& [frame, action] : animActions) {
+        anim->AddCallback(frame, action);
+      }
+
       this->animationIsOver = false;
       anim->OnUpdate(0);
     };
@@ -69,7 +74,12 @@ void CardAction::AddStep(Step step)
 
 void CardAction::AddAnimAction(int frame, const FrameCallback& action) {
   Logger::Logf("AddAnimAction() called");
-  anim->AddCallback(frame, action);
+
+  animActions.emplace_back(frame, action);
+
+  if (started) {
+    anim->AddCallback(frame, action);
+  }
 }
 
 sf::Vector2f CardAction::CalculatePointOffset(const std::string& point) {
@@ -149,6 +159,11 @@ void CardAction::OverrideAnimationFrames(std::list<OverrideFrame> frameData)
       anim->SetInterruptCallback([this]() {
         RecallPreviousState();
       });
+
+      // add animation callbacks
+      for (auto& [frame, action] : animActions) {
+        anim->AddCallback(frame, action);
+      }
 
       this->animationIsOver = false;
       anim->OnUpdate(0);

--- a/BattleNetwork/bnCardAction.h
+++ b/BattleNetwork/bnCardAction.h
@@ -102,6 +102,7 @@ private:
   Attachments attachments;
   std::shared_ptr<AnimationComponent> anim{ nullptr };
   Battle::Card::Properties meta;
+  std::vector<std::pair<int, FrameCallback>> animActions;
 
   // Used internally
   void RecallPreviousState();

--- a/BattleNetwork/bnConfigScene.cpp
+++ b/BattleNetwork/bnConfigScene.cpp
@@ -344,7 +344,9 @@ ConfigScene::ConfigScene(swoosh::ActivityController& controller) :
   setView(sf::Vector2u(480, 320));
 }
 
-ConfigScene::~ConfigScene() { }
+ConfigScene::~ConfigScene() {
+  delete bg;
+}
 
 void ConfigScene::UpdateBgmVolume(int volumeLevel) {
   musicLevel = volumeLevel;

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -238,10 +238,10 @@ void Entity::Spawn(Battle::Tile& start)
       SetFacing(start.GetFacing());
     }
 
+    hasSpawned = true;
+
     OnSpawn(start);
   }
-
-  hasSpawned = true;
 }
 
 bool Entity::HasSpawned() {
@@ -752,6 +752,10 @@ void Entity::SetField(std::shared_ptr<Field> _field) {
 
 std::shared_ptr<Field> Entity::GetField() const {
   return field.lock();
+}
+
+bool Entity::IsOnField() const {
+  return !field.expired();
 }
 
 Team Entity::GetTeam() const {

--- a/BattleNetwork/bnEntity.h
+++ b/BattleNetwork/bnEntity.h
@@ -317,6 +317,8 @@ public:
    */
   std::shared_ptr<Field> GetField() const;
 
+  bool IsOnField() const;
+
   /**
    * @brief Gets the entity's assigned team
    * @return Current Team

--- a/BattleNetwork/bnField.cpp
+++ b/BattleNetwork/bnField.cpp
@@ -275,7 +275,7 @@ std::vector<std::shared_ptr<Character>> Field::FindCharacters(std::function<bool
   return res;
 }
 
-std::vector<std::shared_ptr<Character>> Field::FindNearestCharacters(const std::shared_ptr<Character> test, std::function<bool(std::shared_ptr<Character>& e)> filter) const
+std::vector<std::shared_ptr<Character>> Field::FindNearestCharacters(const std::shared_ptr<Entity> test, std::function<bool(std::shared_ptr<Character>& e)> filter) const
 {
   auto list = this->FindCharacters(filter);
 

--- a/BattleNetwork/bnField.h
+++ b/BattleNetwork/bnField.h
@@ -105,12 +105,12 @@ public:
   std::vector<std::shared_ptr<Character>> FindCharacters(std::function<bool(std::shared_ptr<Character>& e)> query) const;
 
   /**
-   * @brief Query for the closest characters on the entire field given an input character.
-   * @param test. The character to test distance againsr.
+   * @brief Query for the closest characters on the entire field given an input entity.
+   * @param test. The entity to test distance against.
    * @param query. the query input function
    * @return list of std::shared_ptr<Character> that passed the input function's conditions
    */
-  std::vector<std::shared_ptr<Character>> FindNearestCharacters(const std::shared_ptr<Character> test, std::function<bool(std::shared_ptr<Character>& e)> query) const;
+  std::vector<std::shared_ptr<Character>> FindNearestCharacters(const std::shared_ptr<Entity> test, std::function<bool(std::shared_ptr<Character>& e)> query) const;
 
   /**
    * @brief Set the tile at (x,y) team to _team

--- a/BattleNetwork/bnScriptResourceManager.cpp
+++ b/BattleNetwork/bnScriptResourceManager.cpp
@@ -613,7 +613,7 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
 
   auto input_event_record = state.create_table("Input");
 
-  const auto& pressed_input_event_record = input_event_record.new_enum("Pressed",
+  input_event_record.new_enum("Pressed",
     "Up", InputEvents::pressed_move_up,
     "Left", InputEvents::pressed_move_left,
     "Right", InputEvents::pressed_move_right,
@@ -623,7 +623,17 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
     "Shoot", InputEvents::pressed_shoot
   );
 
-  const auto& released_input_event_record = input_event_record.new_enum("Released",
+  input_event_record.new_enum("Held",
+    "Up", InputEvents::held_move_up,
+    "Left", InputEvents::held_move_left,
+    "Right", InputEvents::held_move_right,
+    "Down", InputEvents::held_move_down,
+    "Use", InputEvents::held_use_chip,
+    "Special", InputEvents::held_special,
+    "Shoot", InputEvents::held_shoot
+  );
+
+  input_event_record.new_enum("Released",
     "Up", InputEvents::released_move_up,
     "Left", InputEvents::released_move_left,
     "Right", InputEvents::released_move_right,

--- a/BattleNetwork/bnScriptResourceManager.cpp
+++ b/BattleNetwork/bnScriptResourceManager.cpp
@@ -300,11 +300,21 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
       sol::protected_function luaCollisionCallback = luaCollisionCallbackObject;
 
       auto attackCallback = [luaAttackCallback] (std::shared_ptr<Entity> e) {
-        luaAttackCallback(WeakWrapper(e));
+        auto result = luaAttackCallback(WeakWrapper(e));
+
+        if (!result.valid()) {
+          sol::error error = result;
+          Logger::Log(error.what());
+        }
       };
 
       auto collisionCallback = [luaCollisionCallback] (const std::shared_ptr<Entity> e) {
-        luaCollisionCallback(WeakWrapper(e));
+        auto result = luaCollisionCallback(WeakWrapper(e));
+
+        if (!result.valid()) {
+          sol::error error = result;
+          Logger::Log(error.what());
+        }
       };
 
       spell.Unwrap()->AddCallback(attackCallback, collisionCallback);
@@ -771,7 +781,14 @@ void ScriptResourceManager::ConfigureEnvironment(sol::state& state) {
     "on_begin_func", sol::property(
       [](MoveEvent& event, sol::stack_object onBeginObject) {
         sol::protected_function onBegin = onBeginObject;
-        event.onBegin = [onBegin] { onBegin(); };
+        event.onBegin = [onBegin] {
+          auto result = onBegin();
+
+          if (!result.valid()) {
+            sol::error error = result;
+            Logger::Log(error.what());
+          }
+        };
       }
     )
   );

--- a/BattleNetwork/bnTile.cpp
+++ b/BattleNetwork/bnTile.cpp
@@ -403,6 +403,14 @@ namespace Battle {
       return;
     }
 
+    if (!_entity->IsOnField()) {
+      throw std::runtime_error("Entity must be spawned on the field before adding directly to a tile");
+    }
+
+    if (_entity->WillEraseEOF()) {
+      return;
+    }
+
     if (auto spell = dynamic_cast<Spell*>(_entity.get())) {
       spells.push_back(spell);
     } else if(auto artifact = dynamic_cast<Artifact*>(_entity.get())) {


### PR DESCRIPTION
Changes:
 - Added set_width and set_height for Lua
 - Made on_frame's doOnce param optional for Lua
 - Adjusted GetNearestCharacters to accept all entities for the test param
 - Added Input.Held for Lua
 - Store CardAction animation callbacks to apply right before execution
   - Previously CardAction animation callbacks added before the execution function would be ignored
 - Fixed crash caused by calling `tile:add_entity` instead of `field:spawn`
 - Fixed ScriptedArtifact missing create_node
 - Fixed some Lua callbacks not logging errors
 - Fixed config background memory leak
 - Adjusted Animation parsing
   - Checks only the start of the line for base keys such as `frame`, `point`, etc
     - Prevents bugs from string values matching base key, and should reduce search time
   - Searches for = and " after key name when grabbing values
     - Prevents more matching key name issues
     - Allows for `x = "1"`
     - Blocks malformed keys such as `x  1"
   - Checks for space or start of line before key
     - Prevents `flipx`/`originx` from matching a search for `x` when similar key is specified before `x`
   - Added support for comments. Ex: `flipx` should now be ignored in a line like this: `frame duration="0" x="0" y="0" w="0" h="0" originx="0" originy="0" #flipx="1"`