### PR TITLE
Fixing an issue with SetState on Tiles.

### DIFF
--- a/BattleNetwork/bnTile.cpp
+++ b/BattleNetwork/bnTile.cpp
@@ -281,8 +281,15 @@ namespace Battle {
   }
 
   void Tile::SetState(TileState _state) {
-    if (IsEdgeTile() || _state == TileState::hidden) {
+    if (IsEdgeTile()) {
+      return;
+    }
+
+    if (_state == TileState::hidden && state != TileState::hidden) {
       state = _state;
+      return;
+    }
+    else if (_state != TileState::hidden && state == TileState::hidden) {
       return;
     }
 


### PR DESCRIPTION
This commit/pull request changes the behavior of SetState so that hidden tiles are set once - when they are turned into hidden tiles - and never again. If they are an edge tile they are not made hidden, as edge tiles should not be invisible at all times anyway.