### PR TITLE
Replace uses of std::string with std::filesystem::path.

### DIFF
--- a/BattleNetwork/bindings/bnScriptedMob.cpp
+++ b/BattleNetwork/bindings/bnScriptedMob.cpp
@@ -10,15 +10,15 @@
 //
 // class ScriptedMob::Spawner : public Mob::Spawner<ScriptedCharacter>
 //
-ScriptedMob::ScriptedSpawner::ScriptedSpawner(sol::state& script, const std::string& path, Character::Rank rank)
-{ 
+ScriptedMob::ScriptedSpawner::ScriptedSpawner(sol::state& script, const std::filesystem::path& path, Character::Rank rank)
+{
   scriptedSpawner = std::make_unique<Mob::Spawner<ScriptedCharacter>>(rank);
   std::function<std::shared_ptr<ScriptedCharacter>()> lambda = scriptedSpawner->constructor;
 
   scriptedSpawner->constructor = [lambda, path, scriptPtr=&script] () -> std::shared_ptr<ScriptedCharacter> {
     auto& script = *scriptPtr;
-    script["_modpath"] = path+"/";
-    script["_folderpath"] = path+"/";
+    script["_modpath"] = path.generic_u8string() + "/";
+    script["_folderpath"] = path.generic_u8string() + "/";
 
     auto character = lambda();
     character->InitFromScript(script);
@@ -107,9 +107,9 @@ void ScriptedMob::ScriptedSpawner::SetMob(Mob* mob)
 
 //
 // class ScriptedMob : public Mob
-// 
-ScriptedMob::ScriptedMob(sol::state& script) : 
-  MobFactory(), 
+//
+ScriptedMob::ScriptedMob(sol::state& script) :
+  MobFactory(),
   script(script)
 {
 }
@@ -163,7 +163,7 @@ ScriptedMob::ScriptedSpawner ScriptedMob::CreateSpawner(const std::string& names
   return obj;
 }
 
-void ScriptedMob::SetBackground(const std::string& bgTexturePath, const std::string& animPath, float velx, float vely)
+void ScriptedMob::SetBackground(const std::filesystem::path& bgTexturePath, const std::filesystem::path& animPath, float velx, float vely)
 {
   auto texture = Textures().LoadFromFile(bgTexturePath);
   auto anim = Animation(animPath);
@@ -172,7 +172,7 @@ void ScriptedMob::SetBackground(const std::string& bgTexturePath, const std::str
   mob->SetBackground(background);
 }
 
-void ScriptedMob::StreamMusic(const std::string& path, long long startMs, long long endMs)
+void ScriptedMob::StreamMusic(const std::filesystem::path& path, long long startMs, long long endMs)
 {
   mob->StreamCustomMusic(path, startMs, endMs);
 }

--- a/BattleNetwork/bindings/bnScriptedMob.h
+++ b/BattleNetwork/bindings/bnScriptedMob.h
@@ -28,7 +28,7 @@ public:
 
   public:
     ScriptedSpawner() = default;
-    ScriptedSpawner(sol::state& script, const std::string& path, Character::Rank rank);
+    ScriptedSpawner(sol::state& script, const std::filesystem::path& path, Character::Rank rank);
 
     template<typename BuiltInCharacter>
     void UseBuiltInType(Character::Rank rank);
@@ -47,14 +47,14 @@ public:
   std::shared_ptr<Field> GetField();
   void EnableFreedomMission(uint8_t turnCount, bool playerCanFlip);
   /**
-  * @brief Creates a spawner object that loads a scripted or built-in character by its Fully Qualified Names (FQN) 
+  * @brief Creates a spawner object that loads a scripted or built-in character by its Fully Qualified Names (FQN)
   * @param fqn String. The name of the character stored in script cache. Use `BuiltIns.NAME` prefix for built-in characters.
   * @preconditions The mob `load_script` function should never throw an exception prior to using this function.
   */
   ScriptedSpawner CreateSpawner(const std::string& namespaceId, const std::string& fqn, Character::Rank rank);
 
-  void SetBackground(const std::string& bgTexturePath, const std::string& animPath, float velx, float vely);
-  void StreamMusic(const std::string& path, long long startMs, long long endMs);
+  void SetBackground(const std::filesystem::path& bgTexturePath, const std::filesystem::path& animPath, float velx, float vely);
+  void StreamMusic(const std::filesystem::path& path, long long startMs, long long endMs);
   void SpawnPlayer(unsigned playerNum, int tileX, int tileY);
 };
 

--- a/BattleNetwork/bindings/bnUserTypeAnimation.cpp
+++ b/BattleNetwork/bindings/bnUserTypeAnimation.cpp
@@ -8,7 +8,7 @@ void DefineAnimationUserType(sol::state& state, sol::table& engine_namespace) {
   engine_namespace.new_usertype<AnimationWrapper>("Animation",
     sol::factories(
       [] (const std::string& path) {
-        auto animation = std::make_shared<Animation>(path);
+        auto animation = std::make_shared<Animation>(std::filesystem::u8path(path));
 
         auto animationWrapper = AnimationWrapper(animation, *animation);
         animationWrapper.OwnParent();
@@ -24,14 +24,14 @@ void DefineAnimationUserType(sol::state& state, sol::table& engine_namespace) {
         return animationWrapper;
       }
     ),
-    sol::meta_function::index, []( sol::table table, const std::string key ) { 
+    sol::meta_function::index, []( sol::table table, const std::string key ) {
       ScriptResourceManager::PrintInvalidAccessMessage( table, "Animation", key );
     },
-    sol::meta_function::new_index, []( sol::table table, const std::string key, sol::object obj ) { 
+    sol::meta_function::new_index, []( sol::table table, const std::string key, sol::object obj ) {
       ScriptResourceManager::PrintInvalidAssignMessage( table, "Animation", key );
     },
     "load", [](AnimationWrapper& animation, const std::string& path) {
-      animation.Unwrap().Load(path);
+      animation.Unwrap().Load(std::filesystem::u8path(path));
     },
     "update", [](AnimationWrapper& animation, double elapsed, WeakWrapper<SpriteProxyNode>& target) {
       animation.Unwrap().Update(elapsed, target.Unwrap()->getSprite());

--- a/BattleNetwork/bnAnimation.cpp
+++ b/BattleNetwork/bnAnimation.cpp
@@ -15,11 +15,11 @@ Animation::Animation() : animator(), path("") {
   progress = frames(0);
 }
 
-Animation::Animation(const char* _path) : animator(), path(std::string(_path)) {
+Animation::Animation(const char* _path) : animator(), path(std::filesystem::u8path(_path)) {
   Reload();
 }
 
-Animation::Animation(const string& _path) : animator(), path(_path) {
+Animation::Animation(const std::filesystem::path& _path) : animator(), path(_path) {
   Reload();
 }
 
@@ -53,7 +53,7 @@ void Animation::Reload() {
   }
 }
 
-void Animation::Load(const std::string& newPath)
+void Animation::Load(const std::filesystem::path& newPath)
 {
   if (!newPath.empty()) {
     path = newPath;
@@ -186,7 +186,7 @@ void Animation::LoadWithData(const string& data)
       }
     }
     else if (StartsWith(line, "imagePath")) {
-      // no-op 
+      // no-op
       // editor only at this time
       continue;
     }
@@ -263,8 +263,8 @@ void Animation::LoadWithData(const string& data)
       }
       else {
         frameLists.at(frameAnimationIndex).Add(
-          currentFrameDuration, 
-          IntRect(currentStartx, currentStarty, currentWidth, currentHeight), 
+          currentFrameDuration,
+          IntRect(currentStartx, currentStarty, currentWidth, currentHeight),
           sf::Vector2f(originX, originY),
           flipX,
           flipY
@@ -330,7 +330,7 @@ void Animation::Update(double elapsed, sf::Sprite& target) {
     // apply new state to target on same frame
     animator(frames(0), target, animations[currAnimation]);
     progress = frames(0);
-    
+
     HandleInterrupted();
   }
 
@@ -466,11 +466,11 @@ char Animation::GetMode()
 frame_time_t Animation::GetStateDuration(const std::string& state) const
 {
   auto iter = animations.find(state);
-  
+
   if (iter != animations.end()) {
     return iter->second.GetTotalDuration();
   }
-  
+
   return frames(0);
 }
 

--- a/BattleNetwork/bnAnimation.h
+++ b/BattleNetwork/bnAnimation.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <assert.h>
+#include <filesystem>
 #include <functional>
 
 #include <iostream>
@@ -18,11 +19,11 @@ using std::to_string;
  * @date 14/05/19
  * @see bnAnimator.h
  * @brief Loads a FrameList from an animation file format and animates a sprite
- * 
+ *
  * Basically a wrapper around the animator that knows the possible animations.
- * 
+ *
  * File format example:
- * 
+ *
  * VERSION="1.0"
  * imagePath=C:\User\Bob\Desktop\player.png
  *
@@ -38,7 +39,7 @@ using std::to_string;
  * point label="Buster" x="39" y="14"
  * frame duration="0.05" x="302" y="11" w="68" h="47" originx="18" originy="39" flipx="0" flipy="0"
  * point label="Buster" x="38" y="14"
- * 
+ *
  * animation state="PLAYER_MOVING"
  * ...
  * ```
@@ -50,18 +51,18 @@ public:
   /**
    * @brief No frame list is loaded*/
   Animation();
-  
+
   /**
    * @brief Parses file at path and populates FrameList with data
    * @param path relative path from application to file
    */
   Animation(const char* path);
-  
+
   /**
    * @brief Parses file at path and populates FrameList with data
    * @param path relative path from application to file
    */
-  Animation(const string& path);
+  Animation(const std::filesystem::path& path);
 
   Animation(const Animation& rhs);
 
@@ -77,14 +78,14 @@ public:
      Effectively same as calling Load()
    */
   void Reload();
- 
+
   /**
  * @brief Reads file at path set by constructor, parses lines, and populates FrameList with data
 
     Effectively same as calling Reload();
  */
-  void Load(const std::string& newPath = "");
- 
+  void Load(const std::filesystem::path& newPath = "");
+
   /**
  * @brief Parses lines, and populates FrameList with data
 
@@ -98,7 +99,7 @@ public:
    * @param target sprite to apply to
    */
   void Update(double _elapsed, sf::Sprite& target);
-  
+
   /**
    * @brief Syncs the animation elapsed counter to one provided
    */
@@ -109,16 +110,16 @@ public:
    * @param target
    */
   void Refresh(sf::Sprite& target);
-  
+
   /**
    * @brief Manually set a frame to the sprite
    * @param frame Base 1 frame index
    * @param target Sprite to update
-   * 
+   *
    * If frame is out of bounds for the current animation, ignores
    */
   void SetFrame(int frame, sf::Sprite& target);
-  
+
   /**
    * @brief Sets the current animation from a map of FrameLists
    * @param state animation name is the map key
@@ -150,14 +151,14 @@ public:
    * @return Animation& to chain
    */
   Animation& operator<<(const Animator::On& rhs);
-  
+
   /**
    * @brief Set the animator mode
    * @param rhs byte mode
    * @return Animation& to chain
    */
   Animation& operator<<(char rhs);
-  
+
   /**
    * @brief Set the animation state
    * @param state name to chain
@@ -209,7 +210,7 @@ protected:
   bool noAnim{ false }; /*!< If the requested state was not found, hide the sprite when updating */
   bool handlingInterrupt{ false }; /*!< Whether or not the interupt handler is executing (for nested animations) */
   Animator animator; /*!< Internal animator to delegate most of the work to */
-  string path; /*!< Path to the animation file */
+  std::filesystem::path path; /*!< Path to the animation file */
   string currAnimation; /*!< Name of the current animation state */
   frame_time_t progress; /*!< Current progress of animation */
   double playbackSpeed{ 1.0 }; /*!< Factor to multiply against update `dt`*/

--- a/BattleNetwork/bnAnimationComponent.cpp
+++ b/BattleNetwork/bnAnimationComponent.cpp
@@ -33,7 +33,7 @@ void AnimationComponent::OnUpdate(double _elapsed)
   UpdateAnimationObjects(owner->getSprite(), _elapsed);
 }
 
-void AnimationComponent::SetPath(string _path)
+void AnimationComponent::SetPath(const std::filesystem::path& _path)
 {
   path = _path;
 }
@@ -58,7 +58,7 @@ const std::string AnimationComponent::GetAnimationString() const
   return animation.GetAnimationString();
 }
 
-const std::string& AnimationComponent::GetFilePath() const
+const std::filesystem::path& AnimationComponent::GetFilePath() const
 {
   return path;
 }
@@ -194,7 +194,7 @@ void AnimationComponent::SyncAnimation(std::shared_ptr<AnimationComponent> other
 void AnimationComponent::AddToSyncList(const AnimationComponent::SyncItem& item)
 {
   auto iter = std::find_if(syncList.begin(), syncList.end(), [item](auto in) {
-    return std::tie(in.anim, in.node, in.point) == std::tie(item.anim, item.node, item.point); 
+    return std::tie(in.anim, in.node, in.point) == std::tie(item.anim, item.node, item.point);
   });
 
   if (iter == syncList.end()) {

--- a/BattleNetwork/bnAnimationComponent.h
+++ b/BattleNetwork/bnAnimationComponent.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <assert.h>
 #include <functional>
+#include <filesystem>
 
 #include "bnComponent.h"
 #include "bnAnimation.h"
@@ -49,12 +50,12 @@ public:
    * @param BattleSceneBase& unused
    */
   void Inject(BattleSceneBase&) override { ; }
-  
+
   /**
    * @brief Reconstructs the animation object
    * @param _path to animation file
    */
-  void SetPath(string _path);
+  void SetPath(const std::filesystem::path& _path);
 
   /**
    * @brief Loads the animation object
@@ -70,18 +71,18 @@ public:
   * @brief Do not load from path, copy from an existing animation
   */
   void CopyFrom(const AnimationComponent& rhs);
-  
+
   /**
    * @brief Get animation object's current animation name
    * @return name of animation or empty string if no state
    */
   const std::string GetAnimationString() const;
-  
+
   /**
    * @brief Get animation object's file path used to setup the animation
    * @returnpath of animation file or empty string if no file was loaded
    */
-  const std::string& GetFilePath() const;
+  const std::filesystem::path& GetFilePath() const;
 
   /**
    * @brief Set the animation playback speed
@@ -90,30 +91,30 @@ public:
   void SetPlaybackSpeed(const double playbackSpeed);
 
   /**
-   * @brief Fetch the animation playback speed 
-   * @return double playback speed 
+   * @brief Fetch the animation playback speed
+   * @return double playback speed
    */
   const double GetPlaybackSpeed();
-  
+
   /**
    * @brief Set the playback mode
    * @param playbackMode byte mode
    */
   void SetPlaybackMode(char playbackMode);
-  
+
   /**
    * @brief Set the animation and provide an on finish notifier
    * @param state
    */
   void SetAnimation(string state, FrameFinishCallback onFinish = nullptr);
-  
+
   /**
    * @brief Set the animation, set the playback mode, and provide an on finish notifier
    * @param state
    * @param playbackMode
    */
   void SetAnimation(string state, char playbackMode, FrameFinishCallback onFinish = Animator::NoCallback);
-  
+
   /**
    * @brief Add a frame callback
    * @param frame Base 1 index
@@ -121,7 +122,7 @@ public:
    * @param doOnce Toggle if the callback should be fired every time the animation loops or just once
    */
   void AddCallback(int frame, FrameCallback onFrame, bool doOnce = false);
-  
+
   /**
    * @brief adds a callback to make the frame toggle counterable = true for Characters
    * @param frameStart Base 1 index
@@ -141,7 +142,7 @@ public:
 
   /**
    * @brief Get the (x,y) coordinate of a point from the current frame
-   * @param pointName the name of the point in the animation file 
+   * @param pointName the name of the point in the animation file
    * @return (x,y) vector of point or (0,0) if no point found
    */
   sf::Vector2f GetPoint(const std::string& pointName);
@@ -149,7 +150,7 @@ public:
   const bool HasPoint(const std::string& pointName);
 
   Animation& GetAnimationObject();
-  
+
   void OverrideAnimationFrames(const std::string& animation, std::list<OverrideFrame> data, std::string& uuid);
 
   void SyncAnimation(Animation& other);
@@ -161,7 +162,7 @@ public:
 
   void SetInterruptCallback(const FrameFinishCallback& onInterrupt);
   /**
-   * @brief Force the animation to jump to this frame index 
+   * @brief Force the animation to jump to this frame index
    * @param index index of the frame
    * If the index is out of range, sets frame to 0
    */
@@ -169,7 +170,7 @@ public:
 
   void Refresh();
 private:
-  string path; /*!< Path to animation */
+  std::filesystem::path path; /*!< Path to animation */
   Animation animation; /*!< Animation object */
   bool couldUpdateLastFrame{ true };
   std::vector<SyncItem> syncList;

--- a/BattleNetwork/bnAudioResourceManager.cpp
+++ b/BattleNetwork/bnAudioResourceManager.cpp
@@ -1,4 +1,5 @@
 #include "bnAudioResourceManager.h"
+#include "bnFileUtil.h"
 #include "bnLogger.h"
 
 AudioResourceManager::AudioResourceManager(){
@@ -24,7 +25,7 @@ AudioResourceManager::AudioResourceManager(){
 
 
 AudioResourceManager::~AudioResourceManager() {
-  // Stop playing everything 
+  // Stop playing everything
   stream.stop();
 
   for (int i = 0; i < NUM_OF_CHANNELS; i++) {
@@ -119,8 +120,9 @@ void AudioResourceManager::LoadAllSources(std::atomic<int> &status) {
   LoadSource(AudioType::DEFORM, "resources/sfx/deform.ogg"); status++;
 }
 
-void AudioResourceManager::LoadSource(AudioType type, const std::string& path) {
-  if (!sources[static_cast<size_t>(type)].loadFromFile(path)) {
+void AudioResourceManager::LoadSource(AudioType type, const std::filesystem::path& path) {
+  std::unique_ptr<StdFilesystemInputStream> stream = std::make_unique<StdFilesystemInputStream>(path);
+  if (!sources[static_cast<size_t>(type)].loadFromStream(std::move(stream))) {
     Logger::Logf(LogLevel::critical, "Failed loading Audio(): %s\n", path.c_str());
 
   } else {
@@ -128,14 +130,15 @@ void AudioResourceManager::LoadSource(AudioType type, const std::string& path) {
   }
 }
 
-std::shared_ptr<sf::SoundBuffer> AudioResourceManager::LoadFromFile(const std::string& path)
+std::shared_ptr<sf::SoundBuffer> AudioResourceManager::LoadFromFile(const std::filesystem::path& path)
 {
   auto iter = cached.find(path);
   std::shared_ptr<sf::SoundBuffer> loaded;
 
   if (iter == cached.end()) {
     loaded = std::make_shared<sf::SoundBuffer>();
-    loaded->loadFromFile(path);
+    std::unique_ptr<StdFilesystemInputStream> stream = std::make_unique<StdFilesystemInputStream>(path);
+    loaded->loadFromStream(std::move(stream));
     cached.insert(std::make_pair(path, CachedResource<sf::SoundBuffer>(loaded)));
   }
   else {
@@ -232,7 +235,7 @@ int AudioResourceManager::Play(AudioType type, AudioPriority priority) {
     for (int i = 0; i < NUM_OF_CHANNELS; i++) {
       if (channels[i].buffer.getStatus() == sf::SoundSource::Status::Playing) {
         if ((sf::SoundBuffer*)channels[i].buffer.getBuffer() == &sources[static_cast<size_t>(type)]) {
-          // Lowest priority or high priority sounds only play once 
+          // Lowest priority or high priority sounds only play once
           return -1;
         }
       }
@@ -250,7 +253,7 @@ int AudioResourceManager::Play(AudioType type, AudioPriority priority) {
       }
     }
     else { // HIGH PRIORITY will not overwrite other HIGH priorities unless they have ended
-      bool canOverwrite = channels[i].priority < AudioPriority::high 
+      bool canOverwrite = channels[i].priority < AudioPriority::high
         ||(channels[i].priority == AudioPriority::high && channels[i].buffer.getStatus() != sf::SoundSource::Status::Playing);
       if (canOverwrite) {
         channels[i].buffer.stop();
@@ -332,7 +335,7 @@ int AudioResourceManager::Play(std::shared_ptr<sf::SoundBuffer> resource, AudioP
     for (int i = 0; i < NUM_OF_CHANNELS; i++) {
       if (channels[i].buffer.getStatus() == sf::SoundSource::Status::Playing) {
         if ((sf::SoundBuffer*)channels[i].buffer.getBuffer() == resource.get()) {
-          // Lowest priority or high priority sounds only play once 
+          // Lowest priority or high priority sounds only play once
           return -1;
         }
       }
@@ -366,18 +369,19 @@ int AudioResourceManager::Play(std::shared_ptr<sf::SoundBuffer> resource, AudioP
   return -1;
 }
 
-int AudioResourceManager::Stream(std::string path, bool loop, long long startMs, long long endMs) {
+int AudioResourceManager::Stream(const std::filesystem::path& path, bool loop, long long startMs, long long endMs) {
   if (!isEnabled) { return -1; }
 
   if (path == currStreamPath) { return -1; };
 
   currStreamPath = path;
 
-  // stop previous stream if any 
+  // stop previous stream if any
   stream.stop();
   midiMusic.stop();
 
-  if (!stream.openFromFile(path)) {
+  std::unique_ptr<StdFilesystemInputStream> istream = std::make_unique<StdFilesystemInputStream>(path);
+  if (!stream.openFromStream(std::move(istream))) {
     if (midiMusic.loadMidiFromFile(path)) {
       midiMusic.play();
       midiMusic.setLoop(loop);
@@ -398,7 +402,7 @@ int AudioResourceManager::Stream(std::string path, bool loop, long long startMs,
   return 0;
 }
 
-int AudioResourceManager::Stream(std::string path, bool loop) {
+int AudioResourceManager::Stream(const std::filesystem::path& path, bool loop) {
   return Stream(path, loop, -1, -1);
 }
 

--- a/BattleNetwork/bnAudioResourceManager.h
+++ b/BattleNetwork/bnAudioResourceManager.h
@@ -4,12 +4,14 @@
 #include <SFML/Audio/Sound.hpp>
 #include <SFML/Audio/Music.hpp>
 #include <atomic>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <mutex>
 
 #include "sfMidi/include/sfMidi.h"
 #include "bnAudioType.h"
+#include "bnCachedResource.h"
 #include "bnCachedResource.h"
 
 // For more retro experience, decrease available channels.
@@ -22,7 +24,7 @@
 /**
   * @class AudioPriority
   * @brief Each priority describes how or if a playing sample should be interrupted
-  * 
+  *
   * Priorities are LOWEST  (one at a time, if channel available),
   *                LOW     (any free channels),
   *                HIGH    (force a channel to play sound, but one at a time, and don't interrupt other high priorities),
@@ -61,22 +63,22 @@ public:
   * @param pitch. A floating-point multiplied by 100 to achieve the pitch %
   */
   void SetPitch(float pitch);
-  
+
   /**
    * @brief Loads all queued resources. Increases status value.
    * @param status thread-safe counter will reach total count of all samples to load when finished.
    */
   void LoadAllSources(std::atomic<int> &status);
-  
+
   /**
    * @brief Loads an Audio() source at path and map it to enum type
    * @param type Audio() enum to map to
    * @param path path to Audio() sample
    */
-  void LoadSource(AudioType type, const std::string& path);
+  void LoadSource(AudioType type, const std::filesystem::path& path);
 
-  std::shared_ptr<sf::SoundBuffer> LoadFromFile(const std::string& path);
-  
+  std::shared_ptr<sf::SoundBuffer> LoadFromFile(const std::filesystem::path& path);
+
   void HandleExpiredAudioCache();
 
   /**
@@ -89,8 +91,8 @@ public:
 
   int Play(std::shared_ptr<sf::SoundBuffer> resource, AudioPriority priority = AudioPriority::low);
 
-  int Stream(std::string path, bool loop = false);
-  int Stream(std::string path, bool loop, long long startMs, long long endMs);
+  int Stream(const std::filesystem::path &path, bool loop = false);
+  int Stream(const std::filesystem::path &path, bool loop, long long startMs, long long endMs);
   void StopStream();
   void SetStreamVolume(float volume);
   void SetChannelVolume(float volume);
@@ -110,9 +112,9 @@ private:
   std::mutex mutex;
   Channel* channels;
   sf::SoundBuffer* sources;
-  std::map<std::string, CachedResource<sf::SoundBuffer>> cached;
+  std::map<std::filesystem::path, CachedResource<sf::SoundBuffer>> cached;
   sf::Music stream;
-  std::string currStreamPath;
+  std::filesystem::path currStreamPath;
   float channelVolume{};
   float streamVolume{};
   bool isEnabled{true};

--- a/BattleNetwork/bnConfigReader.cpp
+++ b/BattleNetwork/bnConfigReader.cpp
@@ -259,7 +259,7 @@ bool ConfigReader::IsOK()
   return isOK;
 }
 
-ConfigReader::ConfigReader(const std::string& filepath):
+ConfigReader::ConfigReader(const std::filesystem::path& filepath):
   filepath(filepath)
 {
   settings.isOK = Parse(FileUtil::Read(filepath));
@@ -278,7 +278,7 @@ ConfigSettings ConfigReader::GetConfigSettings()
   return settings;
 }
 
-const std::string ConfigReader::GetPath() const
+const std::filesystem::path ConfigReader::GetPath() const
 {
   return filepath;
 }

--- a/BattleNetwork/bnConfigReader.h
+++ b/BattleNetwork/bnConfigReader.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <filesystem>
 #include <map>
 #include <string_view>
 #include "bnInputEvent.h"
@@ -60,7 +61,7 @@ private:
   };
 
   ConfigSettings settings;
-  std::string filepath;
+  std::filesystem::path filepath;
   bool isOK{ false };
 
   /**
@@ -175,11 +176,11 @@ public:
    * @brief Parses config ini file at filepath
    * @param filepath path to ini file
    */
-  ConfigReader(const std::string& filepath);
+  ConfigReader(const std::filesystem::path& filepath);
 
   ~ConfigReader();
 
   ConfigSettings GetConfigSettings();
-  const std::string GetPath() const;
+  const std::filesystem::path GetPath() const;
   bool IsOK();
 };

--- a/BattleNetwork/bnConfigScene.cpp
+++ b/BattleNetwork/bnConfigScene.cpp
@@ -161,7 +161,7 @@ void ConfigScene::NumberItem::SetAlpha(sf::Uint8 alpha) {
   icon->setColor(color);
 }
 
-void ConfigScene::NumberItem::UseIcon(const std::string& image_path, const std::string& animation_path, const std::string& state)
+void ConfigScene::NumberItem::UseIcon(const std::filesystem::path& image_path, const std::filesystem::path& animation_path, const std::string& state)
 {
   AddNode(icon);
   icon->setTexture(Textures().LoadFromFile(image_path));
@@ -214,8 +214,8 @@ ConfigScene::ConfigScene(swoosh::ActivityController& controller) :
   // ui sprite maps
   // ascii 58 - 96
   // BGM
-  const std::string audio_img = "resources/ui/config/audio.png";
-  const std::string audio_ani = "resources/ui/config/audio.animation";
+  const std::filesystem::path audio_img = "resources/ui/config/audio.png";
+  const std::filesystem::path audio_ani = "resources/ui/config/audio.animation";
 
   musicLevel = configSettings.GetMusicLevel();
   auto bgMusicItem = std::make_shared<NumberItem>(
@@ -285,7 +285,7 @@ ConfigScene::ConfigScene(swoosh::ActivityController& controller) :
 
   primaryMenu.push_back(nicknameItem);
 
-  // For keyboard keys 
+  // For keyboard keys
   auto keyCallback = [this](BindingItem& item) { AwaitKeyBinding(item); };
   auto keySecondaryCallback = [this](BindingItem& item) { UnsetKeyBinding(item); };
 
@@ -548,7 +548,7 @@ void ConfigScene::onUpdate(double elapsed)
         }
 
         getController().Session().SetNick(nickname);
-      
+
         // transition to the next screen
         using namespace swoosh::types;
         using effect = segue<WhiteWashFade, milliseconds<300>>;

--- a/BattleNetwork/bnConfigScene.h
+++ b/BattleNetwork/bnConfigScene.h
@@ -109,7 +109,7 @@ private:
   public:
     NumberItem(const std::string& text, sf::Color color, int value, const std::function<void(int, NumberItem&)>& callback);
     void SetAlpha(sf::Uint8 alpha) override;
-    void UseIcon(const std::string& image_path, const std::string& animation_path, const std::string& state = "DEFAULT");
+    void UseIcon(const std::filesystem::path& image_path, const std::filesystem::path& animation_path, const std::string& state = "DEFAULT");
     void SetValueRange(int min, int max);
   };
 

--- a/BattleNetwork/bnConfigWriter.cpp
+++ b/BattleNetwork/bnConfigWriter.cpp
@@ -9,7 +9,7 @@ ConfigWriter::~ConfigWriter()
 {
 }
 
-void ConfigWriter::Write(std::string path)
+void ConfigWriter::Write(const std::filesystem::path& path)
 {
   FileUtil::WriteStream w(path);
   w << "[Discord]" << w.endl();

--- a/BattleNetwork/bnConfigWriter.h
+++ b/BattleNetwork/bnConfigWriter.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "bnConfigSettings.h"
 
+#include <filesystem>
+
 /*
 Example file contents
 ---------------------
@@ -52,7 +54,7 @@ public:
   ConfigWriter(ConfigSettings& settings);
   ~ConfigWriter();
 
-  void Write(std::string path);
+  void Write(const std::filesystem::path& path);
 
   const std::string quote(const std::string& str);
 

--- a/BattleNetwork/bnFileUtil.cpp
+++ b/BattleNetwork/bnFileUtil.cpp
@@ -1,0 +1,38 @@
+#include "bnFileUtil.h"
+
+StdFilesystemInputStream::StdFilesystemInputStream(const std::filesystem::path& path) :
+  path(path),
+  stream(path, std::ios::in | std::ios::binary) {
+}
+
+sf::Int64 StdFilesystemInputStream::read(void* data, sf::Int64 size) {
+  if (!stream) {
+    return -1;
+  }
+  stream.read(static_cast<char*>(data), size);
+  std::streampos n = stream.gcount();
+  stream.clear();
+  return n;
+}
+
+sf::Int64 StdFilesystemInputStream::seek(sf::Int64 position) {
+  if (!stream) {
+    return -1;
+  }
+  stream.seekg(position);
+  return stream.tellg();
+}
+
+sf::Int64 StdFilesystemInputStream::tell() {
+  if (!stream) {
+    return -1;
+  }
+  return stream.tellg();
+}
+
+sf::Int64 StdFilesystemInputStream::getSize() {
+  if (!stream) {
+    return -1;
+  }
+  return std::filesystem::file_size(path);
+}

--- a/BattleNetwork/bnGame.cpp
+++ b/BattleNetwork/bnGame.cpp
@@ -42,7 +42,7 @@ char* Game::RemotePartition = "pvp";
 char* Game::ServerPartition = "server";
 
 Game::Game(DrawWindow& window) :
-  window(window), 
+  window(window),
   reader("config.ini"),
   configSettings(),
   netManager(),
@@ -51,7 +51,7 @@ Game::Game(DrawWindow& window) :
   shaderManager(),
   inputManager(*window.GetRenderWindow()),
   ActivityController(*window.GetRenderWindow()) {
-  
+
   // figure out system endianness
   {
     int n = 1;
@@ -94,7 +94,7 @@ Game::Game(DrawWindow& window) :
   session->SetCardPackageManager(cardPackagePartitioner->GetPartition(Game::LocalPartition));
   session->SetBlockPackageManager(blockPackagePartitioner->GetPartition(Game::LocalPartition));
 
-  // Use the engine's window settings for this platform to create a properly 
+  // Use the engine's window settings for this platform to create a properly
   // sized render surface...
   unsigned int win_x = static_cast<unsigned int>(window.GetView().getSize().x);
   unsigned int win_y = static_cast<unsigned int>(window.GetView().getSize().y);
@@ -152,7 +152,7 @@ void Game::SetCommandLineValues(const cxxopts::ParseResult& values) {
   commandline = &values;
   commandlineArgs = values.arguments();
 
-  // Now that we have CLI values, we can configure 
+  // Now that we have CLI values, we can configure
   // other subsystems that need to read from them...
   unsigned int myPort = CommandLineValue<int>("port");
   uint16_t maxPayloadSize = CommandLineValue<uint16_t>("mtu");
@@ -273,7 +273,7 @@ bool Game::NextFrame()
 void Game::HandleRecordingEvents()
 {
   return; // for v2, disable this function by returning early.
-  
+
   if (isRecordOutSaving)
     return;
 
@@ -374,7 +374,7 @@ void Game::RunSingleThreaded()
     // Poll window events
     inputManager.EventPoll();
 
-    // unused images need to be free'd 
+    // unused images need to be free'd
     textureManager.HandleExpiredTextureCache();
     audioManager.HandleExpiredAudioCache();
 
@@ -392,7 +392,7 @@ void Game::RunSingleThreaded()
       HandleRecordingEvents();
       this->update(delta);  // update game logic
     }
-    
+
     this->draw();        // draw game
     mouse.draw(*window.GetRenderWindow());
     window.Display(); // display to screen
@@ -413,13 +413,13 @@ void Game::Run()
   if (singlethreaded) {
     RunSingleThreaded();
     return;
-  }  
+  }
 
   while (window.Running() && !quitting) {
     // Poll window events
     inputManager.EventPoll();
 
-    // unused images need to be free'd 
+    // unused images need to be free'd
     textureManager.HandleExpiredTextureCache();
     audioManager.HandleExpiredAudioCache();
 
@@ -489,7 +489,7 @@ void Game::UpdateConfigSettings(const struct ConfigSettings& new_settings)
     ActivityController::enableShaders(false);
   }
 
-  // If the file is good, use the Audio() and 
+  // If the file is good, use the Audio() and
   // controller settings from the config
   audioManager.EnableAudio(configSettings.IsAudioEnabled());
   audioManager.SetStreamVolume(((configSettings.GetMusicLevel()-1) / 3.0f) * 100.0f);
@@ -530,44 +530,44 @@ void Game::SetSubtitle(const std::string& subtitle)
   window.SetSubtitle(subtitle);
 }
 
-const std::string Game::AppDataPath()
+const std::filesystem::path Game::AppDataPath()
 {
-  return sago::getDataHome() + "/" + window.GetTitle();
+  return std::filesystem::u8path(sago::getDataHome()) / window.GetTitle();
 }
 
-const std::string Game::CacheDataPath()
+const std::filesystem::path Game::CacheDataPath()
 {
-  return sago::getCacheDir() + "/" + window.GetTitle();
+  return std::filesystem::u8path(sago::getCacheDir()) / window.GetTitle();
 }
 
-const std::string Game::DesktopPath()
+const std::filesystem::path Game::DesktopPath()
 {
-  return sago::getDesktopFolder();
+  return std::filesystem::u8path(sago::getDesktopFolder());
 }
 
-const std::string Game::DownloadsPath()
+const std::filesystem::path Game::DownloadsPath()
 {
-  return sago::getDownloadFolder();
+  return std::filesystem::u8path(sago::getDownloadFolder());
 }
 
-const std::string Game::DocumentsPath()
+const std::filesystem::path Game::DocumentsPath()
 {
-  return sago::getDocumentsFolder();
+  return std::filesystem::u8path(sago::getDocumentsFolder());
 }
 
-const std::string Game::VideosPath()
+const std::filesystem::path Game::VideosPath()
 {
-  return sago::getVideoFolder();
+  return std::filesystem::u8path(sago::getVideoFolder());
 }
 
-const std::string Game::PicturesPath()
+const std::filesystem::path Game::PicturesPath()
 {
-  return sago::getPicturesFolder();
+  return std::filesystem::u8path(sago::getPicturesFolder());
 }
 
-const std::string Game::SaveGamesPath()
+const std::filesystem::path Game::SaveGamesPath()
 {
-  return sago::getSaveGamesFolder1();
+  return std::filesystem::u8path(sago::getSaveGamesFolder1());
 }
 
 CardPackagePartitioner& Game::CardPackagePartitioner()

--- a/BattleNetwork/bnGame.h
+++ b/BattleNetwork/bnGame.h
@@ -68,7 +68,7 @@ private:
   TextureResourceManager textureManager;
   AudioResourceManager audioManager;
   ShaderResourceManager shaderManager;
-#ifdef BN_MOD_SUPPORT 
+#ifdef BN_MOD_SUPPORT
   ScriptResourceManager scriptManager;
 #endif
   InputManager inputManager;
@@ -146,14 +146,14 @@ public:
   void Record(bool enabled = true);
   void SetSubtitle(const std::string& subtitle);
 
-  const std::string AppDataPath();
-  const std::string CacheDataPath();
-  const std::string DesktopPath();
-  const std::string DownloadsPath();
-  const std::string DocumentsPath();
-  const std::string VideosPath();
-  const std::string PicturesPath();
-  const std::string SaveGamesPath();
+  const std::filesystem::path AppDataPath();
+  const std::filesystem::path CacheDataPath();
+  const std::filesystem::path DesktopPath();
+  const std::filesystem::path DownloadsPath();
+  const std::filesystem::path DocumentsPath();
+  const std::filesystem::path VideosPath();
+  const std::filesystem::path PicturesPath();
+  const std::filesystem::path SaveGamesPath();
 
   CardPackagePartitioner& CardPackagePartitioner();
   PlayerPackagePartitioner& PlayerPackagePartitioner();

--- a/BattleNetwork/bnGameSession.cpp
+++ b/BattleNetwork/bnGameSession.cpp
@@ -4,7 +4,7 @@
 #include "netplay/bnBufferWriter.h"
 #include "netplay/bnBufferReader.h"
 
-const bool GameSession::LoadSession(const std::string& inpath)
+const bool GameSession::LoadSession(const std::filesystem::path& inpath)
 {
   monies = 0;
   cardPool.clear();
@@ -56,10 +56,10 @@ const bool GameSession::LoadSession(const std::string& inpath)
 
   for (size_t i = 0; i < collection_len; i++) {
     CardFolder* folder;
-    
+
     // read folder name
     std::string folder_name = reader.ReadString<char>(buffer);
-    
+
     if (!folders.MakeFolder(folder_name)) {
       Logger::Logf(LogLevel::critical, "Unable to create folder `%s`", folder_name.c_str());
       continue;
@@ -77,7 +77,7 @@ const bool GameSession::LoadSession(const std::string& inpath)
       // read code
       char code = reader.Read<char>(buffer);
 
-      // read name 
+      // read name
       std::string name = reader.ReadString<char>(buffer);
 
       Battle::Card::Properties props;
@@ -134,14 +134,14 @@ const bool GameSession::IsFolderAllowed(CardFolder* folder) const
 }
 
 const bool GameSession::IsBlockAllowed(const std::string& packageId) const
-{  
+{
   if (!blockPackages->HasPackage(packageId)) return false;
 
   const std::string& md5 = blockPackages->FindPackageByID(packageId).GetPackageFingerprint();
   return IsPackageAllowed(PackageHash{ packageId, md5 });
 }
 
-void GameSession::SaveSession(const std::string& outpath)
+void GameSession::SaveSession(const std::filesystem::path& outpath)
 {
   BufferWriter writer;
   Poco::Buffer<char> buffer(0);

--- a/BattleNetwork/bnGameSession.h
+++ b/BattleNetwork/bnGameSession.h
@@ -13,7 +13,7 @@ class GameSession {
   CardFolderCollection folders;
   std::vector<std::string> cardPool;
   std::vector<KeyItem> keyItems;
-  std::vector<PackageHash> whitelist; //!< Used to enforce server restrictions in select scenes 
+  std::vector<PackageHash> whitelist; //!< Used to enforce server restrictions in select scenes
   std::map<std::string, std::string> keys; // key-value table
   uint32_t monies{}; //!< Monies on the account
   std::string nickname = "Anon";
@@ -21,11 +21,11 @@ class GameSession {
   CardPackageManager* cardPackages{ nullptr };
   BlockPackageManager* blockPackages{ nullptr };
 public:
-  const bool LoadSession(const std::string& inpath);
+  const bool LoadSession(const std::filesystem::path& inpath);
   const bool IsPackageAllowed(const PackageHash& hash) const; // utility function to compare package with whitelist
   const bool IsFolderAllowed(CardFolder* folder) const;
   const bool IsBlockAllowed(const std::string& packageId) const;
-  void SaveSession(const std::string& outpath);
+  void SaveSession(const std::filesystem::path& outpath);
   void SetKeyValue(const std::string& key, const std::string& value);
   void SetNick(const std::string& nickname);
   void SetCardPackageManager(CardPackageManager& cardPackageManager);

--- a/BattleNetwork/bnMob.cpp
+++ b/BattleNetwork/bnMob.cpp
@@ -142,17 +142,17 @@ std::shared_ptr<Background> Mob::GetBackground() {
   return background;
 }
 
-void Mob::StreamCustomMusic(const std::string& path, long long startMs, long long endMs) {
+void Mob::StreamCustomMusic(const std::filesystem::path& path, long long startMs, long long endMs) {
   music = path;
   this->startMs = startMs;
   this->endMs = endMs;
 }
 
 bool Mob::HasCustomMusicPath() {
-  return music.length() > 0;
+  return !music.empty();
 }
 
-const std::string Mob::GetCustomMusicPath() const {
+const std::filesystem::path Mob::GetCustomMusicPath() const {
   return music;
 }
 

--- a/BattleNetwork/bnMob.h
+++ b/BattleNetwork/bnMob.h
@@ -62,7 +62,7 @@ private:
   bool nextReady{ true }; /*!< Signal if mob is ready to spawn the next character */
   bool isBoss{ false }; /*!< Flag to change rank and music */
   bool isFreedomMission{ false }, playerCanFlip{ false };
-  std::string music; /*!< Override with custom music */
+  std::filesystem::path music; /*!< Override with custom music */
   std::vector<std::shared_ptr<Mutator>> spawn; /*!< The enemies to spawn and manage */
   std::vector<std::shared_ptr<Character>> tracked; /*! Enemies that may or may not be spawned through the mob class but need to be considered */
   std::vector<std::function<void(std::shared_ptr<Character>)>> defaultStateInvokers; /*!< Invoke the character's default state from the spawn policy */
@@ -89,7 +89,7 @@ public:
   ~Mob();
 
   /**
-   * @brief Register a reward for this mob. 
+   * @brief Register a reward for this mob.
    * @param rank Cap ranks between 1-10 and where 11 is Rank S
    * @param item The item to reward with
    */
@@ -97,8 +97,8 @@ public:
 
   /**
    * @brief Find all possible rewards based on this score
-   * @param score generated from BattleRewards class 
-   * @return Randomly chooses possible ranked reward or nullptr if none 
+   * @param score generated from BattleRewards class
+   * @return Randomly chooses possible ranked reward or nullptr if none
    */
   BattleItem* GetRankedReward(int score);
 
@@ -126,21 +126,21 @@ public:
 
   /**
    * @brief removes a character from the mob list
-   * 
+   *
    * When the list is empty, the mob has been cleared
    * We wish to forget about them because the Field class
    * handles deletion of entities that have spawned
-   * 
+   *
    * @see Field
    */
   void Forget(Character& character);
 
   /**
    * @brief Get the count of remaining enemies in battle
-   * 
+   *
    * If health is below or equal to zero, they are skipped
-   * 
-   * @return const int 
+   *
+   * @return const int
    */
   const int GetRemainingMobCount();
 
@@ -150,7 +150,7 @@ public:
   void ToggleBossFlag();
 
   /**
-   * @brief Query if boss battle 
+   * @brief Query if boss battle
    * @return true if isBoss is true, otherwise false
    */
   bool IsBoss();
@@ -183,9 +183,9 @@ public:
 
   /**
    * @brief The battle scene will load this custom music
-   * @param path path relative to the app 
+   * @param path path relative to the app
    */
-  void StreamCustomMusic(const std::string& path, long long startMs = -1LL, long long endMs = -1LL);
+  void StreamCustomMusic(const std::filesystem::path& path, long long startMs = -1LL, long long endMs = -1LL);
 
   /**
    * @brief Checks if custom music path was set
@@ -195,9 +195,9 @@ public:
 
   /**
    * @brief Gets the custom music path
-   * @return const std::string
+   * @return const std::filesystem::path
    */
-  const std::string GetCustomMusicPath() const;
+  const std::filesystem::path GetCustomMusicPath() const;
 
   /**
   * @brief Gets the music loop points
@@ -208,7 +208,7 @@ public:
   /**
    * @brief Gets the mob at spawn index
    * @param index spawn index
-   * @return const Character& 
+   * @return const Character&
    * @throws std::runtime_error if index is not in range
    */
   const Character& GetMobAt(int index);
@@ -247,14 +247,14 @@ public:
   * @param playerNum the player order e.g. player 1 spawns at tile (x,y)
   * @param tileX the column of the target tile
   * @param tileY the row of the target tile
-  * 
+  *
   * @warning will overwrite any existing playerNum spawn data if a previous `playerNum` entry exists
   */
   void SpawnPlayer(unsigned playerNum, int tileX, int tileY);
 
   /**
    * @brief Get the next unspawned enemy
-   * 
+   *
    * Spawns the character and changes its state to PixelInState<>
    * @return SpawnData
    */
@@ -336,7 +336,7 @@ public:
   template<template<typename> class IntroState>
   std::shared_ptr<Mutator> SpawnAt(unsigned x, unsigned y) {
     // assert that tileX and tileY exist in field
-    assert(x >= 1 && x <= static_cast<unsigned>(mob->field->GetWidth()) 
+    assert(x >= 1 && x <= static_cast<unsigned>(mob->field->GetWidth())
         && y >= 1 && y <= static_cast<unsigned>(mob->field->GetHeight()));
 
     // Create a new enemy spawn data object

--- a/BattleNetwork/bnMobPackageManager.cpp
+++ b/BattleNetwork/bnMobPackageManager.cpp
@@ -5,7 +5,7 @@
 #include <atomic>
 #include <thread>
 
-MobMeta::MobMeta(): 
+MobMeta::MobMeta():
   placeholderTexture(nullptr),
   PackageManager<MobMeta>::Meta<MobFactory>()
 {
@@ -26,7 +26,7 @@ void MobMeta::OnMetaParsed()
   placeholderTexture = handle.Textures().LoadFromFile(placeholderPath);
 }
 
-MobMeta& MobMeta::SetPlaceholderTexturePath(std::string path)
+MobMeta& MobMeta::SetPlaceholderTexturePath(const std::filesystem::path& path)
 {
   placeholderPath = path;
   return *this;
@@ -67,7 +67,7 @@ const std::shared_ptr<sf::Texture> MobMeta::GetPlaceholderTexture() const
   return placeholderTexture;
 }
 
-const std::string MobMeta::GetPlaceholderTexturePath() const
+const std::filesystem::path MobMeta::GetPlaceholderTexturePath() const
 {
   return placeholderPath;
 }

--- a/BattleNetwork/bnMobPackageManager.h
+++ b/BattleNetwork/bnMobPackageManager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <map>
 #include <vector>
 #include <functional>
@@ -24,7 +25,7 @@ struct MobMeta final : public PackageManager<MobMeta>::Meta<MobFactory> {
   sf::Sprite placeholder; /*!< Preview image for the mob in select screen */
   std::string name;       /*!< Name of the mob */
   std::string description;/*!< Description of mob that shows up in the text box */
-  std::string placeholderPath; /*!< Path to the preview image */
+  std::filesystem::path placeholderPath; /*!< Path to the preview image */
   std::shared_ptr<sf::Texture> placeholderTexture; /*!< Texture of the preview image */
   int atk; /*!< Strength of mob to display */
   double speed; /*!< Speed of mob to display */
@@ -32,9 +33,9 @@ struct MobMeta final : public PackageManager<MobMeta>::Meta<MobFactory> {
 
   /**
     * @brief Sets mob to temp data
-    */ 
+    */
   MobMeta();
-    
+
   /**
     * @brief deconstructor
     */
@@ -47,79 +48,79 @@ struct MobMeta final : public PackageManager<MobMeta>::Meta<MobFactory> {
     * @param path path to preview texture
     * @return MobMeta& to chain
     */
-  MobMeta& SetPlaceholderTexturePath(std::string path);
-    
+  MobMeta& SetPlaceholderTexturePath(const std::filesystem::path& path);
+
   /**
     * @brief Sets the description that shows up in text box
-    * @param message 
+    * @param message
     * @return MobMeta& to chain
     */
   MobMeta& SetDescription(const std::string& message);
-    
+
   /**
     * @brief Sets the attack to display on the select screen
     * @param atk strength of the mob
     * @return MobMeta& to chain
     */
   MobMeta& SetAttack(const int atk);
-    
+
   /**
     * @brief Sets the speed to display on the select screen
     * @param speed of the mob
     * @return MobMeta& to chain
     */
   MobMeta& SetSpeed(const double speed);
-    
+
   /**
     * @brief Sets the total HP of the mob
     * @param HP health of the mob to display
     * @return MobMeta& to chain
     */
   MobMeta& SetHP(const int HP);
-    
+
   /**
     * @brief Clever title of the mob
     * @param name name of the mob to display
     * @return MobMeta& to chain
     */
   MobMeta& SetName(const std::string& name);
-    
+
   /**
     * @brief Gets the preview texture
     * @return const std::shared_ptr<sf::Texture>
     */
   const std::shared_ptr<sf::Texture> GetPlaceholderTexture() const;
-    
+
   /**
-    * @brief Gets the preview texture path 
+    * @brief Gets the preview texture path
     * @return const std::string
     */
-  const std::string GetPlaceholderTexturePath() const;
-    
+  const std::filesystem::path GetPlaceholderTexturePath() const;
+
   /**
-    * @brief Gets the name of the mob 
+    * @brief Gets the name of the mob
     * @return const std::string
     */
   const std::string GetName() const;
-    
+
   /**
     * @brief Gets the health of the mob as a string
     * @return const std::string
     */
   const std::string GetHPString() const;
-    
+
   /**
     * @brief Gets the speed of the mob as a string
     * @return const std::string
     */
   const std::string GetSpeedString() const;
-    
+
   /**
     * @brief Gets the attack of the mob as a string
     * @return const std::string
     */
   const std::string GetAttackString() const;
-    
+
   /**
     * @brief Gets the mob description to show up in message box
     * @return const std::string

--- a/BattleNetwork/bnPlayerPackageManager.cpp
+++ b/BattleNetwork/bnPlayerPackageManager.cpp
@@ -85,31 +85,31 @@ PlayerMeta& PlayerMeta::SetIsSword(const bool enabled)
   return *this;
 }
 
-PlayerMeta& PlayerMeta::SetMugshotAnimationPath(const std::string& path)
+PlayerMeta& PlayerMeta::SetMugshotAnimationPath(const std::filesystem::path& path)
 {
   mugshotAnimationPath = path;
   return *this;
 }
 
-PlayerMeta& PlayerMeta::SetMugshotTexturePath(const std::string& path)
+PlayerMeta& PlayerMeta::SetMugshotTexturePath(const std::filesystem::path& path)
 {
   mugshotTexturePath = path;
   return *this;
 }
 
-PlayerMeta& PlayerMeta::SetEmotionsTexturePath(const std::string& texture)
+PlayerMeta& PlayerMeta::SetEmotionsTexturePath(const std::filesystem::path& path)
 {
-  emotionsTexturePath = texture;
+  emotionsTexturePath = path;
   return *this;
 }
 
-PlayerMeta& PlayerMeta::SetOverworldAnimationPath(const std::string& path)
+PlayerMeta& PlayerMeta::SetOverworldAnimationPath(const std::filesystem::path& path)
 {
   overworldAnimationPath = path;
   return *this;
 }
 
-PlayerMeta& PlayerMeta::SetOverworldTexturePath(const std::string& path)
+PlayerMeta& PlayerMeta::SetOverworldTexturePath(const std::filesystem::path& path)
 {
   overworldTexturePath = path;
   return *this;
@@ -126,27 +126,27 @@ const std::shared_ptr<Texture> PlayerMeta::GetIconTexture() const
   return iconTexture;
 }
 
-const std::string& PlayerMeta::GetOverworldTexturePath() const
+const std::filesystem::path& PlayerMeta::GetOverworldTexturePath() const
 {
   return overworldTexturePath;
 }
 
-const std::string& PlayerMeta::GetOverworldAnimationPath() const
+const std::filesystem::path& PlayerMeta::GetOverworldAnimationPath() const
 {
   return overworldAnimationPath;
 }
 
-const std::string& PlayerMeta::GetMugshotTexturePath() const
+const std::filesystem::path& PlayerMeta::GetMugshotTexturePath() const
 {
   return mugshotTexturePath;
 }
 
-const std::string& PlayerMeta::GetMugshotAnimationPath() const
+const std::filesystem::path& PlayerMeta::GetMugshotAnimationPath() const
 {
   return mugshotAnimationPath;
 }
 
-const std::string & PlayerMeta::GetEmotionsTexturePath() const
+const std::filesystem::path & PlayerMeta::GetEmotionsTexturePath() const
 {
   return emotionsTexturePath;
 }

--- a/BattleNetwork/bnPlayerPackageManager.h
+++ b/BattleNetwork/bnPlayerPackageManager.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <vector>
+#include <filesystem>
 #include <functional>
 #include <atomic>
 #include <SFML/Graphics.hpp>
@@ -17,11 +18,11 @@ class Player; // forward decl
 /*! \brief Player package entry detail. Assign details to display them in specific screens. */
 struct PlayerMeta final : public PackageManager<PlayerMeta>::Meta<Player>{
   std::string special; /*!< The net navi's special description */
-  std::string overworldAnimationPath; /*!< The net navi's overworld animation */
-  std::string overworldTexturePath; /*!< The path of the texture to load */
-  std::string mugshotTexturePath;
-  std::string mugshotAnimationPath;
-  std::string emotionsTexturePath; /*!< The path of the texture containing all possible emotions, ordered by emotion enum */
+  std::filesystem::path overworldAnimationPath; /*!< The net navi's overworld animation */
+  std::filesystem::path overworldTexturePath; /*!< The path of the texture to load */
+  std::filesystem::path mugshotTexturePath;
+  std::filesystem::path mugshotAnimationPath;
+  std::filesystem::path emotionsTexturePath; /*!< The path of the texture containing all possible emotions, ordered by emotion enum */
   std::string name; /*!< The net navi's name */
   std::shared_ptr<sf::Texture> iconTexture; /*!< Icon on the top of the screen */
   std::shared_ptr<sf::Texture> previewTexture; /*!< Roster profile picture */
@@ -91,34 +92,34 @@ struct PlayerMeta final : public PackageManager<PlayerMeta>::Meta<Player>{
  * @brief Sets the mugshot animation path used in textboxes
  * @return PlayerMeta& to chain
  */
-  PlayerMeta& SetMugshotAnimationPath(const std::string& path);
+  PlayerMeta& SetMugshotAnimationPath(const std::filesystem::path& path);
 
   /**
    * @brief Sets the texture of the mugshot animation
    * @param texture
    * @return PlayerMeta& to chain
    */
-  PlayerMeta& SetMugshotTexturePath(const std::string& texture);
+  PlayerMeta& SetMugshotTexturePath(const std::filesystem::path& path);
 
   /**
    * @brief Sets the emotions texture atlas
    * @param texture
    * @return PlayerMeta& to chain
    */
-  PlayerMeta& SetEmotionsTexturePath(const std::string& texture);
+  PlayerMeta& SetEmotionsTexturePath(const std::filesystem::path& path);
 
   /**
    * @brief Sets the overworld animation path used in menu screen
    * @return PlayerMeta& to chain
    */
-  PlayerMeta& SetOverworldAnimationPath(const std::string& path);
+  PlayerMeta& SetOverworldAnimationPath(const std::filesystem::path& path);
 
   /**
    * @brief Sets the texture of the overworld animation
    * @param texture
    * @return PlayerMeta& to chain
    */
-  PlayerMeta& SetOverworldTexturePath(const std::string& texture);
+  PlayerMeta& SetOverworldTexturePath(const std::filesystem::path& path);
 
   /**
    * @brief Sets the texture of the preview used in select screen
@@ -144,31 +145,31 @@ struct PlayerMeta final : public PackageManager<PlayerMeta>::Meta<Player>{
    * @brief Gets the overworld texture path to load
    * @return const std::string&
    */
-  const std::string& GetOverworldTexturePath() const;
+  const std::filesystem::path& GetOverworldTexturePath() const;
 
   /**
    * @brief Gets the overworld animation path
    * @return const std::string&
    */
-  const std::string& GetOverworldAnimationPath() const;
+  const std::filesystem::path& GetOverworldAnimationPath() const;
 
   /**
  * @brief Gets the mugshot texture path
  * @return const std::string&
  */
-  const std::string& GetMugshotTexturePath() const;
+  const std::filesystem::path& GetMugshotTexturePath() const;
 
   /**
  * @brief Gets the mugshot animation path
  * @return const std::string&
  */
-  const std::string& GetMugshotAnimationPath() const;
+  const std::filesystem::path& GetMugshotAnimationPath() const;
 
   /**
  * @brief Gets the emotions texture path
  * @return const std::string&
  */
-  const std::string& GetEmotionsTexturePath() const;
+  const std::filesystem::path& GetEmotionsTexturePath() const;
 
   /**
    * @brief Gets the preview texture to draw

--- a/BattleNetwork/bnScriptResourceManager.h
+++ b/BattleNetwork/bnScriptResourceManager.h
@@ -34,7 +34,7 @@ struct ScriptPackage {
   sol::state* state{ nullptr };
   ScriptPackageType type;
   PackageAddress address;
-  std::string path;
+  std::filesystem::path path;
   std::vector<std::string> subpackages;
   std::vector<std::string> dependencies;
 };
@@ -47,7 +47,7 @@ public:
 
   void DropPackageData(sol::state* state);
   void DropPackageData(const PackageAddress& addr);
-  ScriptPackage* DefinePackage(ScriptPackageType type, const std::string& namespaceId, const std::string& fqn, const std::string& path); /* throws */
+  ScriptPackage* DefinePackage(ScriptPackageType type, const std::string& namespaceId, const std::string& fqn, const std::filesystem::path& path); /* throws */
   ScriptPackage* FetchScriptPackage(const std::string& namespaceId, const std::string& fqn, ScriptPackageType type);
   void SetCardPackagePartitioner(CardPackagePartitioner& partition);
   CardPackagePartitioner& GetCardPackagePartitioner();
@@ -61,13 +61,13 @@ private:
   CardPackagePartitioner* cardPartition{ nullptr };
 
   void ConfigureEnvironment(ScriptPackage& scriptPackage);
-  void DefineSubpackage(ScriptPackage& parentPackage, ScriptPackageType type, const std::string& fqn, const std::string& path); /* throws */
+  void DefineSubpackage(ScriptPackage& parentPackage, ScriptPackageType type, const std::string& fqn, const std::filesystem::path& path); /* throws */
   void SetSystemFunctions(ScriptPackage& scriptPackage);
   void SetModPathVariable(sol::state& state, const std::filesystem::path& modDirectory);
 
   static std::string GetCurrentLine( lua_State* L );
-  static stx::result_t<std::string> GetCurrentFile(lua_State* L);
-  static stx::result_t<std::string> GetCurrentFolder(lua_State* L);
+  static stx::result_t<std::filesystem::path> GetCurrentFile(lua_State* L);
+  static stx::result_t<std::filesystem::path> GetCurrentFolder(lua_State* L);
 };
 
 #endif

--- a/BattleNetwork/bnSelectMobScene.cpp
+++ b/BattleNetwork/bnSelectMobScene.cpp
@@ -61,7 +61,7 @@ SelectMobScene::SelectMobScene(swoosh::ActivityController& controller, SelectMob
   bg.setTexture(Textures().LoadFromFile(TexturePaths::BATTLE_SELECT_BG));
   bg.setScale(2.f, 2.f);
 
-  gotoNextScene = true; 
+  gotoNextScene = true;
   doOnce = false; // wait until the scene starts or resumes
   showMob = false;
 
@@ -103,7 +103,7 @@ void SelectMobScene::onUpdate(double elapsed) {
       selectInputCooldown -= elapsed;
 
       if (selectInputCooldown <= 0) {
-        // Go to previous mob 
+        // Go to previous mob
         selectInputCooldown = maxSelectInputCooldown;
         mobSelectionId = getController().MobPackagePartitioner().GetPartition(Game::LocalPartition).GetPackageBefore(mobSelectionId);
 
@@ -115,7 +115,7 @@ void SelectMobScene::onUpdate(double elapsed) {
       selectInputCooldown -= elapsed;
 
       if (selectInputCooldown <= 0) {
-        // Go to next mob 
+        // Go to next mob
         selectInputCooldown = maxSelectInputCooldown;
         mobSelectionId = getController().MobPackagePartitioner().GetPartition(Game::LocalPartition).GetPackageAfter(mobSelectionId);
 
@@ -280,7 +280,7 @@ void SelectMobScene::onUpdate(double elapsed) {
 
       count--;
     }
-    
+
     count = (int)mobinfo.GetAttackString().size() - 1;
 
     while (count >= 0) {
@@ -291,7 +291,7 @@ void SelectMobScene::onUpdate(double elapsed) {
 
       count--;
     }
-    
+
     count = (int)mobinfo.GetSpeedString().size() - 1;
 
     while (count >= 0) {
@@ -309,9 +309,9 @@ void SelectMobScene::onUpdate(double elapsed) {
     mobLabel.SetString(sf::String(newstr));
   }
 
-  
+
   /**
-   * End scramble effect 
+   * End scramble effect
    */
 
   factor -= (float)elapsed * PIXEL_SPEED;
@@ -323,9 +323,9 @@ void SelectMobScene::onUpdate(double elapsed) {
   // Progress for data scramble effect
   float progress = (maxNumberCooldown - numberCooldown) / maxNumberCooldown;
 
-  if (progress > 1.f) { 
-    progress = 1.f; 
-  
+  if (progress > 1.f) {
+    progress = 1.f;
+
   if(!gotoNextScene) {
       textbox.Play();
     }
@@ -360,15 +360,15 @@ void SelectMobScene::onUpdate(double elapsed) {
       // Play the pre battle rumble sound
       Audio().Play(AudioType::PRE_BATTLE, AudioPriority::high);
 
-      // Stop music and go to battle screen 
+      // Stop music and go to battle screen
       Audio().StopStream();
 
 
       // Get the navi we selected
       auto& meta = getController().PlayerPackagePartitioner().GetPartition(Game::LocalPartition).FindPackageByID(selectedNaviId);
-      const std::string& image = meta.GetMugshotTexturePath();
-      const std::string& mugshotAnim = meta.GetMugshotAnimationPath();
-      const std::string& emotionsTexture = meta.GetEmotionsTexturePath();
+      const std::filesystem::path& image = meta.GetMugshotTexturePath();
+      const std::filesystem::path& mugshotAnim = meta.GetMugshotAnimationPath();
+      const std::filesystem::path& emotionsTexture = meta.GetEmotionsTexturePath();
       auto mugshot = Textures().LoadFromFile(image);
       auto emotions = Textures().LoadFromFile(emotionsTexture);
       auto player = std::shared_ptr<Player>(meta.GetData());
@@ -410,7 +410,7 @@ void SelectMobScene::onUpdate(double elapsed) {
         getController().push<effect::to<FreedomMissionMobScene>>(std::move(props));
       }
       else {
-        MobBattleProperties props{ 
+        MobBattleProperties props{
           { player, programAdvance, std::move(newFolder), mob->GetField(), mob->GetBackground() },
           MobBattleProperties::RewardBehavior::take,
           { mob },
@@ -508,16 +508,16 @@ void SelectMobScene::onDraw(sf::RenderTexture & surface) {
     // If there are no more items to the left, fade the cursor
   //  cursor.setColor(sf::Color(255, 255, 255, 100));
   //}
-     
+
   // Add sine offset to create a bob effect
   auto offset = std::sin(elapsed*10.0) * 5;
-  
+
   // Put the left cursor on the left of the mob
   cursor.setPosition(23.0f + (float)offset, 130.0f);
-  
+
   // Flip the x axis
   cursor.setScale(-2.f, 2.f);
-  
+
   // Draw left cursor
   surface.draw(cursor);
 
@@ -531,13 +531,13 @@ void SelectMobScene::onDraw(sf::RenderTexture & surface) {
 
   // Add sine offset to create a bob effect
   offset = -std::sin(elapsed*10.0) * 5;
-  
+
   // Put the right cursor on the right of the mob
   cursor.setPosition(200.0f + (float)offset, 130.0f);
-  
+
   // Flip the x axis
   cursor.setScale(2.f, 2.f);
-  
+
   // Draw the right cursor
   surface.draw(cursor);
 }

--- a/BattleNetwork/bnShaderResourceManager.h
+++ b/BattleNetwork/bnShaderResourceManager.h
@@ -1,10 +1,10 @@
 /*! \file bnShaderResourceManager.h */
 
 /*! \brief Singleton resource manager for scripts and lua state machine
- * 
+ *
  * Script resource manager is intended to be a closed-off resource that the battle engine
  * uses to fetch and inject lua into the environment
- * Some Scripted class implementations will use this resource to pass off to the correct callbacks 
+ * Some Scripted class implementations will use this resource to pass off to the correct callbacks
  */
 
 #pragma once
@@ -12,6 +12,7 @@
 #include "bnLogger.h"
 
 #include <SFML/Graphics.hpp>
+#include <filesystem>
 #include <map>
 #include <vector>
 #include <iostream>
@@ -25,24 +26,24 @@ using std::pair;
 using std::string;
 
 class ShaderResourceManager {
-public:  
+public:
   /**
    * @brief Loads all hard-coded shaders
    * @param status Increases the count after each shader loads
    */
   void LoadAllShaders (std::atomic<int> &status);
-  
+
   /**
    * @brief Given a file path, returns a pointer to the loaded shader
    * @param _path Relative path to the application
    * @return Shader pointer. Must manually delete.
    */
-  sf::Shader* LoadShaderFromFile(string _path);
-  
+  sf::Shader* LoadShaderFromFile(const std::filesystem::path& _path);
+
   /**
    * @brief Returns pointer to the pre-loaded shader type
    * @param _ttype shader type to fetch from cache
-   * @return Shader pointer. 
+   * @return Shader pointer.
    * @warning Do not delete! This resource is managed by the manager.
    */
   sf::Shader* GetShader(ShaderType _ttype);
@@ -53,7 +54,7 @@ public:
   ~ShaderResourceManager();
 private:
   std::mutex mutex;
-  vector<string> paths;  /*!< Paths to all shaders. Must be in order of ShaderType @see ShaderType */
+  vector<std::filesystem::path> paths;  /*!< Paths to all shaders. Must be in order of ShaderType @see ShaderType */
   bool isEnabled{};
   map<ShaderType, sf::Shader*> shaders; /*!< cache */
 };

--- a/BattleNetwork/bnTextureResourceManager.cpp
+++ b/BattleNetwork/bnTextureResourceManager.cpp
@@ -6,6 +6,8 @@
 #include <fstream>
 #include <mutex>
 
+#include "bnFileUtil.h"
+
 using std::ifstream;
 using std::stringstream;
 
@@ -37,7 +39,7 @@ void TextureResourceManager::HandleExpiredTextureCache()
   }
 }
 
-std::shared_ptr<Texture> TextureResourceManager::LoadFromFile(string _path) {
+std::shared_ptr<Texture> TextureResourceManager::LoadFromFile(const std::filesystem::path& _path) {
   //std::scoped_lock lock(mutex);
 
   auto iter = texturesFromPath.find(_path);
@@ -56,11 +58,12 @@ std::shared_ptr<Texture> TextureResourceManager::LoadFromFile(string _path) {
   }
 
   std::shared_ptr<Texture> texture = std::make_shared<Texture>();
-  
-  if (!texture->loadFromFile(_path)) {
-    Logger::Logf(LogLevel::critical, "Failed loading texture: %s", _path.c_str());
+
+  StdFilesystemInputStream stream(_path);
+  if (!texture->loadFromStream(stream)) {
+    Logger::Log(LogLevel::critical, "Failed loading texture: " + _path.u8string());
   } else {
-    Logger::Logf(LogLevel::info, "Loaded texture: %s", _path.c_str());
+    Logger::Log(LogLevel::info, "Loaded texture: " + _path.u8string());
   }
 
   if (!skipCaching) {

--- a/BattleNetwork/bnTextureResourceManager.h
+++ b/BattleNetwork/bnTextureResourceManager.h
@@ -1,8 +1,8 @@
 /*! \file bnTextureResourceManager.h */
 
 /*! \brief resource manager for texture data
- * 
- * Texture resource manager provides utilities to load textures from disc 
+ *
+ * Texture resource manager provides utilities to load textures from disc
  * as well as hard-coded textures loaded at startup.
  */
 
@@ -13,6 +13,7 @@
 
 #include <SFML/Graphics.hpp>
 #include <map>
+#include <filesystem>
 #include <vector>
 #include <iostream>
 #include <atomic>
@@ -43,16 +44,16 @@ public:
   * @brief will clean expired textures from the cache and free image data
   */
   void HandleExpiredTextureCache();
-  
+
   /**
    * @brief Given a file path, returns a pointer to the loaded texture
    * @param _path Relative path to the application
    * @return Texture. The texture is cached.
    */
-  std::shared_ptr<Texture> LoadFromFile(string _path);
+  std::shared_ptr<Texture> LoadFromFile(const std::filesystem::path& _path);
 
 private:
   std::mutex mutex;
-  vector<string> paths; /**< Paths to all textures. Must be in order of TextureType @see TextureType */
-  map<std::string, CachedResource<Texture>> texturesFromPath; /**< Cache for textures loaded at run-time */
+  vector<std::filesystem::path> paths; /**< Paths to all textures. Must be in order of TextureType @see TextureType */
+  map<std::filesystem::path, CachedResource<Texture>> texturesFromPath; /**< Cache for textures loaded at run-time */
 };

--- a/BattleNetwork/bnTitleScene.cpp
+++ b/BattleNetwork/bnTitleScene.cpp
@@ -26,7 +26,7 @@ TitleScene::TitleScene(swoosh::ActivityController& controller, TaskGroup&& tasks
 {
   // Title screen logo based on region
   std::shared_ptr<sf::Texture> logo;
-  
+
   if (getController().CommandLineValue<std::string>("locale") == "jp") {
     logo = Textures().LoadFromFile("resources/scenes/title/tile.png");
   }
@@ -120,13 +120,13 @@ void TitleScene::onUpdate(double elapsed)
     PlayerPackageManager& pm = getController().PlayerPackagePartitioner().GetPartition(Game::LocalPartition);
 
     if (pm.Size() == 0) {
-      std::string path = "resources/ow/prog/";
+      std::filesystem::path path("resources/ow/prog");
       std::string msg = "Looks like you need a Player Mod to continue.\nDownload one and put it under:\n\n`resources/\n mods/\n players/`\nThen re-launch to start playing!";
       sf::Sprite spr;
-      spr.setTexture(*Textures().LoadFromFile(path+"prog_mug.png"));
+      spr.setTexture(*Textures().LoadFromFile(path / "prog_mug.png"));
       currMessage = new Message(msg);
       currMessage->ShowEndMessageCursor();
-      textbox.EnqueMessage(spr, path + "prog_mug.animation", currMessage);
+      textbox.EnqueMessage(spr, path / "prog_mug.animation", currMessage);
       textbox.Open();
       Audio().Play(AudioType::CHIP_DESC, AudioPriority::high);
     }

--- a/BattleNetwork/bnVendorScene.cpp
+++ b/BattleNetwork/bnVendorScene.cpp
@@ -1,21 +1,23 @@
 #include "bnVendorScene.h"
 #include "bnMessage.h"
 #include "bnTextureResourceManager.h"
+
+#include <filesystem>
 #include <Segues/BlackWashFade.h>
 
 //
-// Background 
+// Background
 //
 
 #define TILEW 64
 #define TILEH 64
 
-#define PATH std::string("resources/scenes/vendors/")
+#define PATH std::filesystem::path("resources/scenes/vendors")
 
 VendorScene::VendorBackground::VendorBackground() :
   x(0.0f),
   y(0.0f),
-  Background(Textures().LoadFromFile(PATH + "bg.png"), 240, 180)
+  Background(Textures().LoadFromFile(PATH / "bg.png"), 240, 180)
 {
   FillScreen(sf::Vector2u(TILEW, TILEH));
 }

--- a/BattleNetwork/main.cpp
+++ b/BattleNetwork/main.cpp
@@ -144,7 +144,7 @@ void ParseErrorLevel(std::string in) {
     valid.clear();
     valid.push_back("all");
   }
-  
+
   std::string validStr = "silent";
 
   for (size_t i = 0; i < valid.size(); i++) {
@@ -157,7 +157,7 @@ void ParseErrorLevel(std::string in) {
 
   msg += "`" + validStr + "`";
   std::cerr << msg << std::endl;
-  
+
   Logger::SetLogLevel(level);
 }
 
@@ -220,7 +220,7 @@ int LaunchGame(Game& g, const cxxopts::ParseResult& results) {
     return EXIT_SUCCESS;
   }
 
-  // If single player game, the last screen the player will ever see 
+  // If single player game, the last screen the player will ever see
   // is the game over screen so it goes to the bottom of the stack
   // before the TitleSceene:
   // g.push<GameOverScene>(); // <-- uncomment
@@ -256,16 +256,16 @@ int HandleBattleOnly(Game& g, TaskGroup tasks, const std::string& playerpath, co
   // Play the pre battle rumble sound
   handle.Audio().Play(AudioType::PRE_BATTLE, AudioPriority::high);
 
-  // Stop music and go to battle screen 
+  // Stop music and go to battle screen
   handle.Audio().StopStream();
 
   auto field = std::make_shared<Field>(6, 3);
 
   // Get the navi we selected
   auto& playermeta = g.PlayerPackagePartitioner().GetPartition(Game::LocalPartition).FindPackageByID(playerpath);
-  const std::string& image = playermeta.GetMugshotTexturePath();
-  Animation mugshotAnim = Animation() << playermeta.GetMugshotAnimationPath();
-  const std::string& emotionsTexture = playermeta.GetEmotionsTexturePath();
+  const std::filesystem::path& image = playermeta.GetMugshotTexturePath();
+  Animation mugshotAnim = Animation(playermeta.GetMugshotAnimationPath());
+  const std::filesystem::path& emotionsTexture = playermeta.GetEmotionsTexturePath();
   auto mugshot = handle.Textures().LoadFromFile(image);
   auto emotions = handle.Textures().LoadFromFile(emotionsTexture);
   auto player = std::shared_ptr<Player>(playermeta.GetData());
@@ -323,7 +323,7 @@ stx::result_t<std::string> DownloadPackageFromURL(const std::string& url, Packag
     return stx::error<std::string>("Unable to download package. Result was HTTP_UNAUTHORIZED. Aborting.");
   }
 
-  std::string outpath = "cache/" + stx::rand_alphanum(12) + ".zip";
+  std::filesystem::path outpath = std::filesystem::path("cache") / std::filesystem::path(stx::rand_alphanum(12) + ".zip");
   std::ofstream ofs(outpath, std::fstream::binary);
   Poco::StreamCopier::copyStream(rs, ofs);
   ofs.close();
@@ -334,12 +334,12 @@ stx::result_t<std::string> DownloadPackageFromURL(const std::string& url, Packag
 std::unique_ptr<CardFolder> LoadFolderFromFile(const std::string& filePath, CardPackageManager& packageManager) {
   std::unique_ptr<CardFolder> folder = std::make_unique<CardFolder>();
   std::fstream file;
-  file.open(filePath, std::ios::in); 
+  file.open(filePath, std::ios::in);
   const char space = ' ';
 
   if (file.is_open()) {
     std::string line;
-    while (std::getline(file, line)) { 
+    while (std::getline(file, line)) {
       std::vector<std::string> tokens = stx::tokenize(line, space);
 
       if (tokens.size() < 2) {
@@ -461,7 +461,7 @@ void ReadPackageStep(PackageManagerT& pm, const std::string& path, std::string& 
   hash = pm.FindPackageByID(id).GetPackageFingerprint();
 }
 
-// NOTE: Game needs to instantiate before calling this function so 
+// NOTE: Game needs to instantiate before calling this function so
 //       that PackageManager's ResourceHandle variable will
 //       have a valid script manager ptr!
 void ReadPackageAndHash(const std::string& path, const std::string& modType) {

--- a/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
+++ b/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
@@ -11,7 +11,7 @@
 #include "../../bnBlockPackageManager.h"
 #include "../../bnPlayerHealthUI.h"
 
-// states 
+// states
 #include "states/bnNetworkSyncBattleState.h"
 #include "../../battlescene/States/bnRewardBattleState.h"
 #include "../../battlescene/States/bnTimeFreezeBattleState.h"
@@ -194,9 +194,9 @@ void NetworkBattleScene::OnHit(Entity& victim, const Hit::Properties& props)
   if (props.damage > 0) {
     if (props.damage >= 300) {
       player->SetEmotion(Emotion::angry);
-      
+
       std::shared_ptr<PlayerSelectedCardsUI> ui = player->GetFirstComponent<PlayerSelectedCardsUI>();
-      
+
       if (ui) {
         ui->SetMultiplier(2);
       }
@@ -241,7 +241,7 @@ void NetworkBattleScene::onUpdate(double elapsed) {
 
     SendFrameData(events, (FrameNumber() + frames(5)).count());
   }
-  
+
   if (!remoteInputQueue.empty()) {
     auto frame = remoteInputQueue.begin();
 
@@ -360,7 +360,7 @@ void NetworkBattleScene::onEnd()
 
 const NetPlayFlags& NetworkBattleScene::GetRemoteStateFlags()
 {
-  return remoteState; 
+  return remoteState;
 }
 
 const double NetworkBattleScene::GetAvgLatency() const
@@ -371,6 +371,7 @@ const double NetworkBattleScene::GetAvgLatency() const
 bool NetworkBattleScene::IsRemoteBehind()
 {
   return FrameNumber() > this->maxRemoteFrameNumber;
+  Logger::Logf(LogLevel::debug, "received maxRemoteFrameNumber: %d", maxRemoteFrameNumber);
 }
 
 void NetworkBattleScene::Init()
@@ -402,7 +403,7 @@ void NetworkBattleScene::Init()
   }
 
   std::shared_ptr<MobHealthUI> ui = remotePlayer->GetFirstComponent<MobHealthUI>();
-  
+
   if (ui) {
     ui->SetManualMode(true);
     ui->SetHP(remotePlayer->GetHealth());
@@ -575,7 +576,7 @@ void NetworkBattleScene::RecieveHandshakeSignal(const Poco::Buffer<char>& buffer
 
   // Supply the final hand info
   remoteCardActionUsePublisher->LoadCards(remoteHand);
-  
+
   // Convert to microseconds and use this as the round start delay
   roundStartDelay = from_milliseconds((long long)((duration*1000.0) + packetProcessor->GetAvgLatency()));
 
@@ -607,7 +608,7 @@ void NetworkBattleScene::RecieveFrameData(const Poco::Buffer<char>& buffer)
   }
 
   remoteInputQueue.push_back({ frameNumber, events });
-  
+
   if (remotePlayer) {
     std::shared_ptr<MobHealthUI> ui = remotePlayer->GetFirstComponent<MobHealthUI>();
     remotePlayer->SetHealth(hp);
@@ -794,10 +795,10 @@ void NetworkBattleScene::UpdatePingIndicator(frame_time_t frames)
   }
   else if (count >= 3) {
     // 3rd frame is average - ok but not best
-    idx = 3; 
+    idx = 3;
   }
   else  {
-    // 4th frame is excellent or zero latency 
+    // 4th frame is excellent or zero latency
     idx = 4;
   }
 

--- a/BattleNetwork/netplay/bnDownloadScene.cpp
+++ b/BattleNetwork/netplay/bnDownloadScene.cpp
@@ -18,7 +18,7 @@
 constexpr std::string_view CACHE_FOLDER = "cache";
 
 // class DownloadScene
-DownloadScene::DownloadScene(swoosh::ActivityController& ac, const DownloadSceneProps& props) : 
+DownloadScene::DownloadScene(swoosh::ActivityController& ac, const DownloadSceneProps& props) :
   downloadSuccess(props.downloadSuccess),
   coinFlip(props.coinFlip),
   lastScreen(props.lastScreen),
@@ -37,7 +37,7 @@ DownloadScene::DownloadScene(swoosh::ActivityController& ac, const DownloadScene
   std::sort(playerBlockPackageList.begin(), playerBlockPackageList.end());
   playerBlockPackageList.erase(std::unique(playerBlockPackageList.begin(), playerBlockPackageList.end()), playerBlockPackageList.end());
 
-  downloadSuccess = false; 
+  downloadSuccess = false;
 
   packetProcessor = props.packetProcessor;
   packetProcessor->SetKickCallback([this] {
@@ -507,7 +507,7 @@ void DownloadScene::RecieveTransition(const Poco::Buffer<char>& buffer)
   transitionToPvp = true;
 
   // sync seed
-  getController().SeedRand(maxSeed); 
+  getController().SeedRand(maxSeed);
   Logger::Logf(LogLevel::debug, "Using seed %d", maxSeed);
 }
 
@@ -555,7 +555,7 @@ void DownloadScene::DownloadPlayerData(const Poco::Buffer<char>& buffer)
 
     result = RemotePlayerPartition().LoadPackageFromZip<ScriptedPlayer>(path);
   }
-  
+
   if (result.is_error()) {
     Logger::Logf(LogLevel::critical, "Failed to download custom navi with package ID %s: %s", packageId.c_str(), result.error_cstr());
 
@@ -657,7 +657,7 @@ Poco::Buffer<char> DownloadScene::SerializePackageData(const std::string& packag
 
   BufferWriter writer;
   size_t len = 0;
-  
+
   auto result = packageManager.GetPackageFilePath(packageId);
   if (result.is_error()) {
     Logger::Logf(LogLevel::critical, "Could not serialize package: %s", result.error_cstr());
@@ -666,12 +666,12 @@ Poco::Buffer<char> DownloadScene::SerializePackageData(const std::string& packag
     SendDownloadComplete(false);
   }
   else {
-    std::string path = result.value();
-    
-    if (auto result = stx::zip(path, path + ".zip"); result.value()) {
-      path = path + ".zip";
+    std::filesystem::path path = result.value();
+    std::filesystem::path zipPath = path;
+    zipPath.concat(".zip");
 
-      std::ifstream fs(path, std::ios::binary | std::ios::ate);
+    if (auto result = stx::zip(path, zipPath); result.value()) {
+      std::ifstream fs(zipPath, std::ios::binary | std::ios::ate);
       std::ifstream::pos_type pos = fs.tellg();
       len = pos;
       fileBuffer.resize(len);
@@ -732,7 +732,7 @@ void DownloadScene::onUpdate(double elapsed)
 
     return;
   }
-  
+
   if (AllTasksComplete()) {
     SendDownloadComplete(true);
 

--- a/BattleNetwork/netplay/bnMatchMakingScene.cpp
+++ b/BattleNetwork/netplay/bnMatchMakingScene.cpp
@@ -18,9 +18,9 @@
 
 using namespace swoosh::types;
 
-MatchMakingScene::MatchMakingScene(swoosh::ActivityController& controller, const std::string& naviId, std::unique_ptr<CardFolder> _folder, PA& pa) : 
-  textbox(sf::Vector2f(4, 250)), 
-  selectedNaviId(naviId), 
+MatchMakingScene::MatchMakingScene(swoosh::ActivityController& controller, const std::string& naviId, std::unique_ptr<CardFolder> _folder, PA& pa) :
+  textbox(sf::Vector2f(4, 250)),
+  selectedNaviId(naviId),
   folder(std::move(_folder)), pa(pa),
   uiAnim("resources/ui/pvp_widget.animation"),
   text(Font::Style::thick),
@@ -38,7 +38,7 @@ MatchMakingScene::MatchMakingScene(swoosh::ActivityController& controller, const
   float h = static_cast<float>(controller.getVirtualWindowSize().y);
   vs.setPosition(w / 2.f, h / 2.f);
   swoosh::game::setOrigin(vs.getSprite(), 0.5, 0.5);
-  
+
   // hide this until it is ready
   vs.setScale(0.f, 0.f);
 
@@ -56,12 +56,12 @@ MatchMakingScene::MatchMakingScene(swoosh::ActivityController& controller, const
   clientPreview.setTexture(playerPkg.GetPreviewTexture());
   clientPreview.setScale(2.f, 2.f);
   clientPreview.setOrigin(clientPreview.getLocalBounds().width, clientPreview.getLocalBounds().height);
-  
+
   // flip the remote player
   remotePreview.setScale(-2.f, 2.f);
 
   // text / font
-  text.setPosition(45.f, 4.f); 
+  text.setPosition(45.f, 4.f);
 
   // upscale text
   text.setScale(2.f, 2.f);
@@ -169,9 +169,9 @@ void MatchMakingScene::HandlePasteEvent()
 
         // If everything goes well, we have no error with the address...
         hasError = false;
-      } 
+      }
     }
-    
+
     if(hasError) {
       Audio().Play(AudioType::CHIP_ERROR);
       help = new Message("Bad IP");
@@ -335,9 +335,9 @@ const bool MatchMakingScene::IsValidIPv4(const std::string& ip) const {
   if (ip.find(home) != std::string::npos || ip.find(local) != std::string::npos) {
     size_t pos = ip.find(colon);
     std::string port = ip.substr(pos);
-    
+
     // Do not connect to ourselves...
-    // Note: bad things happen but really shouldn't here, why? 
+    // Note: bad things happen but really shouldn't here, why?
     //       you can connect fine in overworld...
     if (atoi(port.c_str()) == Net().GetSocket().address().port()) {
       return false;
@@ -364,7 +364,7 @@ void MatchMakingScene::Reset()
   remoteNaviPackage = PackageAddress{};
 
   this->isScreenReady = true;
-  
+
   // hide this until it is ready
   vs.setScale(0.f, 0.f);
 
@@ -576,7 +576,7 @@ void MatchMakingScene::onUpdate(double elapsed) {
       // Play the pre battle sound
       Audio().Play(AudioType::PRE_BATTLE, AudioPriority::high);
 
-      // Stop music and go to battle screen 
+      // Stop music and go to battle screen
       Audio().StopStream();
 
       // Configure the session
@@ -584,9 +584,9 @@ void MatchMakingScene::onUpdate(double elapsed) {
       BlockPackagePartitioner& blockPartitioner = getController().BlockPackagePartitioner();
 
       PlayerMeta& meta = playerPartitioner.FindPackageByAddress({ Game::LocalPartition, selectedNaviId });
-      const std::string& image = meta.GetMugshotTexturePath();
-      const std::string& mugshotAnim = meta.GetMugshotAnimationPath();
-      const std::string& emotionsTexture = meta.GetEmotionsTexturePath();
+      const std::filesystem::path& image = meta.GetMugshotTexturePath();
+      const std::filesystem::path& mugshotAnim = meta.GetMugshotAnimationPath();
+      const std::filesystem::path& emotionsTexture = meta.GetEmotionsTexturePath();
       std::shared_ptr<sf::Texture> mugshot = Textures().LoadFromFile(image);
       std::shared_ptr<sf::Texture> emotions = Textures().LoadFromFile(emotionsTexture);
       std::shared_ptr<Player> player = std::shared_ptr<Player>(meta.GetData());
@@ -647,7 +647,7 @@ void MatchMakingScene::onUpdate(double elapsed) {
       infoMode = true;
       Audio().Play(AudioType::CHIP_DESC_CLOSE);
       HandleInfoMode();
-    } 
+    }
     else if (Input().Has(InputEvents::pressed_confirm) && !infoMode && packetProcessor->RemoteAddrIsValid() && !systemEvent) {
       Net().AddHandler(packetProcessor->GetRemoteAddr(), packetProcessor);
 

--- a/BattleNetwork/overworld/bnIdentityManager.cpp
+++ b/BattleNetwork/overworld/bnIdentityManager.cpp
@@ -3,15 +3,15 @@
 #include "bnServerAssetManager.h"
 #include "../bnFileUtil.h"
 #include <Poco/RandomStream.h>
-#include <filesystem>
 
-constexpr std::string_view IDENTITY_FOLDER = "identity";
 constexpr std::streamsize IDENTITY_LENGTH = 32;
+
+#define IDENTITY_FOLDER std::filesystem::path("identity")
 
 namespace Overworld {
   IdentityManager::IdentityManager(const std::string& host, uint16_t port)
   {
-    path = std::string(IDENTITY_FOLDER) + "/" + URIEncode(host + "_p" + std::to_string(port));
+    path = IDENTITY_FOLDER / URIEncode(host + "_p" + std::to_string(port));
   }
 
   std::string IdentityManager::GetIdentity() {

--- a/BattleNetwork/overworld/bnIdentityManager.h
+++ b/BattleNetwork/overworld/bnIdentityManager.h
@@ -1,4 +1,5 @@
 #include <string>
+#include <filesystem>
 
 namespace Overworld {
   /**
@@ -10,7 +11,7 @@ namespace Overworld {
 
       std::string GetIdentity();
     private:
-      std::string path;
+      std::filesystem::path path;
       std::string identity;
   };
 }

--- a/BattleNetwork/overworld/bnOverworldHomepage.cpp
+++ b/BattleNetwork/overworld/bnOverworldHomepage.cpp
@@ -110,7 +110,7 @@ Overworld::Homepage::Homepage(swoosh::ActivityController& controller) :
     mrprog->SetSolid(true);
     mrprog->SetCollisionRadius(5);
 
-    // we ensure pointer to mrprog is alive because when we interact, 
+    // we ensure pointer to mrprog is alive because when we interact,
     // mrprog must've been alive to interact in the first place...
     mrprog->SetInteractCallback([mrprog = mrprog.get(), this](const auto& with, const auto& event) {
       // Face them
@@ -327,12 +327,10 @@ void Overworld::Homepage::onUpdate(double elapsed)
 
   if (Input().Has(InputEvents::pressed_shoulder_right) && !IsInputLocked()) {
     PlayerMeta& meta = getController().PlayerPackagePartitioner().GetPartition(Game::LocalPartition).FindPackageByID(GetCurrentNaviID());
-    const std::string& image = meta.GetMugshotTexturePath();
-    const std::string& anim = meta.GetMugshotAnimationPath();
-    auto mugshot = Textures().LoadFromFile(image);
+    auto mugshot = Textures().LoadFromFile(meta.GetMugshotTexturePath());
 
     auto& menuSystem = GetMenuSystem();
-    menuSystem.SetNextSpeaker(sf::Sprite(*mugshot), anim);
+    menuSystem.SetNextSpeaker(sf::Sprite(*mugshot), meta.GetMugshotAnimationPath());
     menuSystem.EnqueueMessage("This is your homepage.");
     menuSystem.EnqueueMessage("You can edit it anyway you like!");
 

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -4,6 +4,7 @@
 #include <Poco/Buffer.h>
 #include <map>
 #include <unordered_map>
+#include <filesystem>
 #include <functional>
 
 #include "../bnBattleResults.h"
@@ -127,10 +128,10 @@ namespace Overworld {
     void CheckPlayerAgainstWhitelist();
 
     template <typename ScriptedType, typename Partition>
-    void InstallPackage(Partition& partition, const std::string& modFolder, const std::string& packageName, const std::string& packageId, const std::string& filePath);
+    void InstallPackage(Partition& partition, const std::filesystem::path& modFolder, const std::string& packageName, const std::string& packageId, const std::filesystem::path& filePath);
     template <typename ScriptedType, typename Partitioner>
-    void RunPackageWizard(Partitioner& partitioner, const std::string& modFolder, const std::string& packageName, const std::string& packageId, const std::string& filePath);
-    void RunPackageWizard(PackageType packageType, const std::string& packageName, std::string& packageId, const std::string& filePath);
+    void RunPackageWizard(Partitioner& partitioner, const std::filesystem::path& modFolder, const std::string& packageName, const std::string& packageId, const std::filesystem::path& filePath);
+    void RunPackageWizard(PackageType packageType, const std::string& packageName, std::string& packageId, const std::filesystem::path& filePath);
 
     void sendAssetFoundSignal(const std::string& path, uint64_t lastModified);
     void sendAssetsFound();
@@ -214,7 +215,7 @@ namespace Overworld {
     void receiveActorMinimapColorSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void leave();
   protected:
-    virtual std::string GetPath(const std::string& path);
+    virtual std::filesystem::path GetPath(const std::string& path);
     virtual std::string GetText(const std::string& path);
     virtual std::shared_ptr<sf::Texture> GetTexture(const std::string& path);
     virtual std::shared_ptr<sf::SoundBuffer> GetAudio(const std::string& path);

--- a/BattleNetwork/overworld/bnOverworldSceneBase.cpp
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.cpp
@@ -87,7 +87,7 @@ Overworld::SceneBase::SceneBase(swoosh::ActivityController& controller) :
   Overworld::Actor::SetMissingTexture(missingTexture);
 
   personalMenu->setScale(2.f, 2.f);
-   
+
   auto& session = getController().Session();
   bool loaded = session.LoadSession("profile.bin");
 
@@ -542,7 +542,7 @@ void Overworld::SceneBase::RefreshNaviSprite()
   // If coming back from navi select, the navi has changed, update it
   const auto& owPath = meta.GetOverworldAnimationPath();
 
-  if (owPath.size()) {
+  if (!owPath.empty()) {
     if (auto tex = Textures().LoadFromFile(meta.GetOverworldTexturePath())) {
       playerActor->setTexture(tex);
     }
@@ -653,20 +653,20 @@ void Overworld::SceneBase::LoadForeground(const Map& map)
   SetForeground(std::make_shared<CustomBackground>(texture, animation, velocity), parallaxFactor);
 }
 
-std::string Overworld::SceneBase::GetPath(const std::string& path) {
-  return path;
+std::filesystem::path Overworld::SceneBase::GetPath(const std::string& path) {
+  return std::filesystem::u8path(path);
 }
 
 std::string Overworld::SceneBase::GetText(const std::string& path) {
-  return FileUtil::Read(path);
+  return FileUtil::Read(std::filesystem::u8path(path));
 }
 
 std::shared_ptr<sf::Texture> Overworld::SceneBase::GetTexture(const std::string& path) {
-  return Textures().LoadFromFile(path);
+  return Textures().LoadFromFile(std::filesystem::u8path(path));
 }
 
 std::shared_ptr<sf::SoundBuffer> Overworld::SceneBase::GetAudio(const std::string& path) {
-  return Audio().LoadFromFile(path);
+  return Audio().LoadFromFile(std::filesystem::u8path(path));
 }
 
 

--- a/BattleNetwork/overworld/bnOverworldSceneBase.h
+++ b/BattleNetwork/overworld/bnOverworldSceneBase.h
@@ -2,6 +2,7 @@
 
 #include <SFML/Graphics.hpp>
 #include <time.h>
+#include <filesystem>
 #include <future>
 #include <optional>
 #include <Swoosh/Activity.h>
@@ -258,7 +259,7 @@ namespace Overworld {
     Overworld::MenuSystem& GetMenuSystem();
     bool IsInputLocked();
     bool IsInFocus();
-    virtual std::string GetPath(const std::string& path);
+    virtual std::filesystem::path GetPath(const std::string& path);
     virtual std::string GetText(const std::string& path);
     virtual std::shared_ptr<sf::Texture> GetTexture(const std::string& path);
     virtual std::shared_ptr<sf::SoundBuffer> GetAudio(const std::string& path);

--- a/BattleNetwork/overworld/bnOverworldTileBehaviors.cpp
+++ b/BattleNetwork/overworld/bnOverworldTileBehaviors.cpp
@@ -158,7 +158,7 @@ void Overworld::TileBehaviors::HandleConveyor(SceneBase& scene, Actor& actor, Ac
 
   ActorPropertyAnimator::PropertyStep sfxProperty;
   sfxProperty.property = ActorProperty::sound_effect_loop;
-  sfxProperty.stringValue = scene.GetPath(tileMeta.customProperties.GetProperty("sound effect"));
+  sfxProperty.stringValue = scene.GetPath(tileMeta.customProperties.GetProperty("sound effect")).u8string();
 
   ActorPropertyAnimator::KeyFrame startKeyframe;
   startKeyframe.propertySteps.push_back(animationProperty);
@@ -196,7 +196,7 @@ void Overworld::TileBehaviors::HandleIce(SceneBase& scene, Actor& actor, ActorPr
   // start animation with the ice sound effect
   ActorPropertyAnimator::PropertyStep sfxProperty;
   sfxProperty.property = ActorProperty::sound_effect;
-  sfxProperty.stringValue = scene.GetPath(tileMeta.customProperties.GetProperty("sound effect"));
+  sfxProperty.stringValue = scene.GetPath(tileMeta.customProperties.GetProperty("sound effect")).u8string();
 
   // set the animation speed to 0 so the player appears to slip
   ActorPropertyAnimator::PropertyStep animationSpeedProperty(ActorProperty::animation_speed, 0.0f);

--- a/BattleNetwork/overworld/bnServerAssetManager.h
+++ b/BattleNetwork/overworld/bnServerAssetManager.h
@@ -3,6 +3,7 @@
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/Audio/SoundBuffer.hpp>
 #include <Poco/Buffer.h>
+#include <filesystem>
 #include <memory>
 #include <unordered_map>
 
@@ -12,7 +13,7 @@ namespace Overworld {
   class ServerAssetManager {
   private:
     struct CacheMeta {
-      std::string path;
+      std::filesystem::path path;
       uint64_t lastModified{};
       size_t size{};
     };
@@ -21,8 +22,8 @@ namespace Overworld {
     std::unordered_map<std::string, std::shared_ptr<sf::Texture>> textureAssets;
     std::unordered_map<std::string, std::shared_ptr<sf::SoundBuffer>> audioAssets;
     std::unordered_map<std::string, std::vector<char>> dataAssets;
-    std::string cachePath;
-    std::string cachePrefix;
+    std::filesystem::path cachePath;
+    std::filesystem::path cachePrefix;
     std::unordered_map<std::string, CacheMeta> cachedAssets;
 
     void CacheAsset(const std::string& name, uint64_t lastModified, const char* data, size_t size);
@@ -30,7 +31,7 @@ namespace Overworld {
   public:
     ServerAssetManager(const std::string& host, uint16_t port);
 
-    std::string GetPath(const std::string& name);
+    std::filesystem::path GetPath(const std::string& name);
     const std::unordered_map<std::string, CacheMeta>& GetCachedAssetList();
 
     void Preload(const std::string& name);

--- a/BattleNetwork/sfMidi/include/sfMidi/Midi.h
+++ b/BattleNetwork/sfMidi/include/sfMidi/Midi.h
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <vector>
+#include <filesystem>
 #include <SFML/Audio.hpp>
 
 #include "sfMidi/Error.h"
@@ -69,8 +70,8 @@ class sfmidi::Midi : public sf::SoundStream, public sfmidi::Error
 {
 public:
   Midi();
-  Midi(const std::string& soundFont, const std::string& midi);
-  Midi(const std::string& soundFont,
+  Midi(const std::filesystem::path& soundFont, const std::filesystem::path& midi);
+  Midi(const std::filesystem::path& soundFont,
        const void* midiData, unsigned int midiSize);
 
   ~Midi();
@@ -81,9 +82,9 @@ public:
   bool   getLoop() const;
   double getGain() const;
 
-  bool loadSoundFontFromFile(const std::string& filename);
+  bool loadSoundFontFromFile(const std::filesystem::path& filename);
 
-  bool loadMidiFromFile  (const std::string& filename);
+  bool loadMidiFromFile  (const std::filesystem::path& filename);
   bool loadMidiFromMemory(const std::string& data);
   bool loadMidiFromMemory(const void* data, unsigned int size);
 

--- a/BattleNetwork/stx/crypto_utils.h
+++ b/BattleNetwork/stx/crypto_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 #include "result.h"
@@ -14,7 +15,7 @@ namespace stx {
     }
   }
 
-  static result_t<std::string> generate_md5_from_file(const std::string& path) {
+  static result_t<std::string> generate_md5_from_file(const std::filesystem::path& path) {
     std::vector<char> fileBuffer, md5Buffer;
     md5Buffer.resize(16);
     size_t len{};
@@ -22,7 +23,7 @@ namespace stx {
     std::ifstream fs(path, std::ios::binary | std::ios::ate);
 
     if (!fs.good()) {
-      return error<std::string>("Unabled to read file " + path);
+      return error<std::string>("Unabled to read file " + path.u8string());
     }
 
     std::ifstream::pos_type pos = fs.tellg();

--- a/BattleNetwork/stx/zip_utils.cpp
+++ b/BattleNetwork/stx/zip_utils.cpp
@@ -20,16 +20,18 @@ namespace {
       }
 
       std::filesystem::path zip_entry_path = zip_root_path / entry.path().filename();
-      if (int r = zip_entry_open(zip, zip_entry_path.generic_string().c_str()); r != 0) {
-        return stx::error<bool>("zip_entry_open for "s + zip_entry_path.generic_string() + ": " + zip_strerror(r));
+      std::string zip_entry_path_string = zip_entry_path.generic_u8string();
+      if (int r = zip_entry_open(zip, zip_entry_path_string.c_str()); r != 0) {
+        return stx::error<bool>("zip_entry_open for "s + zip_entry_path_string + ": " + zip_strerror(r));
       }
 
-      if (int r = zip_entry_fwrite(zip, entry.path().string().c_str()); r != 0) {
-        return stx::error<bool>("zip_entry_fwrite for "s + entry.path().string() + ", compressing to " + zip_entry_path.generic_string() + ": " + zip_strerror(r));
+      std::string entry_path_string = entry.path().u8string();
+      if (int r = zip_entry_fwrite(zip, entry_path_string.c_str()); r != 0) {
+        return stx::error<bool>("zip_entry_fwrite for "s + entry_path_string + ", compressing to " + zip_entry_path_string + ": " + zip_strerror(r));
       }
 
       if (int r = zip_entry_close(zip); r != 0) {
-        return stx::error<bool>("zip_entry_close for "s + zip_entry_path.generic_string() + ": " + zip_strerror(r));
+        return stx::error<bool>("zip_entry_close for "s + zip_entry_path_string + ": " + zip_strerror(r));
       }
     }
     return stx::ok();
@@ -41,20 +43,24 @@ namespace {
     uint64_t current_size = 0;
 
     int i, n = static_cast<int>(zip_entries_total(zip));
+    if (n < 0) {
+      return stx::error<uint64_t>("zip_entries_total: "s + zip_strerror(n));
+    }
     for (i = 0; i < n; ++i) {
       if (int r = zip_entry_openbyindex(zip, i); r != 0) {
         return stx::error<uint64_t>("zip_entry_openbyindex for "s + std::to_string(i) + ": " + zip_strerror(r));
       }
 
-      std::filesystem::path filename(zip_entry_name(zip));
+      std::filesystem::path filename = std::filesystem::u8path(zip_entry_name(zip));
       std::filesystem::path entry_destination_path = (destination_path / filename).lexically_normal();
+      std::string entry_destination_path_string = entry_destination_path.u8string();
       if (auto [_, end] = std::mismatch(entry_destination_path.begin(), entry_destination_path.end(), root_path.begin(), root_path.end()); end != root_path.end()) {
-        return stx::error<uint64_t>("extracting "s + filename.string() + " will extract outside of root path to " + entry_destination_path.string());
+        return stx::error<uint64_t>("extracting "s + filename.u8string() + " will extract outside of root path to " + entry_destination_path_string);
       }
 
       current_size += zip_entry_size(zip);
       if (size_limit > 0 && current_size > size_limit) {
-        return stx::error<uint64_t>("extracting "s + filename.string() + " exceeds size limit: current = " + std::to_string(current_size) + "bytes, limit = " + std::to_string(size_limit) + " bytes");
+        return stx::error<uint64_t>("extracting "s + filename.u8string() + " exceeds size limit: current = " + std::to_string(current_size) + "bytes, limit = " + std::to_string(size_limit) + " bytes");
       }
 
       if (zip_entry_isdir(zip)) {
@@ -67,13 +73,13 @@ namespace {
       }
       else {
         std::filesystem::create_directories(entry_destination_path.parent_path());  // Result ignored, folder may already exist.
-        if (int r = zip_entry_fread(zip, entry_destination_path.string().c_str()); r != 0) {
-          return stx::error<uint64_t>("zip_entry_fread for "s + filename.string() + ", extracting to " + entry_destination_path.string() + ": " + zip_strerror(r));
+        if (int r = zip_entry_fread(zip, entry_destination_path_string.c_str()); r != 0) {
+          return stx::error<uint64_t>("zip_entry_fread for "s + filename.u8string() + ", extracting to " + entry_destination_path_string + ": " + zip_strerror(r));
         }
       }
 
       if (int r = zip_entry_close(zip); r != 0) {
-        return stx::error<uint64_t>("zip_entry_close for "s + filename.string() + ": " + zip_strerror(r));
+        return stx::error<uint64_t>("zip_entry_close for "s + filename.u8string() + ": " + zip_strerror(r));
       }
     }
     return stx::ok(current_size);
@@ -83,12 +89,20 @@ namespace {
 /* STD LIBRARY extensions */
 namespace stx {
   result_t<bool> zip(const std::filesystem::path& target_path, const std::filesystem::path& destination_path) {
-    std::unique_ptr<zip_t, decltype(&zip_close)> zip{zip_open(destination_path.generic_string().c_str(), 9, 'w'), zip_close};
+    std::string destination_path_string = destination_path.u8string();
+    std::unique_ptr<zip_t, decltype(&zip_close)> zip{zip_open(destination_path_string.c_str(), 9, 'w'), zip_close};
+    if (!zip) {
+      return error<bool>("failed to open zip file");
+    }
     return zip_walk(zip.get(), target_path.lexically_normal());
   }
 
   result_t<bool> unzip(const std::filesystem::path& target_path, const std::filesystem::path& destination_path) {
-    std::unique_ptr<zip_t, decltype(&zip_close)> zip{zip_open(target_path.generic_string().c_str(), -1, 'r'), zip_close};
+    std::string target_path_string = target_path.u8string();
+    std::unique_ptr<zip_t, decltype(&zip_close)> zip{zip_open(target_path_string.c_str(), -1, 'r'), zip_close};
+    if (!zip) {
+      return error<bool>("failed to open zip file");
+    }
     std::filesystem::path normalized_destination_path = destination_path.lexically_normal();
     if (result_t<uint64_t> r = unzip_walk(zip.get(), normalized_destination_path, normalized_destination_path); r.is_error()) {
       return error<bool>(std::string(r.error_cstr()));

--- a/BattleNetwork/zip/zip.c
+++ b/BattleNetwork/zip/zip.c
@@ -1149,8 +1149,9 @@ int zip_entry_close(struct zip_t *zip) {
   if (!mz_zip_writer_add_to_central_dir(
           pzip, zip->entry.name, entrylen, NULL, 0, "", 0,
           zip->entry.uncomp_size, zip->entry.comp_size, zip->entry.uncomp_crc32,
-          zip->entry.method, 0, dos_time, dos_date, zip->entry.header_offset,
-          zip->entry.external_attr, NULL, 0)) {
+          zip->entry.method, MZ_ZIP_GENERAL_PURPOSE_BIT_FLAG_UTF8, dos_time,
+          dos_date, zip->entry.header_offset, zip->entry.external_attr, NULL,
+          0)) {
     // Cannot write to zip central dir
     err = ZIP_EWRTDIR;
     goto cleanup;


### PR DESCRIPTION
**NOTE:** I'm not sure of the changes in the overworld parts of the code (see bnOverworldHomepage.cpp lines 2537-2539).

In C++, we will ALWAYS (with the exception of passing to/from miniz, which will correctly handle UTF-8 encoded paths on windows) use std::filesystem::path to represent local filesystem paths. When we pass into Lua land, these paths will be converted to UTF-8: both Windows and POSIX will exhibit the same behavior in Lua, which means mod writers do not have to care what the underlying platform is.

This fixes most of Unicode safety on Windows. This will also log UTF-8 encoded strings to the console, which will look super wrong on Windows, but this just needs a change in the Logger to perform UTF-8 to UTF-16 conversion.