### PR TITLE
Requested feature of card limit visibility, and text spacing cleanup.

### DIFF
--- a/BattleNetwork/bnFolderEditScene.cpp
+++ b/BattleNetwork/bnFolderEditScene.cpp
@@ -123,6 +123,7 @@ FolderEditScene::FolderEditScene(swoosh::ActivityController& controller, CardFol
     hasFolderChanged(false),
     card(),
     font(Font::Style::wide),
+    limitLabel("NO\nMAX", Font::Style::tiny),
     menuLabel("FOLDER EDIT", font),
     cardFont(Font::Style::thick),
     cardLabel("", cardFont),
@@ -149,8 +150,11 @@ FolderEditScene::FolderEditScene(swoosh::ActivityController& controller, CardFol
     // Battle::Card UI font
     cardLabel.setPosition(275.f, 15.f);
     cardLabel.setScale(2.f, 2.f);
+    numberLabel.setScale(1.6f, 1.6f);
 
-    numberLabel.setScale(1.6, 1.6);
+    limitLabel.setScale(2.f, 2.f);
+    limitLabel.SetLetterSpacing(0.f);
+    limitLabel.SetLineSpacing(1.2f);
 
     // Battle::Card description font
     cardDesc.SetColor(sf::Color::Black);
@@ -179,9 +183,6 @@ FolderEditScene::FolderEditScene(swoosh::ActivityController& controller, CardFol
     packCursor = folderCursor;
     packCursor.setPosition((2.f * 90.f) + 480.0f, 64.0f);
     packSwapCursor = packCursor;
-
-    mbPlaceholder = sf::Sprite(*Textures().LoadFromFile(TexturePaths::FOLDER_MB));
-    mbPlaceholder.setScale(2.f, 2.f);
 
     folderNextArrow = sf::Sprite(*Textures().LoadFromFile(TexturePaths::FOLDER_NEXT_ARROW));
     folderNextArrow.setScale(2.f, 2.f);
@@ -784,9 +785,9 @@ void FolderEditScene::DrawFolder(sf::RenderTarget& surface) {
 
     // Now that we are at the viewing range, draw each card in the list
     for (int i = 0; i < folderView.maxCardsOnScreen && folderView.lastCardOnScreen + i < folderView.numOfCards; i++) {
-        const Battle::Card& copy = iter->ViewCard();
-
         if (!iter->IsEmpty()) {
+            const Battle::Card& copy = iter->ViewCard();
+
             float cardIconY = 66.0f + (32.f * i);
             cardIcon.setTexture(*GetIconForCard(copy.GetUUID()));
             cardIcon.setPosition(2.f * 104.f, cardIconY);
@@ -806,12 +807,17 @@ void FolderEditScene::DrawFolder(sf::RenderTarget& surface) {
             cardLabel.setPosition(2.f * 200.f, cardIconY + 4.0f);
             cardLabel.SetString(std::string() + copy.GetCode());
             surface.draw(cardLabel);
-
-            //Draw MB
-            mbPlaceholder.setPosition(2.f * 210.f, cardIconY + 2.0f);
-            surface.draw(mbPlaceholder);
+            //Draw Card Limit
+            if (copy.GetLimit() > 0) {
+                int limit = copy.GetLimit();
+                limitLabel.SetString(to_string(limit)+"\nMAX");
+            }
+            else {
+                limitLabel.SetString("NO\nMAX");
+            }
+            limitLabel.setPosition(2.f * 210.f, cardIconY+2.f);
+            surface.draw(limitLabel);
         }
-
         // Draw cursor
         if (folderView.lastCardOnScreen + i == folderView.currCardIndex) {
             auto y = swoosh::ease::interpolate((float)frameElapsed * 7.f, folderCursor.getPosition().y, 64.0f + (32.f * i));
@@ -821,7 +827,7 @@ void FolderEditScene::DrawFolder(sf::RenderTarget& surface) {
             surface.draw(folderCursor);
 
             if (!iter->IsEmpty()) {
-
+                const Battle::Card& copy = iter->ViewCard();
                 card.setTexture(*GetPreviewForCard(copy.GetUUID()));
                 card.setScale((float)swoosh::ease::linear(cardRevealTimer.getElapsed().asSeconds(), 0.25f, 1.0f) * 2.0f, 2.0f);
                 surface.draw(card);
@@ -852,7 +858,6 @@ void FolderEditScene::DrawFolder(sf::RenderTarget& surface) {
                 surface.draw(element);
             }
         }
-
         if (folderView.lastCardOnScreen + i == folderView.swapCardIndex && (int(totalTimeElapsed * 1000) % 2 == 0)) {
             auto y = 64.0f + (32.f * i);
 
@@ -914,10 +919,16 @@ void FolderEditScene::DrawPool(sf::RenderTarget& surface) {
         cardLabel.setPosition(216.f + 480.f, 69.0f + (32.f * i));
         cardLabel.SetString(std::string() + copy.GetCode());
         surface.draw(cardLabel);
-
-        //Draw MB
-        mbPlaceholder.setPosition(236.f + 480.f, 67.0f + (32.f * i));
-        surface.draw(mbPlaceholder);
+        //Draw Card Limit
+        if (copy.GetLimit() > 0) {
+            int limit = copy.GetLimit();
+            limitLabel.SetString(to_string(limit) + "\nMAX");
+        }
+        else {
+            limitLabel.SetString("NO\nMAX");
+        }
+        limitLabel.setPosition(236.f + 480.f, 67.0f + (32.f * i));
+        surface.draw(limitLabel);
 
         // Draw count in pack
         cardLabel.setOrigin(0, 0);

--- a/BattleNetwork/bnFolderEditScene.h
+++ b/BattleNetwork/bnFolderEditScene.h
@@ -112,6 +112,8 @@ private:
   Font numberFont;
   Text numberLabel;
 
+  Text limitLabel;
+
   // Card description font
   Font cardDescFont;
   Text cardDesc;
@@ -127,7 +129,6 @@ private:
   sf::Sprite folderNextArrow;
   sf::Sprite packNextArrow;
   sf::Sprite folderCardCountBox;
-  sf::Sprite mbPlaceholder;
 
   // Current card graphic data
   sf::Sprite card;

--- a/BattleNetwork/bnText.cpp
+++ b/BattleNetwork/bnText.cpp
@@ -48,7 +48,6 @@ void Text::UpdateGeometry() const
 
   // Precompute the variables needed by the algorithm
   float whitespaceWidth = font.GetWhiteSpaceWidth();
-  float letterSpacing = 1.0f; //  (whitespaceWidth / 3.f) * (Text::letterSpacing - 1.f);
   whitespaceWidth += letterSpacing;
   float lineSpacing = font.GetLineHeight() * Text::lineSpacing;
   float x = 0.f;
@@ -88,7 +87,7 @@ void Text::UpdateGeometry() const
 
 Text::Text(const Font& font) : font(font), message(""), geometryDirty(true)
 {
-  letterSpacing = (font.GetWhiteSpaceWidth() / 3.0f) + 1.0f;
+  letterSpacing = 1.0f;
   lineSpacing = 1.0f;
   color = sf::Color::White;
   vertices.setPrimitiveType(sf::PrimitiveType::Triangles);
@@ -96,7 +95,7 @@ Text::Text(const Font& font) : font(font), message(""), geometryDirty(true)
 
 Text::Text(const std::string& message, const Font& font) : font(font), message(message), geometryDirty(true)
 {
-  letterSpacing = (font.GetWhiteSpaceWidth()/3.0f) + 1.0f;
+  letterSpacing = 1.0f;
   lineSpacing = 1.0f;
   color = sf::Color::White;
   vertices.setPrimitiveType(sf::PrimitiveType::Triangles);


### PR DESCRIPTION
This Pull Request adds the requested feature of showing card limits in folder & pack.

However, as there were issues with getting the text to space properly, a small tweak to the text bnText.cpp file was required to properly allow the use of SetLetterSpacing, which was previously doing nothing as a local variable was overwriting its effects.

With these changes, N MAX and NO MAX now display at the proper 2x upscaling with legible text and fit within the confines of both the chip pack menu and the folder menu.