### PR TITLE
Add the ability to implement WhiCapsl.

### DIFF
--- a/BattleNetwork/bindings/bnUserTypeCardMeta.cpp
+++ b/BattleNetwork/bindings/bnUserTypeCardMeta.cpp
@@ -6,10 +6,10 @@
 
 void DefineCardMetaUserTypes(ScriptResourceManager* scriptManager, sol::state& state, sol::table& battle_namespace, std::function<void(const std::string& packageId)> setPackageId) {
   const auto& cardpropsmeta_table = battle_namespace.new_usertype<Battle::Card::Properties>("CardProperties",
-    sol::meta_function::index, []( sol::table table, const std::string key ) { 
+    sol::meta_function::index, []( sol::table table, const std::string key ) {
       ScriptResourceManager::PrintInvalidAccessMessage( table, "CardProperties", key );
     },
-    sol::meta_function::new_index, []( sol::table table, const std::string key, sol::object obj ) { 
+    sol::meta_function::new_index, []( sol::table table, const std::string key, sol::object obj ) {
       ScriptResourceManager::PrintInvalidAssignMessage( table, "CardProperties", key );
     },
     "from_card", [scriptManager] (const std::string& fqn) -> Battle::Card::Properties {
@@ -34,6 +34,7 @@ void DefineCardMetaUserTypes(ScriptResourceManager* scriptManager, sol::state& s
     "description", &Battle::Card::Properties::description,
     "element", &Battle::Card::Properties::element,
     "limit", &Battle::Card::Properties::limit,
+    "hit_flags", &Battle::Card::Properties::hitFlags,
     "meta_classes", &Battle::Card::Properties::metaClasses,
     "secondary_element", &Battle::Card::Properties::secondaryElement,
     "shortname", &Battle::Card::Properties::shortname,
@@ -43,10 +44,10 @@ void DefineCardMetaUserTypes(ScriptResourceManager* scriptManager, sol::state& s
   );
 
   const auto& cardmeta_table = battle_namespace.new_usertype<CardMeta>("CardMeta",
-    sol::meta_function::index, []( sol::table table, const std::string key ) { 
+    sol::meta_function::index, []( sol::table table, const std::string key ) {
       ScriptResourceManager::PrintInvalidAccessMessage( table, "CardMeta", key );
     },
-    sol::meta_function::new_index, []( sol::table table, const std::string key, sol::object obj ) { 
+    sol::meta_function::new_index, []( sol::table table, const std::string key, sol::object obj ) {
       ScriptResourceManager::PrintInvalidAssignMessage( table, "CardMeta", key );
     },
     "filter_hand_step", &CardMeta::filterHandStep,

--- a/BattleNetwork/bnCard.h
+++ b/BattleNetwork/bnCard.h
@@ -4,6 +4,7 @@
 #include <tuple>
 #include <vector>
 #include "bnElements.h"
+#include "bnHitProperties.h"
 
 using std::string;
 
@@ -15,9 +16,9 @@ class SelectedCardsUI;
  * @author mav
  * @date 05/05/19
  * @brief Describes card record entry in database of loaded cards
- * 
+ *
  * This will be expanded to load the corresponding script information
- * 
+ *
  */
 namespace Battle {
   enum class CardClass : unsigned {
@@ -38,10 +39,11 @@ namespace Battle {
       bool timeFreeze{ false }; /*!< Does this card rely on action items to resolve before resuming the battle scene? */
       bool skipTimeFreezeIntro{ false }; /*! Skips the fade in/out and name appearing for this card */
       string shortname;
-      string action; 
+      string action;
       string description;
       string verboseDescription;
       Element element{ Element::none }, secondaryElement{ Element::none };
+      Hit::Flags hitFlags{ 0 };
       CardClass cardClass{ CardClass::standard };
       std::vector<std::string> metaClasses; /*!< Cards can be tagged with additional user information*/
     };

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -1422,9 +1422,6 @@ void Entity::ResolveFrameBattleDamage()
             hasSuperArmor = hasSuperArmor || dynamic_cast<DefenseSuperArmor*>(d);
           }*/
 
-          // assume some defense rule strips out flinch, prevent abuse of stun
-          frameStunCancel = frameStunCancel ||(props.filtered.flags & Hit::flinch) == 0 && (props.hitbox.flags & Hit::flinch) == Hit::flinch;
-
           if ((props.filtered.flags & Hit::flash) == Hit::flash && frameStunCancel) {
             // cancel stun
             stunCooldown = frames(0);

--- a/BattleNetwork/bnPA.cpp
+++ b/BattleNetwork/bnPA.cpp
@@ -63,7 +63,7 @@ const int PA::FindPA(std::vector<Battle::Card>& input)
 
   for (iter = advances.begin(); iter != advances.end(); iter++) {
     bool match = false;
-    
+
     if (iter->steps.size() > size) {
       continue; // try next recipe
     }
@@ -91,7 +91,7 @@ const int PA::FindPA(std::vector<Battle::Card>& input)
           }
 
           match = true;
-          // We do not break here. If it is a match all across the steps, then the for loop ends 
+          // We do not break here. If it is a match all across the steps, then the for loop ends
           // and match stays == true
 
           if (startIndex == -1) {
@@ -128,6 +128,7 @@ const int PA::FindPA(std::vector<Battle::Card>& input)
         "combo",
         iter->primaryElement,
         iter->secondElement,
+        iter->hitFlags,
         Battle::CardClass::standard,
         iter->metaClasses
       });

--- a/BattleNetwork/bnPA.h
+++ b/BattleNetwork/bnPA.h
@@ -1,26 +1,27 @@
 /*! \file bnPA.h */
 
-/*! \brief PA loads the recipes for PA combos and 
+/*! \brief PA loads the recipes for PA combos and
  *         provides interface to swap cards with PA card
- * 
+ *
  * Program Advanced class parses a PA input into a lookup table.
  * Then the class accepts cards as input during game play and replaces
  * matching PA sets with a new unlisted card.
- *  
+ *
  * This takes place during the transition from card custom select screen
  * and battle. The names of each card in the PA is listed one at a time,
  * then the PA name is displayed and the battle continues.
  */
-   
+
 #pragma once
 
 #include <string>
 #include <vector>
 #include "bnCard.h"
+#include "bnHitProperties.h"
 
 class PA
 {
-public: 
+public:
   enum class RuleType : char {
     ordered = 0, // only order matters: any code can be replaced by wildcard
     dupes        // set of duplicate cards matching the code combination with a limit of 1 wildcard
@@ -43,9 +44,10 @@ public:
     unsigned damage{ 0 };  /*!< damage of the PA*/
     Element primaryElement{ Element::none };/*!< element of the PA*/
     Element secondElement{ Element::none }; /*!< Secondary (hidden) element of PA*/
+    Hit::Flags hitFlags{ 0 };
     bool canBoost{ false }; /*!< true if damage > 0*/
     bool timeFreeze{ false }; /*!< Triggers time freeze if true */
-    
+
     std::vector<std::string> metaClasses; /*!< User-created class types*/
     PA::Steps steps; /*!< list of steps for PA */
     RuleType ruleType;
@@ -55,36 +57,36 @@ public:
    * @brief sets advanceCardRef to null
    */
   PA();
-  
+
   /**
    * @brief If advanceCardRef is non null, deletes it. Clears PA lookup.
    */
   ~PA();
-  
+
   /**
    * @brief Registers a new combo
    */
   void RegisterPA(PACard entry);
-  
+
   /**
-   * @brief Given a list of cards, generates a matching PA. 
+   * @brief Given a list of cards, generates a matching PA.
    * @param input list of cards
    * @param size size of card list
    * @return -1 if no match. Otherwise returns the start position of the PA
    */
   const int FindPA(std::vector<Battle::Card>& input);
-  
+
   /**
    * @brief Returns the list of matching steps in the PA
    * @return const PASteps
    */
   const PA::Steps GetMatchingSteps();
-  
+
   /**
-   * @brief Fetch the generated PA as a card 
+   * @brief Fetch the generated PA as a card
    * @return Card*
    * @warning do not delete this pointer!
-   * This is deleted by the PA 
+   * This is deleted by the PA
    */
   Battle::Card& GetAdvanceCard();
 


### PR DESCRIPTION
Two changes:
1. As discussed, add missing hit_flags to Card::Properties to allow hit_flags to be passed between chips. No chips support this so there will need to be some kind of migration of existing chips to do this (but a lot of them are hardcoding other things too, so they'll need revisions either way).
2. Allow Flinch + Stun. In bnEntity.cpp there's an explicit check that specifically disallows this, but I don't know what the implications of it are. Let me know if I'm way off the mark in taking this out.