### PR TITLE
Fix tile origin

### DIFF
--- a/BattleNetwork/bnMobHealthUI.cpp
+++ b/BattleNetwork/bnMobHealthUI.cpp
@@ -9,6 +9,8 @@ using std::to_string;
 #include "bnLogger.h"
 #include "bnField.h"
 
+#define PIXELS_FROM_BOTTOM 10.0f
+
 MobHealthUI::MobHealthUI(std::weak_ptr<Character> mob) : UIComponent(mob) {
   healthCounter = mob.lock()->GetHealth();
   cooldown = 0;
@@ -113,7 +115,7 @@ void MobHealthUI::draw(sf::RenderTarget & target, sf::RenderStates states) const
 
       auto glyphsRect = sf::IntRect(0, rowStart, 8, 10);
       glyphs.setTextureRect(glyphsRect);
-      glyphs.setPosition(sf::Vector2f(offsetx, 0.0f) + mob->getPosition());
+      glyphs.setPosition(sf::Vector2f(offsetx, PIXELS_FROM_BOTTOM) + mob->getPosition());
       glyphs.setColor(color);
 
       target.draw(glyphs, this_states);

--- a/BattleNetwork/bnTile.cpp
+++ b/BattleNetwork/bnTile.cpp
@@ -21,8 +21,9 @@
 #define TILE_WIDTH 40.0f
 #define TILE_HEIGHT 30.0f
 #define START_X 0.0f
-#define START_Y 144.f
+#define START_Y 134.f
 #define Y_OFFSET 10.0f
+#define TILE_CENTER_Y (TILE_HEIGHT - Y_OFFSET) / 2.0f
 #define COOLDOWN 10.0
 #define FLICKER 3.0
 
@@ -49,7 +50,7 @@ namespace Battle {
     setScale(2.f, 2.f);
     width = TILE_WIDTH * getScale().x;
     height = TILE_HEIGHT * getScale().y;
-    setOrigin(TILE_WIDTH / 2.0f, TILE_HEIGHT / 2.0f);
+    setOrigin(TILE_WIDTH / 2.0f, TILE_CENTER_Y);
     setPosition((width/2.0f) + ((x - 1) * width) + START_X, (height/2.0f) + ((y - 1) * (height - Y_OFFSET)) + START_Y);
     willHighlight = false;
     isTimeFrozen = true;
@@ -572,7 +573,7 @@ namespace Battle {
     }
 
     // animation will want to override the sprite's origin. Use setOrigin() to fix this.
-    setOrigin(TILE_WIDTH / 2.0f, TILE_HEIGHT / 2.0f);
+    setOrigin(TILE_WIDTH / 2.0f, TILE_CENTER_Y);
     highlightMode = TileHighlight::none;
 
     // Process tile behaviors


### PR DESCRIPTION
The center of the tile was calculated as lower than the real center as it used the entire texture height, rather than just the surface height (texture height - overlap height)

Left is the fix, Right is old:
![fixed centers](https://user-images.githubusercontent.com/15239026/146643923-00ab6110-ea85-4222-bf27-7211ecc2f5ce.png)
