### PR TITLE
Development

### DIFF
--- a/BattleNetwork/bnFolderChangeNameScene.cpp
+++ b/BattleNetwork/bnFolderChangeNameScene.cpp
@@ -302,7 +302,7 @@ void FolderChangeNameScene::onDraw(sf::RenderTexture& surface) {
   surface.draw(cursorPieceRight);
 
   bool blink = (int(elapsed * 3000) % 1000) < 500;
-  float labelTop = 18 * 2.f;
+  float labelTop = 18 * 2.f - 2.f;
 
   for (int i = 0; i < name.size(); i++) {
     if(i == letterPos && blink)

--- a/BattleNetwork/bnFolderScene.cpp
+++ b/BattleNetwork/bnFolderScene.cpp
@@ -511,6 +511,9 @@ void FolderScene::onDraw(sf::RenderTexture& surface) {
     for (int i = 0; i < folderNames.size(); i++) {
       CardFolder* folder{ nullptr };
       collection.GetFolder(folderNames[i], folder);
+      if (folder == nullptr) {
+          continue;
+      }
       bool allowed = IsFolderAllowed(folder);
 
       float folderLeft = 26.0f + (i*144.0f) - (float)folderOffsetX;


### PR DESCRIPTION
Requested changes.
-Folder name change text is 2px higher
-Folders now refresh names properly on a name change without a crash.