### PR TITLE
PVP fixes and set_team

### DIFF
--- a/BattleNetwork/bindings/bnUserTypeEntity.h
+++ b/BattleNetwork/bindings/bnUserTypeEntity.h
@@ -211,6 +211,9 @@ void DefineEntityFunctionsOn(sol::basic_usertype<WeakWrapper<E>, sol::basic_refe
   entity_table["is_team"] = [](WeakWrapper<E>& entity, Team team) -> bool {
     return entity.Unwrap()->Teammate(team);
   };
+  entity_table["set_team"] = [](WeakWrapper<E>& entity, Team team) {
+    entity.Unwrap()->SetTeam(team);
+  };
   entity_table["get_team"] = [](WeakWrapper<E>& entity) -> Team {
     return entity.Unwrap()->GetTeam();
   };

--- a/BattleNetwork/bnFolderEditScene.cpp
+++ b/BattleNetwork/bnFolderEditScene.cpp
@@ -774,7 +774,7 @@ void FolderEditScene::DrawFolder(sf::RenderTarget& surface) {
       float scaleFactor = (float)swoosh::ease::linear(cardRevealTimer.getElapsed().asSeconds(), 0.25f, 1.0f);
       float xscale = scaleFactor * 2.f;
 
-      auto interp_position = [scaleFactor, this](sf::Vector2f& pos) {
+      auto interp_position = [scaleFactor, this](sf::Vector2f pos) {
         sf::Vector2f center = card.getPosition();
         pos.x = ((scaleFactor * pos) + ((1.0f - scaleFactor) * center)).x;
         return pos;
@@ -912,7 +912,7 @@ void FolderEditScene::DrawPool(sf::RenderTarget& surface) {
       float scaleFactor = (float)swoosh::ease::linear(cardRevealTimer.getElapsed().asSeconds(), 0.25f, 1.0f);
       float xscale = scaleFactor * 2.f;
 
-      auto interp_position = [scaleFactor, this](sf::Vector2f& pos) {
+      auto interp_position = [scaleFactor, this](sf::Vector2f pos) {
         sf::Vector2f center = card.getPosition();
         pos.x = ((scaleFactor * pos) + ((1.0f - scaleFactor) * center)).x;
         return pos;

--- a/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
+++ b/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
@@ -426,7 +426,7 @@ void NetworkBattleScene::SendHandshakeSignal()
     buffer.append(id.c_str(), len);
   }
 
-  auto [_, id] = packetProcessor->SendPacket(Reliability::Reliable, buffer);
+  auto [_, id] = packetProcessor->SendPacket(Reliability::ReliableOrdered, buffer);
   packetProcessor->UpdateHandshakeID(id);
 }
 

--- a/BattleNetwork/netplay/bnDownloadScene.cpp
+++ b/BattleNetwork/netplay/bnDownloadScene.cpp
@@ -49,6 +49,11 @@ DownloadScene::DownloadScene(swoosh::ActivityController& ac, const DownloadScene
 
   packetProcessor->EnableKickForSilence(true);
 
+  // send handshake + begin coinflip before reading packets
+  SendHandshake();
+  SendCoinFlip();
+
+  // queued packets will come in after this
   packetProcessor->SetPacketBodyCallback([this](NetPlaySignals header, const Poco::Buffer<char>& body) {
     this->ProcessPacketBody(header, body);
   });
@@ -64,10 +69,6 @@ DownloadScene::DownloadScene(swoosh::ActivityController& ac, const DownloadScene
   std::filesystem::create_directories(CACHE_FOLDER);
 
   ResetRemotePartitions();
-
-  // send handshake + begin coinflip before reading packets
-  SendHandshake();
-  SendCoinFlip();
 }
 
 DownloadScene::~DownloadScene()

--- a/BattleNetwork/netplay/bnDownloadScene.h
+++ b/BattleNetwork/netplay/bnDownloadScene.h
@@ -30,7 +30,7 @@ struct DownloadSceneProps;
 class DownloadScene final : public Scene {
 private:
   bool& downloadSuccess;
-  bool downloadFlagSet{}, aborting{}, remoteSuccess{}, remoteHandshake{}, hasTradedData{}, coinFlipComplete{};
+  bool downloadFlagSet{}, transitionSignalSent{}, transitionToPvp{}, aborting{}, remoteSuccess{}, remoteHandshake{}, hasTradedData{}, coinFlipComplete{};
   bool playerPackageRequested{}, cardPackageRequested{}, blockPackageRequested{};
   unsigned& coinFlip;
   unsigned coinValue{};
@@ -67,6 +67,7 @@ private:
   void SendHandshake();
   void SendPing(); //!< keep connections alive while clients download data
   void SendDownloadComplete(bool success);
+  void SendTransition();
   void SendCoinFlip();
 
   // Initiate trades
@@ -89,6 +90,7 @@ private:
   void RecieveRequestCardPackageData(const Poco::Buffer<char>& buffer);
   void RecieveRequestBlockPackageData(const Poco::Buffer<char>& buffer);
   void RecieveDownloadComplete(const Poco::Buffer<char>& buffer);
+  void RecieveTransition(const Poco::Buffer<char>& buffer);
   void RecieveCoinFlip(const Poco::Buffer<char>& buffer);
 
   // Downloads

--- a/BattleNetwork/netplay/bnDownloadScene.h
+++ b/BattleNetwork/netplay/bnDownloadScene.h
@@ -30,9 +30,10 @@ struct DownloadSceneProps;
 class DownloadScene final : public Scene {
 private:
   bool& downloadSuccess;
-  bool downloadFlagSet{}, aborting{}, remoteSuccess{}, remoteHandshake{}, hasTradedData{}, coinFlipComplete{}, remoteCoinFlipComplete{};
+  bool downloadFlagSet{}, aborting{}, remoteSuccess{}, remoteHandshake{}, hasTradedData{}, coinFlipComplete{};
   bool playerPackageRequested{}, cardPackageRequested{}, blockPackageRequested{};
   unsigned& coinFlip;
+  unsigned coinValue{};
   unsigned mySeed{}, maxSeed{};
   frame_time_t abortingCountdown{frames(150)};
   size_t tries{}; //!< After so many attempts, quit the download...
@@ -63,10 +64,10 @@ private:
   void RemoveFromDownloadList(const std::string& id);
 
   // Send direct data
-  void SendHandshakeAck();
+  void SendHandshake();
   void SendPing(); //!< keep connections alive while clients download data
   void SendDownloadComplete(bool success);
-  void SendCoinFlip(bool completed);
+  void SendCoinFlip();
 
   // Initiate trades
   void TradePlayerPackageData(const PackageHash& hash);

--- a/BattleNetwork/netplay/bnMatchMakingPacketProcessor.cpp
+++ b/BattleNetwork/netplay/bnMatchMakingPacketProcessor.cpp
@@ -71,6 +71,10 @@ void MatchMaking::PacketProcessor::SetKickCallback(const Netplay::PacketProcesso
 void MatchMaking::PacketProcessor::SetPacketBodyCallback(const Netplay::PacketProcessor::PacketbodyFunc& callback)
 {
   this->callback = callback;
+
+  if (proxy) {
+    proxy->SetPacketBodyCallback(callback);
+  }
 }
 
 std::shared_ptr<Netplay::PacketProcessor> MatchMaking::PacketProcessor::GetProxy()

--- a/BattleNetwork/netplay/bnNetPlayPacketProcessor.h
+++ b/BattleNetwork/netplay/bnNetPlayPacketProcessor.h
@@ -24,6 +24,9 @@ namespace Netplay {
     PacketSorter<NetPlaySignals::ack> packetSorter;
     KickFunc onKickCallback;
     PacketbodyFunc onPacketBodyCallback;
+    std::vector<Poco::Buffer<char>> pendingPackets;
+
+    void ProcessPackets(std::vector<Poco::Buffer<char>> packets);
   public:
     PacketProcessor(const Poco::Net::SocketAddress& remoteAddress, uint16_t maxBytes);
     virtual ~PacketProcessor();

--- a/BattleNetwork/netplay/bnNetPlaySignals.h
+++ b/BattleNetwork/netplay/bnNetPlaySignals.h
@@ -34,6 +34,7 @@ enum class NetPlaySignals : unsigned int {
   block_package_request, // Ask to download only specific package
   block_package_download, // Download block package data
   downloads_complete,
+  download_transition, // transition to pvp
 
   ///////////////////////
   //     Misc. Cmds    //


### PR DESCRIPTION
Changes:
 - Added entity:set_team
 - Fixed some match making scene connection issues after disconnection
 - Possibly fixed coin flip by setting seed to the current microsecond (worked in my testing)
 - Possibly fixed missed packets at battle start by queueing packets (could not test)
 - Removed some packet spam (including coin flip)