### PR TITLE
Support Unicode text rendering.

### DIFF
--- a/BattleNetwork/bnAnimatedTextBox.cpp
+++ b/BattleNetwork/bnAnimatedTextBox.cpp
@@ -1,9 +1,9 @@
 #include "bnAnimatedTextBox.h"
 #include <cmath>
 
-AnimatedTextBox::AnimatedTextBox(const sf::Vector2f& pos) : 
-  textArea(), 
-  totalTime(0), 
+AnimatedTextBox::AnimatedTextBox(const sf::Vector2f& pos) :
+  textArea(),
+  totalTime(0),
   textBox(280, 45) {
   textureRef = Textures().LoadFromFile(TexturePaths::ANIMATED_TEXT_BOX);
   frame = sf::Sprite(*textureRef);
@@ -36,10 +36,10 @@ void AnimatedTextBox::Close() {
 
   animator.SetAnimation("CLOSE");
 
-  animator << Animator::On(2, 
-    [this] 
+  animator << Animator::On(2,
+    [this]
     {
-      canDraw = false; 
+      canDraw = false;
     }
   );
 
@@ -190,7 +190,7 @@ void AnimatedTextBox::EnqueMessage(const sf::Sprite& speaker, const Animation& a
 {
   messages.push_back(message);
   anims.push_back(anim);
-  
+
   auto& mugAnim = anims[anims.size() - 1];
   mugAnim.SetAnimation("IDLE");
   mugAnim << Animator::Mode::Loop;
@@ -228,10 +228,10 @@ void AnimatedTextBox::Update(double elapsed) {
     auto y = (textBox.GetNumberOfFittingLines() -yIndex) * 10.0f;
     y = frame.getPosition().y - y;
 
-    char currChar = textBox.GetCurrentCharacter();
+    uint32_t currChar = textBox.GetCurrentCharacter();
     bool muteFX = (textBox.GetVFX() & TextBox::effects::zzz) == TextBox::effects::zzz;
-    bool speakingDot = currChar == '.' || currChar == '\0';
-    bool silence = (currChar == ' ' && mugAnimator.GetAnimationString() == "IDLE");
+    bool speakingDot = currChar == U'.' || currChar == U'\0';
+    bool silence = (currChar == U' ' && mugAnimator.GetAnimationString() == "IDLE");
     bool lipsSealed = muteFX || speakingDot || silence;
 
     auto playIdleThunk = [this] {

--- a/BattleNetwork/bnFont.cpp
+++ b/BattleNetwork/bnFont.cpp
@@ -1,6 +1,8 @@
 #include "bnFont.h"
 
-std::map<char, std::string> Font::specialCharLookup;
+#include <iomanip>
+#include <iostream>
+
 std::array<Animation, Font::style_sz> Font::animationArray{};
 bool Font::animationsLoaded = false;
 
@@ -32,13 +34,13 @@ void Font::ApplyStyle()
   std::string animName;
 
   switch (style) {
-  case Style::thick: 
+  case Style::thick:
     animName = "THICK_";
     break;
   case Style::small:
     animName = "SMALL_";
     break;
-  case Style::tiny: 
+  case Style::tiny:
     animName = "TINY_";
     break;
   case Style::wide:
@@ -70,36 +72,19 @@ void Font::ApplyStyle()
     break;
   }
 
-  // prioritize special char lookup for special font letters (e.g. buttons, symbols, multichar letters)
-  if (auto iter = Font::specialCharLookup.find(letter); iter != Font::specialCharLookup.end()) {
-    animName = iter->second;
-  }
-  else {
-    // otherwise, compose the font lookup name
-    std::string letterStr(1, letter);
-    std::transform(letterStr.begin(), letterStr.end(), letterStr.begin(), ::toupper);
-
-    if (letter != '"') {
-      // some font cannot be lower-cased
-      if (::islower(letter) && HasLowerCase(style)) {
-        letterStr = "LOWER_" + letterStr;
-      }
-
-      animName = animName + letterStr;
-    }
-    else {
-      animName = animName + "QUOTE";
-    }
-  }
+  // otherwise, compose the font lookup name
+  std::stringstream ss;
+  ss << "U" << std::setfill('0') << std::setw(6) << std::uppercase << std::hex << letter;
+  animName = animName + ss.str();
 
   // Get the frame (list of size 1) of the font
   FrameList list = animation.GetFrameList(animName);
-  
+
   if (list.IsEmpty()) {
     // If the list is empty (font support not existing), use small letter 'A'
-    list = animation.GetFrameList("SMALL_A");
+    list = animation.GetFrameList("SMALL_U000041");
   }
-  
+
   auto& frame = list.GetFrame(0);
   texcoords = frame.subregion;
   origin = frame.origin;
@@ -132,7 +117,7 @@ const Font::Style & Font::GetStyle() const
   return style;
 }
 
-void Font::SetLetter(char letter)
+void Font::SetLetter(uint32_t letter)
 {
   auto prev = Font::letter;
   Font::letter = letter;

--- a/BattleNetwork/bnFont.h
+++ b/BattleNetwork/bnFont.h
@@ -4,6 +4,7 @@
 #include "bnResourceHandle.h"
 #include "bnTextureResourceManager.h"
 
+#include <cstdint>
 #include <memory>
 #include <array>
 
@@ -25,14 +26,12 @@ public:
     size // don't use!
   } style;
 
-  static std::map<char, std::string> specialCharLookup;
-
 private:
   static constexpr size_t style_sz = static_cast<size_t>(Style::size);
   static bool animationsLoaded;
   static std::array<Animation, style_sz> animationArray;
 
-  char letter{ 'A' };
+  uint32_t letter{ 'A' };
   sf::IntRect texcoords{};
   sf::IntRect letterATexcoords{};
   sf::Vector2f origin{};
@@ -43,7 +42,7 @@ public:
   ~Font();
 
   const Style& GetStyle() const;
-  void SetLetter(char letter);
+  void SetLetter(uint32_t letter);
   const sf::Texture& GetTexture() const;
   const sf::IntRect GetTextureCoords() const;
   const sf::Vector2f GetOrigin() const;

--- a/BattleNetwork/bnGame.cpp
+++ b/BattleNetwork/bnGame.cpp
@@ -212,10 +212,6 @@ TaskGroup Game::Boot(const cxxopts::ParseResult& values)
     inputManager.BindLoseFocusEvent(std::bind(&Game::LoseFocus, this));
     inputManager.BindRegainFocusEvent(std::bind(&Game::GainFocus, this));
     inputManager.BindResizedEvent(std::bind(&Game::Resize, this, std::placeholders::_1, std::placeholders::_2));
-
-    Font::specialCharLookup.insert(std::make_pair(char(-1), "THICK_SP"));
-    Font::specialCharLookup.insert(std::make_pair(char(-2), "THICK_EX"));
-    Font::specialCharLookup.insert(std::make_pair(char(-3), "THICK_NM"));
   });
 
   this->UpdateConfigSettings(reader.GetConfigSettings());

--- a/BattleNetwork/bnResourcePaths.h
+++ b/BattleNetwork/bnResourcePaths.h
@@ -136,7 +136,7 @@ namespace TexturePaths {
   path SCREEN_BAR = "resources/ui/screen_bar.png";
 
   // FONT
-  path FONT = "resources/fonts/fonts_compressed.png";
+  path FONT = "resources/fonts/fonts.png";
 
   // CONFIG UI
   path AUDIO_ICO = "resources/scenes/config/audio.png";

--- a/BattleNetwork/bnSelectMobScene.cpp
+++ b/BattleNetwork/bnSelectMobScene.cpp
@@ -7,6 +7,11 @@
 #include "Android/bnTouchArea.h"
 #include "../../bnBlockPackageManager.h"
 #include "../../bnPlayerCustScene.h"
+
+#include <Poco/TextIterator.h>
+#include <Poco/UTF8Encoding.h>
+#include <Poco/UnicodeConverter.h>
+
 constexpr float PIXEL_MAX = 50.0f;
 constexpr float PIXEL_SPEED = 180.0f;
 
@@ -250,21 +255,29 @@ void SelectMobScene::onUpdate(double elapsed) {
     numberCooldown -= (float)elapsed;
     std::string newstr;
 
-    for (int i = 0; i < mobLabel.GetString().length(); i++) {
+    Poco::UTF8Encoding utf8Encoding;
+    Poco::TextIterator it(mobLabel.GetString(), utf8Encoding);
+    Poco::TextIterator end(mobLabel.GetString());
+    size_t i = 0;
+    size_t length = Poco::UnicodeConverter::UTFStrlen(mobLabel.GetString().c_str());
+    for (; it != end; ++it) {
       double progress = (maxNumberCooldown - numberCooldown) / maxNumberCooldown;
-      double index = progress * mobLabel.GetString().length();
+      double index = progress * length;
 
       if (i < (int)index) {
-        newstr += mobLabel.GetString()[i];
+        std::string utf8string;
+        Poco::UnicodeConverter::convert(Poco::UTF32String(1, *it), utf8string);
+        newstr += utf8string;
       }
       else {
-        if (mobLabel.GetString()[i] != ' ') {
+        if (*it != U' ') {
           newstr += (char)(((rand() % (90 - 65)) + 65) + 1);
         }
         else {
           newstr += ' ';
         }
       }
+      ++i;
     }
 
     int randAttack = 0;

--- a/BattleNetwork/bnSelectNaviScene.cpp
+++ b/BattleNetwork/bnSelectNaviScene.cpp
@@ -8,6 +8,10 @@
 #include "bnSelectNaviScene.h"
 #include "Segues/Checkerboard.h"
 
+#include <Poco/TextIterator.h>
+#include <Poco/UTF8Encoding.h>
+#include <Poco/UnicodeConverter.h>
+
 using namespace swoosh::types;
 
 bool SelectNaviScene::IsNaviAllowed()
@@ -101,7 +105,7 @@ SelectNaviScene::SelectNaviScene(swoosh::ActivityController& controller, std::st
   speedLabel.SetString(sf::String(playerPkg.GetSpeedString().c_str()));
   attackLabel.SetString(sf::String(playerPkg.GetAttackString().c_str()));
   hpLabel.SetString(sf::String(playerPkg.GetHPString().c_str()));
-  
+
   // Distortion effect
   factor = MAX_PIXEL_FACTOR;
 
@@ -403,24 +407,29 @@ void SelectNaviScene::onUpdate(double elapsed) {
     numberCooldown -= (float)elapsed;
     std::string newstr;
 
-    for (int i = 0; i < naviLabel.GetString().length(); i++) {
+    Poco::UTF8Encoding utf8Encoding;
+    Poco::TextIterator it(naviLabel.GetString(), utf8Encoding);
+    Poco::TextIterator end(naviLabel.GetString());
+    size_t i = 0;
+    size_t length = Poco::UnicodeConverter::UTFStrlen(naviLabel.GetString().c_str());
+    for (; it != end; ++it) {
       double progress = (maxNumberCooldown - numberCooldown) / maxNumberCooldown;
-      double index = progress * naviLabel.GetString().length();
+      double index = progress * length;
 
       if (i < (int)index) {
-        // Choose the unscrambled character from the original string
-        newstr += naviLabel.GetString()[i];
+        std::string utf8string;
+        Poco::UnicodeConverter::convert(Poco::UTF32String(1, *it), utf8string);
+        newstr += utf8string;
       }
       else {
-        // If the character in the string isn't a space...
-        if (naviLabel.GetString()[i] != ' ') {
-          // Choose a random, capital ASCII character
+        if (*it != U' ') {
           newstr += (char)(((rand() % (90 - 65)) + 65) + 1);
         }
         else {
           newstr += ' ';
         }
       }
+      ++i;
     }
 
     int randAttack = rand() % 10;

--- a/BattleNetwork/bnText.cpp
+++ b/BattleNetwork/bnText.cpp
@@ -2,7 +2,10 @@
 #include <cmath>
 #include <cctype> // for control codes
 
-void Text::AddLetterQuad(sf::Vector2f position, const sf::Color & color, char letter) const
+#include <Poco/UTF8Encoding.h>
+#include <Poco/TextIterator.h>
+
+void Text::AddLetterQuad(sf::Vector2f position, const sf::Color & color, uint32_t letter) const
 {
   font.SetLetter(letter);
   const auto texcoords = font.GetTextureCoords();
@@ -10,7 +13,7 @@ void Text::AddLetterQuad(sf::Vector2f position, const sf::Color & color, char le
   const sf::Texture& texture = font.GetTexture();
   float width  = static_cast<float>(texture.getSize().x);
   float height = static_cast<float>(texture.getSize().y);
-  
+
   float left   = 0;
   float top    = 0;
   float right  = static_cast<float>(texcoords.width);
@@ -54,19 +57,24 @@ void Text::UpdateGeometry() const
   float y = 0.f;
   float width = 0.f;
 
-  for (char letter : message) {
+  Poco::UTF8Encoding utf8Encoding;
+  Poco::TextIterator it(message, utf8Encoding);
+  Poco::TextIterator end(message);
+  for (; it != end; ++it) {
+    uint32_t letter = *it;
+
     // Handle special characters
-    if ((letter == L' ') || (letter == L'\n') || (letter == L'\t'))
+    if ((letter == U' ') || (letter == U'\n') || (letter == U'\t'))
     {
       switch (letter)
       {
-      case L' ':  x += whitespaceWidth;     break;
-      case L'\t': x += whitespaceWidth * 4; break;
-      case L'\n': y += lineSpacing; x = 0;  break;
+      case U' ':  x += whitespaceWidth;     break;
+      case U'\t': x += whitespaceWidth * 4; break;
+      case U'\n': y += lineSpacing; x = 0;  break;
       }
     } else {
       // skip user-defined control codes
-      if (letter > 0 && iscntrl(letter)) continue;
+      if (letter > 0 && letter <= 0xff && iscntrl(letter)) continue;
 
       AddLetterQuad(sf::Vector2f(x, y), color, letter);
 

--- a/BattleNetwork/bnText.h
+++ b/BattleNetwork/bnText.h
@@ -2,6 +2,8 @@
 #include "bnSceneNode.h"
 #include "bnFont.h"
 
+#include <cstdint>
+
 class Text : public SceneNode
 {
 private:
@@ -14,7 +16,7 @@ private:
   mutable bool geometryDirty; //!< Flag if text needs to be recomputed due to a change in properties
 
   // Add a glyph quad to the vertex array
-  void AddLetterQuad(sf::Vector2f position, const sf::Color& color, char letter) const;
+  void AddLetterQuad(sf::Vector2f position, const sf::Color& color, uint32_t letter) const;
 
   // Computes geometry before draw
   void UpdateGeometry() const;

--- a/BattleNetwork/bnTextBox.cpp
+++ b/BattleNetwork/bnTextBox.cpp
@@ -3,18 +3,71 @@
 #include "bnTextureResourceManager.h"
 #include "stx/string.h"
 
+#include <string_view>
+#include <Poco/UTF8Encoding.h>
+
 namespace {
   const char dramatic_token = '\x01';
   const char nolip_token = '\x02';
   const char fast_token = '\x03';
   const auto special_chars = { ::nolip_token, ::dramatic_token, ' ',  '\n' };
+
+  stx::result_t<std::pair<uint32_t, size_t>> nextUTF8CodepointAndSize(std::string_view s) {
+    Poco::UTF8Encoding utf8Encoding;
+    size_t size = 1;
+    for (;;) {
+      if (size > s.size()) {
+        return stx::error<std::pair<uint32_t, size_t>>("premature end of bytes");
+      }
+
+      int r = utf8Encoding.queryConvert(reinterpret_cast<const unsigned char*>(s.data()), size);
+      if (r == -1) {
+        return stx::error<std::pair<uint32_t, size_t>>("malformed byte sequence");
+      }
+
+      if (r > 0) {
+        return std::make_pair(r, size);
+      }
+
+      size = -r;
+    }
+  }
+
+  size_t nextValidUTF8CodepointIndex(std::string_view s) {
+    for (size_t i = 0; i < s.size(); ++i) {
+      stx::result_t<std::pair<uint32_t, size_t>> r = nextUTF8CodepointAndSize(s.substr(i));
+      if (!r.is_error()) {
+        return i + r.value().second;
+      }
+    }
+    return s.size();
+  }
+
+  uint32_t lastUTF8Codepoint(std::string_view s) {
+    // The cursed UTF-8 backwards iteration routine. Based on https://stackoverflow.com/a/22257843.
+    if (s.empty()) {
+      return 0;
+    }
+
+    size_t i = s.size() - 1;
+    while (i >= 0 && (s[i] & 0xc0) == 0x80) {
+      --i;
+    }
+
+    stx::result_t<std::pair<uint32_t, size_t>> r = nextUTF8CodepointAndSize(s.substr(i));
+    if (r.is_error()) {
+      return 0;
+    }
+
+    return r.value().first;
+  }
 }
 
 TextBox::TextBox(int width, int height) :
-  TextBox::TextBox(width, height, Font::Style::thin) { } 
+  TextBox::TextBox(width, height, Font::Style::thin) { }
 
-TextBox::TextBox(int width, int height, const Font& font) : 
-  font(font), 
+TextBox::TextBox(int width, int height, const Font& font) :
+  font(font),
   text("", font) {
   text.scale(2.0f, 2.0f);
   message = "";
@@ -63,10 +116,10 @@ void TextBox::FormatToFit() {
       wordIndex = -1;
     }
 
-    std::string fitString = message.substr(lastRow, (size_t)index - (size_t)lastRow + 1);
+    std::string fitString = message.substr(lastRow, (size_t)index - (size_t)lastRow + nextValidUTF8CodepointIndex(std::string_view(message).substr(index)));
 
     // fx sections shouldn't increase real estate...
-    fitString = stx::replace(fitString, std::string(1, ::nolip_token), ""); 
+    fitString = stx::replace(fitString, std::string(1, ::nolip_token), "");
     fitString = stx::replace(fitString, std::string(1, ::dramatic_token), "");
     fitString = stx::replace(fitString, std::string(1, ::fast_token), "");
 
@@ -111,7 +164,7 @@ void TextBox::FormatToFit() {
     else if (width > areaWidth) {
       // if we're on a space place the new line after
       if (message[index] == ' ') {
-        index++;
+        index += nextValidUTF8CodepointIndex(std::string_view(message).substr(index));
       }
 
       lastRow = index;
@@ -126,7 +179,7 @@ void TextBox::FormatToFit() {
 
       wordIndex = -1;
     }
-    index++;
+    index += nextValidUTF8CodepointIndex(std::string_view(message).substr(index));
   }
 
   // make final text blank to start
@@ -228,7 +281,7 @@ void TextBox::CompleteCurrentBlock()
 {
   if (lineIndex >= lines.size()) return;
 
-  // simulate the end of the text block starting from the beginning 
+  // simulate the end of the text block starting from the beginning
   // and compile a list of flags and set as complete
   int start = lines[lineIndex];
   int end = (int)message.size();
@@ -254,7 +307,7 @@ void TextBox::CompleteCurrentBlock()
     else if ((currEffect & effects::fast) == effects::fast) {
       modifiedCharsPerSecond = charsPerSecond * FAST_TEXT_SPEED;
     }
-    
+
     simProgress += 1.0 / modifiedCharsPerSecond;
   }
 
@@ -310,10 +363,8 @@ void TextBox::Stop() {
   Play(false);
 }
 
-const char TextBox::GetCurrentCharacter() const {
-  if (text.GetString().empty()) return '\0';
-
-  return text.GetString().back();
+const uint32_t TextBox::GetCurrentCharacter() const {
+  return lastUTF8Codepoint(text.GetString());
 }
 
 const int TextBox::GetNumberOfFittingLines() const {
@@ -402,7 +453,7 @@ void TextBox::Update(const double elapsed) {
   // If the text is set don't update the first frame
   if (!play && !dirty) return;
 
-  // If we're at the end of the message, don't step  
+  // If we're at the end of the message, don't step
   // through the words
   if (charIndex >= message.length()) {
     StoreCurrentBlock();
@@ -432,7 +483,7 @@ void TextBox::Update(const double elapsed) {
 
     // Try the next character
     if (!ProcessSpecialCharacters(charIndexIter)) {
-      charIndexIter++;
+      charIndexIter+=nextValidUTF8CodepointIndex(std::string_view(message).substr(charIndexIter));
       ProcessSpecialCharacters(charIndexIter);
     }
 
@@ -440,8 +491,8 @@ void TextBox::Update(const double elapsed) {
     if (charIndexIter > charIndex && charIndex < message.size()) {
       // See how many non-spaces there were in this pass
       int length = charIndexIter - charIndex;
-      std::string pass = message.substr(charIndex, (size_t)length+1);
-      bool talking = pass.end() != std::find_if(pass.begin(), pass.end(), [](char in) { 
+      std::string pass = message.substr(charIndex, (size_t)length+nextValidUTF8CodepointIndex(std::string_view(message).substr(charIndex+length)));
+      bool talking = pass.end() != std::find_if(pass.begin(), pass.end(), [](char in) {
         auto iter = std::find(::special_chars.begin(), ::special_chars.end(), in);
         return iter == ::special_chars.end();
       });
@@ -481,13 +532,13 @@ void TextBox::Update(const double elapsed) {
     }
 
     // Len will be > 0 after first call to Update()
-    // Set the sf::Text to show only the visible text in 
+    // Set the sf::Text to show only the visible text in
     // the text area
     if (len <= 0) {
       text.SetString("");
     }
     else {
-      std::string outString = message.substr(begin, (size_t)len+1);
+      std::string outString = message.substr(begin, (size_t)len+nextValidUTF8CodepointIndex(std::string_view(message).substr(begin+len)));
       outString = stx::replace(outString, std::string(1, ::nolip_token), ""); // fx should not appear in final message
       outString = stx::replace(outString, std::string(1, ::dramatic_token), ""); // fx should not appear in final message
       text.SetString(outString);
@@ -510,7 +561,7 @@ const bool TextBox::IsEndOfBlock() const
   if (lastLine < this->lines.size()) {
     testCharIndex = this->lines[lastLine] - 1;
   }
-  
+
   return charIndex >= testCharIndex;
 }
 

--- a/BattleNetwork/bnTextBox.h
+++ b/BattleNetwork/bnTextBox.h
@@ -5,6 +5,7 @@
 
 #include <SFML/Graphics.hpp>
 #include <memory>
+#include <cstdint>
 
 #include "bnText.h"
 #include "bnFont.h"
@@ -118,7 +119,7 @@ public:
    * @brief Moves lines upward in text area, shows next lines
    */
   void ShowNextLine();
-  
+
   /**
    * @brief Moves lines downward in text area, shows previous lines
    */
@@ -161,7 +162,7 @@ public:
    * @brief Returns the current character printed
    * @return char
    */
-  const char GetCurrentCharacter() const;
+  const uint32_t GetCurrentCharacter() const;
 
   /**
    * @brief Returns the character range of the displayed text
@@ -198,7 +199,7 @@ public:
    * @return double in sec
    */
   const double GetCharsPerSecond() const;
-  
+
   /**
    * @brief Query if textbox is playing
    * @return true if playing, false if paused
@@ -219,7 +220,7 @@ public:
 
   /**
    * @brief Draws the textbox with correct transformations
-   * 
+   *
    * The textbox inherits sf::Drawable which give it transform properties
    * and can be rotated and scaled. We make sure the text is rendered appropriately.
    * @param target

--- a/BattleNetwork/resources/fonts/fonts.animation
+++ b/BattleNetwork/resources/fonts/fonts.animation
@@ -1,1533 +1,1533 @@
 imagePath="C:/Users/Proto/Documents/Code/OpenNetBattle/BattleNetwork/resources/fonts/fonts.png"
 
-animation state="SMALL_A"
-frame duration="0" x="4" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000041"
+frame duration="0" x="4" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_B"
-frame duration="0" x="13" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000042"
+frame duration="0" x="13" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_C"
-frame duration="0" x="22" y="9" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000043"
+frame duration="0" x="22" y="9" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_D"
-frame duration="0" x="30" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000044"
+frame duration="0" x="30" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_E"
-frame duration="0" x="39" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000045"
+frame duration="0" x="39" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_F"
-frame duration="0" x="48" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000046"
+frame duration="0" x="48" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_G"
-frame duration="0" x="57" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000047"
+frame duration="0" x="57" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_H"
-frame duration="0" x="66" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000048"
+frame duration="0" x="66" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_I"
-frame duration="0" x="75" y="9" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000049"
+frame duration="0" x="75" y="9" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_J"
-frame duration="0" x="82" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004A"
+frame duration="0" x="82" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_K"
-frame duration="0" x="91" y="9" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004B"
+frame duration="0" x="91" y="9" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_L"
-frame duration="0" x="99" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004C"
+frame duration="0" x="99" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_M"
-frame duration="0" x="108" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004D"
+frame duration="0" x="108" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_N"
-frame duration="0" x="117" y="9" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004E"
+frame duration="0" x="117" y="9" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_O"
-frame duration="0" x="125" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004F"
+frame duration="0" x="125" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_P"
-frame duration="0" x="134" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000050"
+frame duration="0" x="134" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_Q"
-frame duration="0" x="143" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000051"
+frame duration="0" x="143" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_R"
-frame duration="0" x="153" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000052"
+frame duration="0" x="153" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_S"
-frame duration="0" x="162" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000053"
+frame duration="0" x="162" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_T"
-frame duration="0" x="171" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000054"
+frame duration="0" x="171" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_U"
-frame duration="0" x="180" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000055"
+frame duration="0" x="180" y="9" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_V"
-frame duration="0" x="4" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000056"
+frame duration="0" x="4" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_W"
-frame duration="0" x="13" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000057"
+frame duration="0" x="13" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_X"
-frame duration="0" x="22" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000058"
+frame duration="0" x="22" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_Y"
-frame duration="0" x="31" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000059"
+frame duration="0" x="31" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_Z"
-frame duration="0" x="40" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00005A"
+frame duration="0" x="40" y="29" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_A"
-frame duration="0" x="4" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000061"
+frame duration="0" x="4" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_B"
-frame duration="0" x="12" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000062"
+frame duration="0" x="12" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_C"
-frame duration="0" x="20" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000063"
+frame duration="0" x="20" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_D"
-frame duration="0" x="28" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000064"
+frame duration="0" x="28" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_E"
-frame duration="0" x="36" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000065"
+frame duration="0" x="36" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_F"
-frame duration="0" x="44" y="48" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000066"
+frame duration="0" x="44" y="48" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_G"
-frame duration="0" x="51" y="47" w="4" h="9" originx="0" originy="1" flipx="0" flipy="0" 
+animation state="SMALL_U000067"
+frame duration="0" x="51" y="47" w="4" h="9" originx="0" originy="1" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_H"
-frame duration="0" x="59" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000068"
+frame duration="0" x="59" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_I"
-frame duration="0" x="65" y="48" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000069"
+frame duration="0" x="65" y="48" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_J"
-frame duration="0" x="71" y="48" w="5" h="9" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006A"
+frame duration="0" x="71" y="48" w="5" h="9" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_K"
-frame duration="0" x="78" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006B"
+frame duration="0" x="78" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_L"
-frame duration="0" x="84" y="47" w="5" h="8" originx="0" originy="1" flipx="0" flipy="0" 
+animation state="SMALL_U00006C"
+frame duration="0" x="84" y="47" w="5" h="8" originx="0" originy="1" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_M"
-frame duration="0" x="91" y="50" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006D"
+frame duration="0" x="91" y="50" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_N"
-frame duration="0" x="100" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006E"
+frame duration="0" x="100" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_O"
-frame duration="0" x="108" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006F"
+frame duration="0" x="108" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_P"
-frame duration="0" x="116" y="48" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000070"
+frame duration="0" x="116" y="48" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_Q"
-frame duration="0" x="125" y="48" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000071"
+frame duration="0" x="125" y="48" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_R"
-frame duration="0" x="134" y="49" w="4" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000072"
+frame duration="0" x="134" y="49" w="4" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_S"
-frame duration="0" x="142" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000073"
+frame duration="0" x="142" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_T"
-frame duration="0" x="150" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000074"
+frame duration="0" x="150" y="48" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_U"
-frame duration="0" x="158" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000075"
+frame duration="0" x="158" y="50" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_V"
-frame duration="0" x="4" y="69" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000076"
+frame duration="0" x="4" y="69" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_W"
-frame duration="0" x="12" y="69" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000077"
+frame duration="0" x="12" y="69" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_X"
-frame duration="0" x="21" y="69" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000078"
+frame duration="0" x="21" y="69" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_Y"
-frame duration="0" x="29" y="67" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000079"
+frame duration="0" x="29" y="67" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_Z"
-frame duration="0" x="37" y="69" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00007A"
+frame duration="0" x="37" y="69" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_0"
-frame duration="0" x="4" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000030"
+frame duration="0" x="4" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_1"
-frame duration="0" x="12" y="86" w="2" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000031"
+frame duration="0" x="12" y="86" w="2" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_2"
-frame duration="0" x="18" y="86" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000032"
+frame duration="0" x="18" y="86" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_3"
-frame duration="0" x="27" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000033"
+frame duration="0" x="27" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_4"
-frame duration="0" x="35" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000034"
+frame duration="0" x="35" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_5"
-frame duration="0" x="43" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000035"
+frame duration="0" x="43" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_6"
-frame duration="0" x="51" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000036"
+frame duration="0" x="51" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_7"
-frame duration="0" x="59" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000037"
+frame duration="0" x="59" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_8"
-frame duration="0" x="67" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000038"
+frame duration="0" x="67" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_9"
-frame duration="0" x="75" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000039"
+frame duration="0" x="75" y="86" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_("
-frame duration="0.05" x="4" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000028"
+frame duration="0.05" x="4" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_)"
-frame duration="0" x="11" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000029"
+frame duration="0" x="11" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL__"
-frame duration="0" x="18" y="105" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00005F"
+frame duration="0" x="18" y="105" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_-"
-frame duration="0" x="26" y="105" w="3" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002D"
+frame duration="0" x="26" y="105" w="3" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_+"
-frame duration="0" x="33" y="105" w="3" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002B"
+frame duration="0" x="33" y="105" w="3" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_="
-frame duration="0" x="40" y="105" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003D"
+frame duration="0" x="40" y="105" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_\"
-frame duration="0" x="48" y="105" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00005C"
+frame duration="0" x="48" y="105" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_/"
-frame duration="0" x="57" y="105" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002F"
+frame duration="0" x="57" y="105" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_<"
-frame duration="0" x="66" y="106" w="3" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003C"
+frame duration="0" x="66" y="106" w="3" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_>"
-frame duration="0" x="74" y="106" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003E"
+frame duration="0" x="74" y="106" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_?"
-frame duration="0" x="81" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003F"
+frame duration="0" x="81" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_,"
-frame duration="0" x="87" y="105" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002C"
+frame duration="0" x="87" y="105" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_."
-frame duration="0" x="93" y="104" w="3" h="9" originx="0" originy="1" flipx="0" flipy="0" 
+animation state="SMALL_U00002E"
+frame duration="0" x="93" y="104" w="3" h="9" originx="0" originy="1" flipx="0" flipy="0"
 
-animation state="SMALL_!"
-frame duration="0" x="99" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000021"
+frame duration="0" x="99" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_@"
-frame duration="0" x="104" y="104" w="7" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000040"
+frame duration="0" x="104" y="104" w="7" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_#"
-frame duration="0" x="115" y="105" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000023"
+frame duration="0" x="115" y="105" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_$"
-frame duration="0" x="124" y="105" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000024"
+frame duration="0" x="124" y="105" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_%"
-frame duration="0" x="133" y="104" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000025"
+frame duration="0" x="133" y="104" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_^"
-frame duration="0" x="142" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00005E"
+frame duration="0" x="142" y="105" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_&"
-frame duration="0" x="149" y="105" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000026"
+frame duration="0" x="149" y="105" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_*"
-frame duration="0" x="157" y="106" w="5" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002A"
+frame duration="0" x="157" y="106" w="5" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_'"
-frame duration="0" x="166" y="106" w="2" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000027"
+frame duration="0" x="166" y="106" w="2" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_QUOTE"
-frame duration="0" x="171" y="106" w="5" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000022"
+frame duration="0" x="171" y="106" w="5" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_:"
-frame duration="0" x="180" y="106" w="2" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003A"
+frame duration="0" x="180" y="106" w="2" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_;"
-frame duration="0" x="184" y="106" w="2" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003B"
+frame duration="0" x="184" y="106" w="2" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_A"
-frame duration="0.05" x="244" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
-frame duration="0.05" x="0" y="0" w="0" h="0" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000041"
+frame duration="0.05" x="244" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
+frame duration="0.05" x="0" y="0" w="0" h="0" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_B"
-frame duration="0.05" x="254" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000042"
+frame duration="0.05" x="254" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_C"
-frame duration="0.05" x="264" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000043"
+frame duration="0.05" x="264" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_D"
-frame duration="0.05" x="274" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000044"
+frame duration="0.05" x="274" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_E"
-frame duration="0.05" x="284" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000045"
+frame duration="0.05" x="284" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_F"
-frame duration="0.05" x="294" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000046"
+frame duration="0.05" x="294" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_G"
-frame duration="0.05" x="304" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000047"
+frame duration="0.05" x="304" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_H"
-frame duration="0.05" x="314" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000048"
+frame duration="0.05" x="314" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_I"
-frame duration="0.05" x="322" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000049"
+frame duration="0.05" x="322" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_J"
-frame duration="0.05" x="330" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004A"
+frame duration="0.05" x="330" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_K"
-frame duration="0.05" x="339" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004B"
+frame duration="0.05" x="339" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_L"
-frame duration="0.05" x="349" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004C"
+frame duration="0.05" x="349" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_M"
-frame duration="0.05" x="359" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004D"
+frame duration="0.05" x="359" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_N"
-frame duration="0.05" x="369" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004E"
+frame duration="0.05" x="369" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_O"
-frame duration="0.05" x="379" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004F"
+frame duration="0.05" x="379" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_P"
-frame duration="0.05" x="389" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000050"
+frame duration="0.05" x="389" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_Q"
-frame duration="0.05" x="399" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000051"
+frame duration="0.05" x="399" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_R"
-frame duration="0.05" x="410" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000052"
+frame duration="0.05" x="410" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_S"
-frame duration="0.05" x="420" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000053"
+frame duration="0.05" x="420" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_T"
-frame duration="0.05" x="430" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000054"
+frame duration="0.05" x="430" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_U"
-frame duration="0.05" x="440" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000055"
+frame duration="0.05" x="440" y="8" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_V"
-frame duration="0.05" x="244" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000056"
+frame duration="0.05" x="244" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_W"
-frame duration="0.05" x="254" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000057"
+frame duration="0.05" x="254" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_X"
-frame duration="0.05" x="264" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000058"
+frame duration="0.05" x="264" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_Y"
-frame duration="0.05" x="274" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000059"
+frame duration="0.05" x="274" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_Z"
-frame duration="0.05" x="284" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00005A"
+frame duration="0.05" x="284" y="28" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_A"
-frame duration="0.05" x="244" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000061"
+frame duration="0.05" x="244" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_B"
-frame duration="0.05" x="254" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000062"
+frame duration="0.05" x="254" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_C"
-frame duration="0.05" x="264" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000063"
+frame duration="0.05" x="264" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_D"
-frame duration="0.05" x="274" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000064"
+frame duration="0.05" x="274" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_E"
-frame duration="0.05" x="284" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000065"
+frame duration="0.05" x="284" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_F"
-frame duration="0.05" x="294" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000066"
+frame duration="0.05" x="294" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_G"
-frame duration="0.05" x="304" y="47" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000067"
+frame duration="0.05" x="304" y="47" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_H"
-frame duration="0.05" x="314" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000068"
+frame duration="0.05" x="314" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_I"
-frame duration="0.05" x="322" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000069"
+frame duration="0.05" x="322" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_K"
-frame duration="0.05" x="337" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006B"
+frame duration="0.05" x="337" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_J"
-frame duration="0.05" x="329" y="47" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006A"
+frame duration="0.05" x="329" y="47" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_L"
-frame duration="0.05" x="345" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006C"
+frame duration="0.05" x="345" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_M"
-frame duration="0.05" x="353" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006D"
+frame duration="0.05" x="353" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_N"
-frame duration="0.05" x="363" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006E"
+frame duration="0.05" x="363" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_O"
-frame duration="0.05" x="373" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006F"
+frame duration="0.05" x="373" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_P"
-frame duration="0.05" x="383" y="47" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000070"
+frame duration="0.05" x="383" y="47" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_Q"
-frame duration="0.05" x="393" y="47" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000071"
+frame duration="0.05" x="393" y="47" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_R"
-frame duration="0.05" x="403" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000072"
+frame duration="0.05" x="403" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_S"
-frame duration="0.05" x="413" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000073"
+frame duration="0.05" x="413" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_T"
-frame duration="0.05" x="423" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000074"
+frame duration="0.05" x="423" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_U"
-frame duration="0.05" x="433" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000075"
+frame duration="0.05" x="433" y="47" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_V"
-frame duration="0.05" x="244" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000076"
+frame duration="0.05" x="244" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_W"
-frame duration="0.05" x="254" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000077"
+frame duration="0.05" x="254" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_X"
-frame duration="0.05" x="264" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000078"
+frame duration="0.05" x="264" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_Y"
-frame duration="0.05" x="274" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000079"
+frame duration="0.05" x="274" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_Z"
-frame duration="0.05" x="284" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00007A"
+frame duration="0.05" x="284" y="66" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_0"
-frame duration="0.05" x="244" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000030"
+frame duration="0.05" x="244" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_1"
-frame duration="0.05" x="252" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000031"
+frame duration="0.05" x="252" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_2"
-frame duration="0.05" x="261" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000032"
+frame duration="0.05" x="261" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_3"
-frame duration="0.05" x="271" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000033"
+frame duration="0.05" x="271" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_4"
-frame duration="0.05" x="281" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000034"
+frame duration="0.05" x="281" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_5"
-frame duration="0.05" x="291" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000035"
+frame duration="0.05" x="291" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_6"
-frame duration="0.05" x="301" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000036"
+frame duration="0.05" x="301" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_7"
-frame duration="0.05" x="311" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000037"
+frame duration="0.05" x="311" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_8"
-frame duration="0.05" x="321" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000038"
+frame duration="0.05" x="321" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_9"
-frame duration="0.05" x="331" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
-frame duration="0.05" x="0" y="0" w="0" h="0" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000039"
+frame duration="0.05" x="331" y="85" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
+frame duration="0.05" x="0" y="0" w="0" h="0" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_("
-frame duration="0.05" x="245" y="103" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000028"
+frame duration="0.05" x="245" y="103" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_)"
-frame duration="0.05" x="252" y="103" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000029"
+frame duration="0.05" x="252" y="103" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK__"
-frame duration="0.05" x="262" y="103" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00005F"
+frame duration="0.05" x="262" y="103" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_-"
-frame duration="0.05" x="272" y="103" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002D"
+frame duration="0.05" x="272" y="103" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_+"
-frame duration="0.05" x="282" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002B"
+frame duration="0.05" x="282" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_="
-frame duration="0.05" x="292" y="103" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003D"
+frame duration="0.05" x="292" y="103" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_\"
-frame duration="0.05" x="301" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00005C"
+frame duration="0.05" x="301" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_/"
-frame duration="0.05" x="311" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002F"
+frame duration="0.05" x="311" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_<"
-frame duration="0.05" x="321" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003C"
+frame duration="0.05" x="321" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_>"
-frame duration="0.05" x="330" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003E"
+frame duration="0.05" x="330" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_?"
-frame duration="0.05" x="339" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003F"
+frame duration="0.05" x="339" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_,"
-frame duration="0.05" x="347" y="104" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002C"
+frame duration="0.05" x="347" y="104" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_."
-frame duration="0.05" x="353" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002E"
+frame duration="0.05" x="353" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_!"
-frame duration="0.05" x="359" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000021"
+frame duration="0.05" x="359" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_@"
-frame duration="0.05" x="367" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000040"
+frame duration="0.05" x="367" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_#"
-frame duration="0.05" x="376" y="104" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000023"
+frame duration="0.05" x="376" y="104" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_$"
-frame duration="0.05" x="386" y="102" w="7" h="13" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000024"
+frame duration="0.05" x="386" y="102" w="7" h="13" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_%"
-frame duration="0.05" x="397" y="104" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000025"
+frame duration="0.05" x="397" y="104" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_^"
-frame duration="0.05" x="408" y="102" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00005E"
+frame duration="0.05" x="408" y="102" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_&"
-frame duration="0.05" x="416" y="104" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000026"
+frame duration="0.05" x="416" y="104" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_*"
-frame duration="0.05" x="426" y="103" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002A"
+frame duration="0.05" x="426" y="103" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_'"
-frame duration="0.05" x="436" y="102" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000027"
+frame duration="0.05" x="436" y="102" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_QUOTE"
-frame duration="0.05" x="442" y="102" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000022"
+frame duration="0.05" x="442" y="102" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_:"
-frame duration="0.05" x="448" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003A"
+frame duration="0.05" x="448" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_;"
-frame duration="0.05" x="454" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003B"
+frame duration="0.05" x="454" y="104" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_A"
-frame duration="0.05" x="469" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000041"
+frame duration="0.05" x="469" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_B"
-frame duration="0.05" x="476" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000042"
+frame duration="0.05" x="476" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_C"
-frame duration="0.05" x="483" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000043"
+frame duration="0.05" x="483" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_D"
-frame duration="0.05" x="490" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000044"
+frame duration="0.05" x="490" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_E"
-frame duration="0.05" x="497" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000045"
+frame duration="0.05" x="497" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_F"
-frame duration="0.05" x="504" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000046"
+frame duration="0.05" x="504" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_G"
-frame duration="0.05" x="511" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000047"
+frame duration="0.05" x="511" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_H"
-frame duration="0.05" x="518" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000048"
+frame duration="0.05" x="518" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_I"
-frame duration="0.05" x="524" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000049"
+frame duration="0.05" x="524" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_J"
-frame duration="0.05" x="530" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004A"
+frame duration="0.05" x="530" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_K"
-frame duration="0.05" x="537" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004B"
+frame duration="0.05" x="537" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_L"
-frame duration="0.05" x="544" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004C"
+frame duration="0.05" x="544" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_M"
-frame duration="0.05" x="552" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004D"
+frame duration="0.05" x="552" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_N"
-frame duration="0.05" x="560" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004E"
+frame duration="0.05" x="560" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_O"
-frame duration="0.05" x="567" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004F"
+frame duration="0.05" x="567" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_P"
-frame duration="0.05" x="574" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000050"
+frame duration="0.05" x="574" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_Q"
-frame duration="0.05" x="581" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000051"
+frame duration="0.05" x="581" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_R"
-frame duration="0.05" x="589" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000052"
+frame duration="0.05" x="589" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_S"
-frame duration="0.05" x="596" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000053"
+frame duration="0.05" x="596" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_T"
-frame duration="0.05" x="603" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000054"
+frame duration="0.05" x="603" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_U"
-frame duration="0.05" x="610" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000055"
+frame duration="0.05" x="610" y="9" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_V"
-frame duration="0.05" x="469" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000056"
+frame duration="0.05" x="469" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_W"
-frame duration="0.05" x="477" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000057"
+frame duration="0.05" x="477" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_X"
-frame duration="0.05" x="485" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000058"
+frame duration="0.05" x="485" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_Y"
-frame duration="0.05" x="492" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000059"
+frame duration="0.05" x="492" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_Z"
-frame duration="0.05" x="499" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00005A"
+frame duration="0.05" x="499" y="29" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_A"
-frame duration="0.05" x="469" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000061"
+frame duration="0.05" x="469" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_B"
-frame duration="0.05" x="476" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000062"
+frame duration="0.05" x="476" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_C"
-frame duration="0.05" x="483" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000063"
+frame duration="0.05" x="483" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_D"
-frame duration="0.05" x="490" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000064"
+frame duration="0.05" x="490" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_E"
-frame duration="0.05" x="497" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000065"
+frame duration="0.05" x="497" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_F"
-frame duration="0.05" x="504" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000066"
+frame duration="0.05" x="504" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_G"
-frame duration="0.05" x="511" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000067"
+frame duration="0.05" x="511" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_H"
-frame duration="0.05" x="518" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000068"
+frame duration="0.05" x="518" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_I"
-frame duration="0.05" x="524" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000069"
+frame duration="0.05" x="524" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_J"
-frame duration="0.05" x="529" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006A"
+frame duration="0.05" x="529" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_K"
-frame duration="0.05" x="536" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006B"
+frame duration="0.05" x="536" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_L"
-frame duration="0.05" x="542" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006C"
+frame duration="0.05" x="542" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_M"
-frame duration="0.05" x="549" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006D"
+frame duration="0.05" x="549" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_N"
-frame duration="0.05" x="557" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006E"
+frame duration="0.05" x="557" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_O"
-frame duration="0.05" x="564" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006F"
+frame duration="0.05" x="564" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_P"
-frame duration="0.05" x="571" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000070"
+frame duration="0.05" x="571" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_Q"
-frame duration="0.05" x="578" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000071"
+frame duration="0.05" x="578" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_R"
-frame duration="0.05" x="586" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000072"
+frame duration="0.05" x="586" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_S"
-frame duration="0.05" x="593" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000073"
+frame duration="0.05" x="593" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_T"
-frame duration="0.05" x="600" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000074"
+frame duration="0.05" x="600" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_U"
-frame duration="0.05" x="607" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000075"
+frame duration="0.05" x="607" y="48" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_V"
-frame duration="0.05" x="469" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000076"
+frame duration="0.05" x="469" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_W"
-frame duration="0.05" x="477" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000077"
+frame duration="0.05" x="477" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_X"
-frame duration="0.05" x="485" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000078"
+frame duration="0.05" x="485" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_Y"
-frame duration="0.05" x="492" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000079"
+frame duration="0.05" x="492" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_Z"
-frame duration="0.05" x="499" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00007A"
+frame duration="0.05" x="499" y="67" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_0"
-frame duration="0.05" x="469" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000030"
+frame duration="0.05" x="469" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_1"
-frame duration="0.05" x="476" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000031"
+frame duration="0.05" x="476" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_2"
-frame duration="0.05" x="482" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000032"
+frame duration="0.05" x="482" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_3"
-frame duration="0.05" x="489" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000033"
+frame duration="0.05" x="489" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_4"
-frame duration="0.05" x="496" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000034"
+frame duration="0.05" x="496" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_5"
-frame duration="0.05" x="503" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000035"
+frame duration="0.05" x="503" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_6"
-frame duration="0.05" x="510" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000036"
+frame duration="0.05" x="510" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_7"
-frame duration="0.05" x="517" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000037"
+frame duration="0.05" x="517" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_8"
-frame duration="0.05" x="524" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000038"
+frame duration="0.05" x="524" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_9"
-frame duration="0.05" x="531" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000039"
+frame duration="0.05" x="531" y="86" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_("
-frame duration="0.05" x="469" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000028"
+frame duration="0.05" x="469" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_)"
-frame duration="0.05" x="474" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000029"
+frame duration="0.05" x="474" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY__"
-frame duration="0.05" x="481" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00005F"
+frame duration="0.05" x="481" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_-"
-frame duration="0.05" x="488" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002D"
+frame duration="0.05" x="488" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_+"
-frame duration="0.05" x="494" y="106" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002B"
+frame duration="0.05" x="494" y="106" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_="
-frame duration="0.05" x="501" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003D"
+frame duration="0.05" x="501" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_\"
-frame duration="0.05" x="508" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00005C"
+frame duration="0.05" x="508" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_/"
-frame duration="0.05" x="515" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002F"
+frame duration="0.05" x="515" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_<"
-frame duration="0.05" x="522" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003C"
+frame duration="0.05" x="522" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_>"
-frame duration="0.05" x="528" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003E"
+frame duration="0.05" x="528" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_?"
-frame duration="0.05" x="535" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003F"
+frame duration="0.05" x="535" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_,"
-frame duration="0.05" x="542" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002C"
+frame duration="0.05" x="542" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_."
-frame duration="0.05" x="547" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002E"
+frame duration="0.05" x="547" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_!"
-frame duration="0.05" x="552" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000021"
+frame duration="0.05" x="552" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_@"
-frame duration="0.05" x="558" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000040"
+frame duration="0.05" x="558" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_#"
-frame duration="0.05" x="565" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000023"
+frame duration="0.05" x="565" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_$"
-frame duration="0.05" x="572" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000024"
+frame duration="0.05" x="572" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_%"
-frame duration="0.05" x="580" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000025"
+frame duration="0.05" x="580" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_^"
-frame duration="0.05" x="587" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00005E"
+frame duration="0.05" x="587" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_&"
-frame duration="0.05" x="595" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000026"
+frame duration="0.05" x="595" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_*"
-frame duration="0.05" x="602" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002A"
+frame duration="0.05" x="602" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_'"
-frame duration="0.05" x="608" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000027"
+frame duration="0.05" x="608" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_QUOTE"
-frame duration="0.05" x="614" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000022"
+frame duration="0.05" x="614" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_:"
-frame duration="0.05" x="621" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003A"
+frame duration="0.05" x="621" y="105" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_;"
-frame duration="0.05" x="627" y="106" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003B"
+frame duration="0.05" x="627" y="106" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_A"
-frame duration="0.05" x="639" y="9" w="7" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000041"
+frame duration="0.05" x="639" y="9" w="7" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_B"
-frame duration="0.05" x="649" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000042"
+frame duration="0.05" x="649" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_C"
-frame duration="0.05" x="659" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000043"
+frame duration="0.05" x="659" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_D"
-frame duration="0.05" x="669" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000044"
+frame duration="0.05" x="669" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_E"
-frame duration="0.05" x="679" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000045"
+frame duration="0.05" x="679" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_F"
-frame duration="0.05" x="689" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000046"
+frame duration="0.05" x="689" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_G"
-frame duration="0.05" x="699" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000047"
+frame duration="0.05" x="699" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_H"
-frame duration="0.05" x="709" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000048"
+frame duration="0.05" x="709" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_I"
-frame duration="0.05" x="717" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000049"
+frame duration="0.05" x="717" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_J"
-frame duration="0.05" x="725" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004A"
+frame duration="0.05" x="725" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_K"
-frame duration="0.05" x="734" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004B"
+frame duration="0.05" x="734" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_L"
-frame duration="0.05" x="744" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004C"
+frame duration="0.05" x="744" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_M"
-frame duration="0.05" x="754" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004D"
+frame duration="0.05" x="754" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_N"
-frame duration="0.05" x="764" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004E"
+frame duration="0.05" x="764" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_O"
-frame duration="0.05" x="774" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004F"
+frame duration="0.05" x="774" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_P"
-frame duration="0.05" x="784" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000050"
+frame duration="0.05" x="784" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_Q"
-frame duration="0.05" x="794" y="9" w="7" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000051"
+frame duration="0.05" x="794" y="9" w="7" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_R"
-frame duration="0.05" x="806" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000052"
+frame duration="0.05" x="806" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_S"
-frame duration="0.05" x="816" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000053"
+frame duration="0.05" x="816" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_T"
-frame duration="0.05" x="826" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000054"
+frame duration="0.05" x="826" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_U"
-frame duration="0.05" x="836" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000055"
+frame duration="0.05" x="836" y="9" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_V"
-frame duration="0.05" x="639" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000056"
+frame duration="0.05" x="639" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_W"
-frame duration="0.05" x="649" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000057"
+frame duration="0.05" x="649" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_X"
-frame duration="0.05" x="659" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000058"
+frame duration="0.05" x="659" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_Y"
-frame duration="0.05" x="669" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000059"
+frame duration="0.05" x="669" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_Z"
-frame duration="0.05" x="679" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00005A"
+frame duration="0.05" x="679" y="29" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_0"
-frame duration="0.05" x="639" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000030"
+frame duration="0.05" x="639" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_1"
-frame duration="0.05" x="648" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000031"
+frame duration="0.05" x="648" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_2"
-frame duration="0.05" x="656" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000032"
+frame duration="0.05" x="656" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_3"
-frame duration="0.05" x="666" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000033"
+frame duration="0.05" x="666" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_4"
-frame duration="0.05" x="676" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000034"
+frame duration="0.05" x="676" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_5"
-frame duration="0.05" x="685" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000035"
+frame duration="0.05" x="685" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_6"
-frame duration="0.05" x="695" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000036"
+frame duration="0.05" x="695" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_7"
-frame duration="0.05" x="705" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000037"
+frame duration="0.05" x="705" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_8"
-frame duration="0.05" x="715" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000038"
+frame duration="0.05" x="715" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_9"
-frame duration="0.05" x="725" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000039"
+frame duration="0.05" x="725" y="86" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_("
-frame duration="0.05" x="639" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000028"
+frame duration="0.05" x="639" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_)"
-frame duration="0.05" x="646" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000029"
+frame duration="0.05" x="646" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE__"
-frame duration="0.05" x="655" y="105" w="6" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00005F"
+frame duration="0.05" x="655" y="105" w="6" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_-"
-frame duration="0.05" x="664" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002D"
+frame duration="0.05" x="664" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_+"
-frame duration="0.05" x="672" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002B"
+frame duration="0.05" x="672" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_="
-frame duration="0.05" x="681" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003D"
+frame duration="0.05" x="681" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_\"
-frame duration="0.05" x="691" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00005C"
+frame duration="0.05" x="691" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_/"
-frame duration="0.05" x="699" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002F"
+frame duration="0.05" x="699" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_<"
-frame duration="0.05" x="708" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003C"
+frame duration="0.05" x="708" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_>"
-frame duration="0.05" x="715" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003E"
+frame duration="0.05" x="715" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_?"
-frame duration="0.05" x="725" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003F"
+frame duration="0.05" x="725" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_,"
-frame duration="0.05" x="733" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002C"
+frame duration="0.05" x="733" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_."
-frame duration="0.05" x="740" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002E"
+frame duration="0.05" x="740" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_!"
-frame duration="0.05" x="747" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000021"
+frame duration="0.05" x="747" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_@"
-frame duration="0.05" x="754" y="104" w="7" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000040"
+frame duration="0.05" x="754" y="104" w="7" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_#"
-frame duration="0.05" x="765" y="105" w="6" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000023"
+frame duration="0.05" x="765" y="105" w="6" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_$"
-frame duration="0.05" x="774" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000024"
+frame duration="0.05" x="774" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_%"
-frame duration="0.05" x="785" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000025"
+frame duration="0.05" x="785" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_^"
-frame duration="0.05" x="794" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00005E"
+frame duration="0.05" x="794" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_&"
-frame duration="0.05" x="802" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000026"
+frame duration="0.05" x="802" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_*"
-frame duration="0.05" x="812" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002A"
+frame duration="0.05" x="812" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_'"
-frame duration="0.05" x="821" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000027"
+frame duration="0.05" x="821" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_QUOTE"
-frame duration="0.05" x="828" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000022"
+frame duration="0.05" x="828" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_:"
-frame duration="0.05" x="837" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003A"
+frame duration="0.05" x="837" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_;"
-frame duration="0.05" x="844" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003B"
+frame duration="0.05" x="844" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_A"
-frame duration="0.05" x="859" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000041"
+frame duration="0.05" x="859" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_B"
-frame duration="0.05" x="879" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000042"
+frame duration="0.05" x="879" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_C"
-frame duration="0.05" x="899" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000043"
+frame duration="0.05" x="899" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_D"
-frame duration="0.05" x="919" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000044"
+frame duration="0.05" x="919" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_E"
-frame duration="0.05" x="939" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000045"
+frame duration="0.05" x="939" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_F"
-frame duration="0.05" x="959" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000046"
+frame duration="0.05" x="959" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_G"
-frame duration="0.05" x="979" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000047"
+frame duration="0.05" x="979" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_H"
-frame duration="0.05" x="999" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000048"
+frame duration="0.05" x="999" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_I"
-frame duration="0.05" x="1017" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000049"
+frame duration="0.05" x="1017" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_J"
-frame duration="0.05" x="1039" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004A"
+frame duration="0.05" x="1039" y="2" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_K"
-frame duration="0.05" x="859" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004B"
+frame duration="0.05" x="859" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_L"
-frame duration="0.05" x="879" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004C"
+frame duration="0.05" x="879" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_M"
-frame duration="0.05" x="899" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004D"
+frame duration="0.05" x="899" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_N"
-frame duration="0.05" x="919" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004E"
+frame duration="0.05" x="919" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_O"
-frame duration="0.05" x="939" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004F"
+frame duration="0.05" x="939" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_P"
-frame duration="0.05" x="959" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000050"
+frame duration="0.05" x="959" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_Q"
-frame duration="0.05" x="979" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000051"
+frame duration="0.05" x="979" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_R"
-frame duration="0.05" x="999" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000052"
+frame duration="0.05" x="999" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_S"
-frame duration="0.05" x="1019" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000053"
+frame duration="0.05" x="1019" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_T"
-frame duration="0.05" x="1039" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000054"
+frame duration="0.05" x="1039" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_U"
-frame duration="0.05" x="859" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000055"
+frame duration="0.05" x="859" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_V"
-frame duration="0.05" x="879" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000056"
+frame duration="0.05" x="879" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_W"
-frame duration="0.05" x="899" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000057"
+frame duration="0.05" x="899" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_X"
-frame duration="0.05" x="919" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000058"
+frame duration="0.05" x="919" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_Y"
-frame duration="0.05" x="939" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000059"
+frame duration="0.05" x="939" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_Z"
-frame duration="0.05" x="959" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005A"
+frame duration="0.05" x="959" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_:"
-frame duration="0.05" x="983" y="40" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003A"
+frame duration="0.05" x="983" y="40" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_&"
-frame duration="0.05" x="999" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000026"
+frame duration="0.05" x="999" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_'"
-frame duration="0.05" x="1023" y="42" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000027"
+frame duration="0.05" x="1023" y="42" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_="
-frame duration="0.05" x="1043" y="40" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003D"
+frame duration="0.05" x="1043" y="40" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_0"
-frame duration="0.05" x="859" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000030"
+frame duration="0.05" x="859" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_1"
-frame duration="0.05" x="878" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000031"
+frame duration="0.05" x="878" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_2"
-frame duration="0.05" x="899" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000032"
+frame duration="0.05" x="899" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_3"
-frame duration="0.05" x="919" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000033"
+frame duration="0.05" x="919" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_4"
-frame duration="0.05" x="939" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000034"
+frame duration="0.05" x="939" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_5"
-frame duration="0.05" x="959" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000035"
+frame duration="0.05" x="959" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_6"
-frame duration="0.05" x="979" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000036"
+frame duration="0.05" x="979" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_7"
-frame duration="0.05" x="999" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000037"
+frame duration="0.05" x="999" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_8"
-frame duration="0.05" x="1019" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000038"
+frame duration="0.05" x="1019" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_9"
-frame duration="0.05" x="1039" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000039"
+frame duration="0.05" x="1039" y="62" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_A"
-frame duration="0.05" x="859" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000061"
+frame duration="0.05" x="859" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_B"
-frame duration="0.05" x="879" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000062"
+frame duration="0.05" x="879" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_C"
-frame duration="0.05" x="899" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000063"
+frame duration="0.05" x="899" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_D"
-frame duration="0.05" x="919" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000064"
+frame duration="0.05" x="919" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_E"
-frame duration="0.05" x="939" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000065"
+frame duration="0.05" x="939" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_F"
-frame duration="0.05" x="959" y="82" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000066"
+frame duration="0.05" x="959" y="82" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_G"
-frame duration="0.05" x="979" y="81" w="7" h="17" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000067"
+frame duration="0.05" x="979" y="81" w="7" h="17" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_H"
-frame duration="0.05" x="999" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000068"
+frame duration="0.05" x="999" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_I"
-frame duration="0.05" x="1018" y="82" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000069"
+frame duration="0.05" x="1018" y="82" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_J"
-frame duration="0.05" x="1038" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006A"
+frame duration="0.05" x="1038" y="82" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_K"
-frame duration="0.05" x="858" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006B"
+frame duration="0.05" x="858" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_L"
-frame duration="0.05" x="878" y="102" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006C"
+frame duration="0.05" x="878" y="102" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_M"
-frame duration="0.05" x="899" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006D"
+frame duration="0.05" x="899" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_N"
-frame duration="0.05" x="919" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006E"
+frame duration="0.05" x="919" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_O"
-frame duration="0.05" x="939" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006F"
+frame duration="0.05" x="939" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_P"
-frame duration="0.05" x="959" y="101" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000070"
+frame duration="0.05" x="959" y="101" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_Q"
-frame duration="0.05" x="979" y="101" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000071"
+frame duration="0.05" x="979" y="101" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_R"
-frame duration="0.05" x="999" y="102" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000072"
+frame duration="0.05" x="999" y="102" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_S"
-frame duration="0.05" x="1019" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000073"
+frame duration="0.05" x="1019" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_T"
-frame duration="0.05" x="1039" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000074"
+frame duration="0.05" x="1039" y="102" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_U"
-frame duration="0.05" x="859" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000075"
+frame duration="0.05" x="859" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_V"
-frame duration="0.05" x="879" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000076"
+frame duration="0.05" x="879" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_W"
-frame duration="0.05" x="899" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000077"
+frame duration="0.05" x="899" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_X"
-frame duration="0.05" x="919" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000078"
+frame duration="0.05" x="919" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_Y"
-frame duration="0.05" x="939" y="121" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000079"
+frame duration="0.05" x="939" y="121" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_Z"
-frame duration="0.05" x="959" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00007A"
+frame duration="0.05" x="959" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_-"
-frame duration="0.05" x="983" y="121" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002D"
+frame duration="0.05" x="983" y="121" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_!"
-frame duration="0.05" x="998" y="122" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000021"
+frame duration="0.05" x="998" y="122" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_/"
-frame duration="0.05" x="1019" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002F"
+frame duration="0.05" x="1019" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_."
-frame duration="0.05" x="1045" y="119" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002E"
+frame duration="0.05" x="1045" y="119" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_?"
-frame duration="0.05" x="1056" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003F"
+frame duration="0.05" x="1056" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_,"
-frame duration="0.05" x="1024" y="37" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002C"
+frame duration="0.05" x="1024" y="37" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_0"
-frame duration="0.05" x="736" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000030"
+frame duration="0.05" x="736" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_1"
-frame duration="0.05" x="745" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000031"
+frame duration="0.05" x="745" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_2"
-frame duration="0.05" x="754" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000032"
+frame duration="0.05" x="754" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_3"
-frame duration="0.05" x="764" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000033"
+frame duration="0.05" x="764" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_4"
-frame duration="0.05" x="774" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000034"
+frame duration="0.05" x="774" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_5"
-frame duration="0.05" x="784" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000035"
+frame duration="0.05" x="784" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_6"
-frame duration="0.05" x="794" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000036"
+frame duration="0.05" x="794" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_7"
-frame duration="0.05" x="804" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000037"
+frame duration="0.05" x="804" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_8"
-frame duration="0.05" x="814" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000038"
+frame duration="0.05" x="814" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_9"
-frame duration="0.05" x="824" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000039"
+frame duration="0.05" x="824" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_S"
-frame duration="0.05" x="834" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000053"
+frame duration="0.05" x="834" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_:"
-frame duration="0.05" x="843" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U00003A"
+frame duration="0.05" x="843" y="125" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_0"
-frame duration="0.05" x="755" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000030"
+frame duration="0.05" x="755" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_1"
-frame duration="0.05" x="764" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000031"
+frame duration="0.05" x="764" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_2"
-frame duration="0.05" x="771" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000032"
+frame duration="0.05" x="771" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_3"
-frame duration="0.05" x="779" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000033"
+frame duration="0.05" x="779" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_4"
-frame duration="0.05" x="787" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000034"
+frame duration="0.05" x="787" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_5"
-frame duration="0.05" x="795" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000035"
+frame duration="0.05" x="795" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_6"
-frame duration="0.05" x="803" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000036"
+frame duration="0.05" x="803" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_7"
-frame duration="0.05" x="811" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000037"
+frame duration="0.05" x="811" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_8"
-frame duration="0.05" x="819" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000038"
+frame duration="0.05" x="819" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_9"
-frame duration="0.05" x="827" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000039"
+frame duration="0.05" x="827" y="63" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_0"
-frame duration="0.05" x="755" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000030"
+frame duration="0.05" x="755" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_1"
-frame duration="0.05" x="764" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000031"
+frame duration="0.05" x="764" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_2"
-frame duration="0.05" x="771" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000032"
+frame duration="0.05" x="771" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_3"
-frame duration="0.05" x="779" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000033"
+frame duration="0.05" x="779" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_4"
-frame duration="0.05" x="787" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000034"
+frame duration="0.05" x="787" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_5"
-frame duration="0.05" x="795" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000035"
+frame duration="0.05" x="795" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_6"
-frame duration="0.05" x="803" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000036"
+frame duration="0.05" x="803" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_7"
-frame duration="0.05" x="811" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000037"
+frame duration="0.05" x="811" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_8"
-frame duration="0.05" x="819" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000038"
+frame duration="0.05" x="819" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_9"
-frame duration="0.05" x="827" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000039"
+frame duration="0.05" x="827" y="74" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_0"
-frame duration="0.05" x="755" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000030"
+frame duration="0.05" x="755" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_1"
-frame duration="0.05" x="764" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000031"
+frame duration="0.05" x="764" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_2"
-frame duration="0.05" x="771" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000032"
+frame duration="0.05" x="771" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_3"
-frame duration="0.05" x="779" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000033"
+frame duration="0.05" x="779" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_4"
-frame duration="0.05" x="787" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000034"
+frame duration="0.05" x="787" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_5"
-frame duration="0.05" x="795" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000035"
+frame duration="0.05" x="795" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_6"
-frame duration="0.05" x="803" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000036"
+frame duration="0.05" x="803" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_7"
-frame duration="0.05" x="811" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000037"
+frame duration="0.05" x="811" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_8"
-frame duration="0.05" x="819" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000038"
+frame duration="0.05" x="819" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_9"
-frame duration="0.05" x="827" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000039"
+frame duration="0.05" x="827" y="85" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_0"
-frame duration="0.05" x="756" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000030"
+frame duration="0.05" x="756" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_1"
-frame duration="0.05" x="765" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000031"
+frame duration="0.05" x="765" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_2"
-frame duration="0.05" x="772" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000032"
+frame duration="0.05" x="772" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_3"
-frame duration="0.05" x="780" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000033"
+frame duration="0.05" x="780" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_4"
-frame duration="0.05" x="788" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000034"
+frame duration="0.05" x="788" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_5"
-frame duration="0.05" x="796" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000035"
+frame duration="0.05" x="796" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_6"
-frame duration="0.05" x="804" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000036"
+frame duration="0.05" x="804" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_7"
-frame duration="0.05" x="812" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000037"
+frame duration="0.05" x="812" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_8"
-frame duration="0.05" x="820" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000038"
+frame duration="0.05" x="820" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_9"
-frame duration="0.05" x="828" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000039"
+frame duration="0.05" x="828" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_+"
-frame duration="0.05" x="748" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U00002B"
+frame duration="0.05" x="748" y="113" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_SP"
-frame duration="0.05" x="298" y="66" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00E000"
+frame duration="0.05" x="298" y="66" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_EX"
-frame duration="0.05" x="314" y="66" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00E001"
+frame duration="0.05" x="314" y="66" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_NM"
-frame duration="0.05" x="330" y="66" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00E002"
+frame duration="0.05" x="330" y="66" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_QUOTE"
-frame duration="0.05" x="1060" y="44" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000022"
+frame duration="0.05" x="1060" y="44" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN__"
-frame duration="0.05" x="1077" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005F"
+frame duration="0.05" x="1077" y="42" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_$"
-frame duration="0.05" x="1074" y="21" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000024"
+frame duration="0.05" x="1074" y="21" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_("
-frame duration="0.05" x="1053" y="103" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000028"
+frame duration="0.05" x="1053" y="103" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_)"
-frame duration="0.05" x="1065" y="103" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000029"
+frame duration="0.05" x="1065" y="103" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_["
-frame duration="0.05" x="1074" y="103" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005B"
+frame duration="0.05" x="1074" y="103" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_]"
-frame duration="0.05" x="1086" y="103" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005D"
+frame duration="0.05" x="1086" y="103" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_*"
-frame duration="0.05" x="1081" y="81" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002A"
+frame duration="0.05" x="1081" y="81" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_~"
-frame duration="0.05" x="1070" y="84" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00007E"
+frame duration="0.05" x="1070" y="84" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_`"
-frame duration="0.05" x="1062" y="61" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000060"
+frame duration="0.05" x="1062" y="61" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_^"
-frame duration="0.05" x="1079" y="61" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005E"
+frame duration="0.05" x="1079" y="61" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_+"
-frame duration="0.05" x="1053" y="61" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002B"
+frame duration="0.05" x="1053" y="61" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_#"
-frame duration="0.05" x="1084" y="123" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000023"
+frame duration="0.05" x="1084" y="123" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_%"
-frame duration="0.05" x="1072" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000025"
+frame duration="0.05" x="1072" y="122" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_@"
-frame duration="0.05" x="1053" y="83" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000040"
+frame duration="0.05" x="1053" y="83" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_<"
-frame duration="0.05" x="1054" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003C"
+frame duration="0.05" x="1054" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_>"
-frame duration="0.05" x="1060" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003E"
+frame duration="0.05" x="1060" y="22" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_{"
-frame duration="0.05" x="1075" y="137" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00007B"
+frame duration="0.05" x="1075" y="137" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_}"
-frame duration="0.05" x="1087" y="137" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00007D"
+frame duration="0.05" x="1087" y="137" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_;"
-frame duration="0.05" x="1012" y="40" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003B"
+frame duration="0.05" x="1012" y="40" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_A"
-frame duration="0.05" x="389" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000041"
+frame duration="0.05" x="389" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_B"
-frame duration="0.05" x="400" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000042"
+frame duration="0.05" x="400" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_C"
-frame duration="0.05" x="411" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000043"
+frame duration="0.05" x="411" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_D"
-frame duration="0.05" x="422" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000044"
+frame duration="0.05" x="422" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_E"
-frame duration="0.05" x="433" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000045"
+frame duration="0.05" x="433" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_F"
-frame duration="0.05" x="445" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000046"
+frame duration="0.05" x="445" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_G"
-frame duration="0.05" x="457" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000047"
+frame duration="0.05" x="457" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_H"
-frame duration="0.05" x="469" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000048"
+frame duration="0.05" x="469" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_I"
-frame duration="0.05" x="480" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000049"
+frame duration="0.05" x="480" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_J"
-frame duration="0.05" x="493" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004A"
+frame duration="0.05" x="493" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_K"
-frame duration="0.05" x="504" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004B"
+frame duration="0.05" x="504" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_L"
-frame duration="0.05" x="516" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004C"
+frame duration="0.05" x="516" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_M"
-frame duration="0.05" x="527" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004D"
+frame duration="0.05" x="527" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_N"
-frame duration="0.05" x="538" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004E"
+frame duration="0.05" x="538" y="115" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_O"
-frame duration="0.05" x="389" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004F"
+frame duration="0.05" x="389" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_P"
-frame duration="0.05" x="400" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000050"
+frame duration="0.05" x="400" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_Q"
-frame duration="0.05" x="411" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000051"
+frame duration="0.05" x="411" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_R"
-frame duration="0.05" x="423" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000052"
+frame duration="0.05" x="423" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_S"
-frame duration="0.05" x="435" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000053"
+frame duration="0.05" x="435" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_T"
-frame duration="0.05" x="447" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000054"
+frame duration="0.05" x="447" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_U"
-frame duration="0.05" x="458" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000055"
+frame duration="0.05" x="458" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_V"
-frame duration="0.05" x="471" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000056"
+frame duration="0.05" x="471" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_W"
-frame duration="0.05" x="482" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000057"
+frame duration="0.05" x="482" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_X"
-frame duration="0.05" x="493" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000058"
+frame duration="0.05" x="493" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_Y"
-frame duration="0.05" x="504" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000059"
+frame duration="0.05" x="504" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_Z"
-frame duration="0.05" x="516" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00005A"
+frame duration="0.05" x="516" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE__"
-frame duration="0.05" x="556" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00005F"
+frame duration="0.05" x="556" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_<"
-frame duration="0.05" x="547" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00003C"
+frame duration="0.05" x="547" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_>"
-frame duration="0.05" x="538" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00003E"
+frame duration="0.05" x="538" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_!"
-frame duration="0.05" x="527" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000021"
+frame duration="0.05" x="527" y="132" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_0"
-frame duration="0.05" x="406" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000030"
+frame duration="0.05" x="406" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_1"
-frame duration="0.05" x="418" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000031"
+frame duration="0.05" x="418" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_2"
-frame duration="0.05" x="429" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000032"
+frame duration="0.05" x="429" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_3"
-frame duration="0.05" x="441" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000033"
+frame duration="0.05" x="441" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_4"
-frame duration="0.05" x="452" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000034"
+frame duration="0.05" x="452" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_5"
-frame duration="0.05" x="464" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000035"
+frame duration="0.05" x="464" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_6"
-frame duration="0.05" x="477" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000036"
+frame duration="0.05" x="477" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_7"
-frame duration="0.05" x="489" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000037"
+frame duration="0.05" x="489" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_8"
-frame duration="0.05" x="501" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000038"
+frame duration="0.05" x="501" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_9"
-frame duration="0.05" x="513" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000039"
+frame duration="0.05" x="513" y="152" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"

--- a/BattleNetwork/resources/fonts/fonts_compressed.animation
+++ b/BattleNetwork/resources/fonts/fonts_compressed.animation
@@ -1,1533 +1,1533 @@
 imagePath="fonts_compressed.png"
 
-animation state="SMALL_A"
-frame duration="0" x="136" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000041"
+frame duration="0" x="136" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_B"
-frame duration="0" x="155" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000042"
+frame duration="0" x="155" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_C"
-frame duration="0" x="8" y="103" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000043"
+frame duration="0" x="8" y="103" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_D"
-frame duration="0" x="193" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000044"
+frame duration="0" x="193" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_E"
-frame duration="0" x="198" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000045"
+frame duration="0" x="198" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_F"
-frame duration="0" x="203" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000046"
+frame duration="0" x="203" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_G"
-frame duration="0" x="208" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000047"
+frame duration="0" x="208" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_H"
-frame duration="0" x="221" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000048"
+frame duration="0" x="221" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_I"
-frame duration="0" x="52" y="113" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000049"
+frame duration="0" x="52" y="113" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_J"
-frame duration="0" x="226" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004A"
+frame duration="0" x="226" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_K"
-frame duration="0" x="4" y="103" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004B"
+frame duration="0" x="4" y="103" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_L"
-frame duration="0" x="231" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004C"
+frame duration="0" x="231" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_M"
-frame duration="0" x="75" y="97" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004D"
+frame duration="0" x="75" y="97" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_N"
-frame duration="0" x="0" y="103" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004E"
+frame duration="0" x="0" y="103" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_O"
-frame duration="0" x="141" y="98" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00004F"
+frame duration="0" x="141" y="98" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_P"
-frame duration="0" x="146" y="98" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000050"
+frame duration="0" x="146" y="98" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_Q"
-frame duration="0" x="181" y="99" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000051"
+frame duration="0" x="181" y="99" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_R"
-frame duration="0" x="186" y="99" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000052"
+frame duration="0" x="186" y="99" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_S"
-frame duration="0" x="124" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000053"
+frame duration="0" x="124" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_T"
-frame duration="0" x="129" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000054"
+frame duration="0" x="129" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_U"
-frame duration="0" x="134" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000055"
+frame duration="0" x="134" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_V"
-frame duration="0" x="155" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000056"
+frame duration="0" x="155" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_W"
-frame duration="0" x="193" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000057"
+frame duration="0" x="193" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_X"
-frame duration="0" x="198" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000058"
+frame duration="0" x="198" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_Y"
-frame duration="0" x="203" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000059"
+frame duration="0" x="203" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_Z"
-frame duration="0" x="208" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00005A"
+frame duration="0" x="208" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_A"
-frame duration="0" x="247" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000061"
+frame duration="0" x="247" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_B"
-frame duration="0" x="243" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000062"
+frame duration="0" x="243" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_C"
-frame duration="0" x="177" y="119" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000063"
+frame duration="0" x="177" y="119" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_D"
-frame duration="0" x="239" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000064"
+frame duration="0" x="239" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_E"
-frame duration="0" x="156" y="115" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000065"
+frame duration="0" x="156" y="115" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_F"
-frame duration="0" x="236" y="110" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000066"
+frame duration="0" x="236" y="110" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_G"
-frame duration="0" x="251" y="31" w="4" h="9" originx="0" originy="1" flipx="0" flipy="0" 
+animation state="SMALL_U000067"
+frame duration="0" x="251" y="31" w="4" h="9" originx="0" originy="1" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_H"
-frame duration="0" x="214" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000068"
+frame duration="0" x="214" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_I"
-frame duration="0" x="221" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000069"
+frame duration="0" x="221" y="100" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_J"
-frame duration="0" x="250" y="61" w="5" h="9" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006A"
+frame duration="0" x="250" y="61" w="5" h="9" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_K"
-frame duration="0" x="175" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006B"
+frame duration="0" x="175" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_L"
-frame duration="0" x="155" y="72" w="5" h="8" originx="0" originy="1" flipx="0" flipy="0" 
+animation state="SMALL_U00006C"
+frame duration="0" x="155" y="72" w="5" h="8" originx="0" originy="1" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_M"
-frame duration="0" x="37" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006D"
+frame duration="0" x="37" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_N"
-frame duration="0" x="76" y="114" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006E"
+frame duration="0" x="76" y="114" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_O"
-frame duration="0" x="251" y="56" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00006F"
+frame duration="0" x="251" y="56" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_P"
-frame duration="0" x="251" y="40" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000070"
+frame duration="0" x="251" y="40" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_Q"
-frame duration="0" x="156" y="46" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000071"
+frame duration="0" x="156" y="46" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_R"
-frame duration="0" x="251" y="108" w="4" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000072"
+frame duration="0" x="251" y="108" w="4" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_S"
-frame duration="0" x="231" y="120" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000073"
+frame duration="0" x="231" y="120" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_T"
-frame duration="0" x="171" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000074"
+frame duration="0" x="171" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_U"
-frame duration="0" x="156" y="120" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000075"
+frame duration="0" x="156" y="120" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_V"
-frame duration="0" x="113" y="120" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000076"
+frame duration="0" x="113" y="120" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_W"
-frame duration="0" x="27" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000077"
+frame duration="0" x="27" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_X"
-frame duration="0" x="76" y="119" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000078"
+frame duration="0" x="76" y="119" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_Y"
-frame duration="0" x="251" y="48" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000079"
+frame duration="0" x="251" y="48" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_LOWER_Z"
-frame duration="0" x="177" y="114" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00007A"
+frame duration="0" x="177" y="114" w="4" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_0"
-frame duration="0" x="167" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000030"
+frame duration="0" x="167" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_1"
-frame duration="0" x="91" y="40" w="2" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000031"
+frame duration="0" x="91" y="40" w="2" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_2"
-frame duration="0" x="75" y="90" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000032"
+frame duration="0" x="75" y="90" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_3"
-frame duration="0" x="87" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000033"
+frame duration="0" x="87" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_4"
-frame duration="0" x="69" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000034"
+frame duration="0" x="69" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_5"
-frame duration="0" x="65" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000035"
+frame duration="0" x="65" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_6"
-frame duration="0" x="61" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000036"
+frame duration="0" x="61" y="102" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_7"
-frame duration="0" x="251" y="101" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000037"
+frame duration="0" x="251" y="101" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_8"
-frame duration="0" x="251" y="94" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000038"
+frame duration="0" x="251" y="94" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_9"
-frame duration="0" x="151" y="98" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000039"
+frame duration="0" x="151" y="98" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_("
-frame duration="0.05" x="218" y="102" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000028"
+frame duration="0.05" x="218" y="102" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_)"
-frame duration="0" x="42" y="98" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000029"
+frame duration="0" x="42" y="98" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL__"
-frame duration="0" x="251" y="72" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00005F"
+frame duration="0" x="251" y="72" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_-"
-frame duration="0" x="30" y="73" w="3" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002D"
+frame duration="0" x="30" y="73" w="3" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_+"
-frame duration="0" x="42" y="83" w="3" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002B"
+frame duration="0" x="42" y="83" w="3" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_="
-frame duration="0" x="156" y="54" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003D"
+frame duration="0" x="156" y="54" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_\"
-frame duration="0" x="40" y="62" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00005C"
+frame duration="0" x="40" y="62" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_/"
-frame duration="0" x="75" y="82" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002F"
+frame duration="0" x="75" y="82" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_<"
-frame duration="0" x="236" y="117" w="3" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003C"
+frame duration="0" x="236" y="117" w="3" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_>"
-frame duration="0" x="113" y="113" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003E"
+frame duration="0" x="113" y="113" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_?"
-frame duration="0" x="236" y="93" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003F"
+frame duration="0" x="236" y="93" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_,"
-frame duration="0" x="156" y="62" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002C"
+frame duration="0" x="156" y="62" w="4" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_."
-frame duration="0" x="199" y="72" w="3" h="9" originx="0" originy="1" flipx="0" flipy="0" 
+animation state="SMALL_U00002E"
+frame duration="0" x="199" y="72" w="3" h="9" originx="0" originy="1" flipx="0" flipy="0"
 
-animation state="SMALL_!"
-frame duration="0" x="42" y="91" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000021"
+frame duration="0" x="42" y="91" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_@"
-frame duration="0" x="117" y="93" w="7" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000040"
+frame duration="0" x="117" y="93" w="7" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_#"
-frame duration="0" x="131" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000023"
+frame duration="0" x="131" y="93" w="5" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_$"
-frame duration="0" x="251" y="80" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000024"
+frame duration="0" x="251" y="80" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_%"
-frame duration="0" x="28" y="62" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000025"
+frame duration="0" x="28" y="62" w="5" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_^"
-frame duration="0" x="211" y="83" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00005E"
+frame duration="0" x="211" y="83" w="3" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_&"
-frame duration="0" x="251" y="87" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000026"
+frame duration="0" x="251" y="87" w="4" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_*"
-frame duration="0" x="50" y="102" w="5" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00002A"
+frame duration="0" x="50" y="102" w="5" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_'"
-frame duration="0" x="179" y="89" w="2" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000027"
+frame duration="0" x="179" y="89" w="2" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_QUOTE"
-frame duration="0" x="45" y="102" w="5" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U000022"
+frame duration="0" x="45" y="102" w="5" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_:"
-frame duration="0" x="91" y="32" w="2" h="8" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003A"
+frame duration="0" x="91" y="32" w="2" h="8" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="SMALL_;"
-frame duration="0" x="179" y="82" w="2" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="SMALL_U00003B"
+frame duration="0" x="179" y="82" w="2" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_A"
-frame duration="0.05" x="36" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
-frame duration="0.05" x="255" y="0" w="0" h="0" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000041"
+frame duration="0.05" x="36" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
+frame duration="0.05" x="255" y="0" w="0" h="0" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_B"
-frame duration="0.05" x="93" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000042"
+frame duration="0.05" x="93" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_C"
-frame duration="0.05" x="99" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000043"
+frame duration="0.05" x="99" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_D"
-frame duration="0.05" x="105" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000044"
+frame duration="0.05" x="105" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_E"
-frame duration="0.05" x="111" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000045"
+frame duration="0.05" x="111" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_F"
-frame duration="0.05" x="141" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000046"
+frame duration="0.05" x="141" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_G"
-frame duration="0.05" x="147" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000047"
+frame duration="0.05" x="147" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_H"
-frame duration="0.05" x="153" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000048"
+frame duration="0.05" x="153" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_I"
-frame duration="0.05" x="181" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000049"
+frame duration="0.05" x="181" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_J"
-frame duration="0.05" x="187" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004A"
+frame duration="0.05" x="187" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_K"
-frame duration="0.05" x="193" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004B"
+frame duration="0.05" x="193" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_L"
-frame duration="0.05" x="199" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004C"
+frame duration="0.05" x="199" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_M"
-frame duration="0.05" x="205" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004D"
+frame duration="0.05" x="205" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_N"
-frame duration="0.05" x="221" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004E"
+frame duration="0.05" x="221" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_O"
-frame duration="0.05" x="227" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00004F"
+frame duration="0.05" x="227" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_P"
-frame duration="0.05" x="233" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000050"
+frame duration="0.05" x="233" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_Q"
-frame duration="0.05" x="80" y="91" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000051"
+frame duration="0.05" x="80" y="91" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_R"
-frame duration="0.05" x="160" y="91" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000052"
+frame duration="0.05" x="160" y="91" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_S"
-frame duration="0.05" x="135" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000053"
+frame duration="0.05" x="135" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_T"
-frame duration="0.05" x="45" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000054"
+frame duration="0.05" x="45" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_U"
-frame duration="0.05" x="51" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000055"
+frame duration="0.05" x="51" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_V"
-frame duration="0.05" x="57" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000056"
+frame duration="0.05" x="57" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_W"
-frame duration="0.05" x="63" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000057"
+frame duration="0.05" x="63" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_X"
-frame duration="0.05" x="69" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000058"
+frame duration="0.05" x="69" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_Y"
-frame duration="0.05" x="87" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000059"
+frame duration="0.05" x="87" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_Z"
-frame duration="0.05" x="167" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00005A"
+frame duration="0.05" x="167" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_A"
-frame duration="0.05" x="173" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000061"
+frame duration="0.05" x="173" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_B"
-frame duration="0.05" x="214" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000062"
+frame duration="0.05" x="214" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_C"
-frame duration="0.05" x="239" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000063"
+frame duration="0.05" x="239" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_D"
-frame duration="0.05" x="245" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000064"
+frame duration="0.05" x="245" y="92" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_E"
-frame duration="0.05" x="0" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000065"
+frame duration="0.05" x="0" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_F"
-frame duration="0.05" x="6" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000066"
+frame duration="0.05" x="6" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_G"
-frame duration="0.05" x="187" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000067"
+frame duration="0.05" x="187" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_H"
-frame duration="0.05" x="12" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000068"
+frame duration="0.05" x="12" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_I"
-frame duration="0.05" x="18" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000069"
+frame duration="0.05" x="18" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_K"
-frame duration="0.05" x="24" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006B"
+frame duration="0.05" x="24" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_J"
-frame duration="0.05" x="193" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006A"
+frame duration="0.05" x="193" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_L"
-frame duration="0.05" x="30" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006C"
+frame duration="0.05" x="30" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_M"
-frame duration="0.05" x="36" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006D"
+frame duration="0.05" x="36" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_N"
-frame duration="0.05" x="93" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006E"
+frame duration="0.05" x="93" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_O"
-frame duration="0.05" x="202" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00006F"
+frame duration="0.05" x="202" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_P"
-frame duration="0.05" x="221" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000070"
+frame duration="0.05" x="221" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_Q"
-frame duration="0.05" x="208" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000071"
+frame duration="0.05" x="208" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_R"
-frame duration="0.05" x="99" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000072"
+frame duration="0.05" x="99" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_S"
-frame duration="0.05" x="105" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000073"
+frame duration="0.05" x="105" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_T"
-frame duration="0.05" x="111" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000074"
+frame duration="0.05" x="111" y="93" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_U"
-frame duration="0.05" x="239" y="72" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000075"
+frame duration="0.05" x="239" y="72" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_V"
-frame duration="0.05" x="245" y="72" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000076"
+frame duration="0.05" x="245" y="72" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_W"
-frame duration="0.05" x="0" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000077"
+frame duration="0.05" x="0" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_X"
-frame duration="0.05" x="6" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000078"
+frame duration="0.05" x="6" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_Y"
-frame duration="0.05" x="12" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000079"
+frame duration="0.05" x="12" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_LOWER_Z"
-frame duration="0.05" x="18" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00007A"
+frame duration="0.05" x="18" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_0"
-frame duration="0.05" x="24" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000030"
+frame duration="0.05" x="24" y="73" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_1"
-frame duration="0.05" x="129" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000031"
+frame duration="0.05" x="129" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_2"
-frame duration="0.05" x="80" y="81" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000032"
+frame duration="0.05" x="80" y="81" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_3"
-frame duration="0.05" x="160" y="81" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000033"
+frame duration="0.05" x="160" y="81" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_4"
-frame duration="0.05" x="45" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000034"
+frame duration="0.05" x="45" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_5"
-frame duration="0.05" x="51" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000035"
+frame duration="0.05" x="51" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_6"
-frame duration="0.05" x="57" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000036"
+frame duration="0.05" x="57" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_7"
-frame duration="0.05" x="63" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000037"
+frame duration="0.05" x="63" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_8"
-frame duration="0.05" x="69" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000038"
+frame duration="0.05" x="69" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_9"
-frame duration="0.05" x="87" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
-frame duration="0.05" x="255" y="0" w="0" h="0" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000039"
+frame duration="0.05" x="87" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
+frame duration="0.05" x="255" y="0" w="0" h="0" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_("
-frame duration="0.05" x="87" y="71" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000028"
+frame duration="0.05" x="87" y="71" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_)"
-frame duration="0.05" x="233" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000029"
+frame duration="0.05" x="233" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK__"
-frame duration="0.05" x="33" y="71" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00005F"
+frame duration="0.05" x="33" y="71" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_-"
-frame duration="0.05" x="167" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002D"
+frame duration="0.05" x="167" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_+"
-frame duration="0.05" x="173" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002B"
+frame duration="0.05" x="173" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_="
-frame duration="0.05" x="214" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003D"
+frame duration="0.05" x="214" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_\"
-frame duration="0.05" x="239" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00005C"
+frame duration="0.05" x="239" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_/"
-frame duration="0.05" x="245" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002F"
+frame duration="0.05" x="245" y="82" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_<"
-frame duration="0.05" x="0" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003C"
+frame duration="0.05" x="0" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_>"
-frame duration="0.05" x="6" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003E"
+frame duration="0.05" x="6" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_?"
-frame duration="0.05" x="12" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003F"
+frame duration="0.05" x="12" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_,"
-frame duration="0.05" x="39" y="71" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002C"
+frame duration="0.05" x="39" y="71" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_."
-frame duration="0.05" x="18" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002E"
+frame duration="0.05" x="18" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_!"
-frame duration="0.05" x="24" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000021"
+frame duration="0.05" x="24" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_@"
-frame duration="0.05" x="30" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000040"
+frame duration="0.05" x="30" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_#"
-frame duration="0.05" x="214" y="72" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000023"
+frame duration="0.05" x="214" y="72" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_$"
-frame duration="0.05" x="33" y="47" w="7" h="13" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000024"
+frame duration="0.05" x="33" y="47" w="7" h="13" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_%"
-frame duration="0.05" x="174" y="72" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000025"
+frame duration="0.05" x="174" y="72" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_^"
-frame duration="0.05" x="202" y="61" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00005E"
+frame duration="0.05" x="202" y="61" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_&"
-frame duration="0.05" x="167" y="72" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000026"
+frame duration="0.05" x="167" y="72" w="7" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_*"
-frame duration="0.05" x="195" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00002A"
+frame duration="0.05" x="195" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_'"
-frame duration="0.05" x="87" y="59" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000027"
+frame duration="0.05" x="87" y="59" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_QUOTE"
-frame duration="0.05" x="87" y="47" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U000022"
+frame duration="0.05" x="87" y="47" w="6" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_:"
-frame duration="0.05" x="117" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003A"
+frame duration="0.05" x="117" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_;"
-frame duration="0.05" x="123" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00003B"
+frame duration="0.05" x="123" y="83" w="6" h="10" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_A"
-frame duration="0.05" x="134" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000041"
+frame duration="0.05" x="134" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_B"
-frame duration="0.05" x="129" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000042"
+frame duration="0.05" x="129" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_C"
-frame duration="0.05" x="124" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000043"
+frame duration="0.05" x="124" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_D"
-frame duration="0.05" x="55" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000044"
+frame duration="0.05" x="55" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_E"
-frame duration="0.05" x="186" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000045"
+frame duration="0.05" x="186" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_F"
-frame duration="0.05" x="181" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000046"
+frame duration="0.05" x="181" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_G"
-frame duration="0.05" x="160" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000047"
+frame duration="0.05" x="160" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_H"
-frame duration="0.05" x="117" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000048"
+frame duration="0.05" x="117" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_I"
-frame duration="0.05" x="80" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000049"
+frame duration="0.05" x="80" y="111" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_J"
-frame duration="0.05" x="231" y="110" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004A"
+frame duration="0.05" x="231" y="110" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_K"
-frame duration="0.05" x="226" y="110" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004B"
+frame duration="0.05" x="226" y="110" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_L"
-frame duration="0.05" x="136" y="107" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004C"
+frame duration="0.05" x="136" y="107" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_M"
-frame duration="0.05" x="75" y="104" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004D"
+frame duration="0.05" x="75" y="104" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_N"
-frame duration="0.05" x="226" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004E"
+frame duration="0.05" x="226" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_O"
-frame duration="0.05" x="151" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00004F"
+frame duration="0.05" x="151" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_P"
-frame duration="0.05" x="146" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000050"
+frame duration="0.05" x="146" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_Q"
-frame duration="0.05" x="98" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000051"
+frame duration="0.05" x="98" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_R"
-frame duration="0.05" x="141" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000052"
+frame duration="0.05" x="141" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_S"
-frame duration="0.05" x="249" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000053"
+frame duration="0.05" x="249" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_T"
-frame duration="0.05" x="244" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000054"
+frame duration="0.05" x="244" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_U"
-frame duration="0.05" x="239" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000055"
+frame duration="0.05" x="239" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_V"
-frame duration="0.05" x="219" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000056"
+frame duration="0.05" x="219" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_W"
-frame duration="0.05" x="214" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000057"
+frame duration="0.05" x="214" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_X"
-frame duration="0.05" x="172" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000058"
+frame duration="0.05" x="172" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_Y"
-frame duration="0.05" x="167" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000059"
+frame duration="0.05" x="167" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_Z"
-frame duration="0.05" x="87" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00005A"
+frame duration="0.05" x="87" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_A"
-frame duration="0.05" x="71" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000061"
+frame duration="0.05" x="71" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_B"
-frame duration="0.05" x="66" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000062"
+frame duration="0.05" x="66" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_C"
-frame duration="0.05" x="61" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000063"
+frame duration="0.05" x="61" y="119" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_D"
-frame duration="0.05" x="103" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000064"
+frame duration="0.05" x="103" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_E"
-frame duration="0.05" x="98" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000065"
+frame duration="0.05" x="98" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_F"
-frame duration="0.05" x="93" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000066"
+frame duration="0.05" x="93" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_G"
-frame duration="0.05" x="47" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000067"
+frame duration="0.05" x="47" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_H"
-frame duration="0.05" x="42" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000068"
+frame duration="0.05" x="42" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_I"
-frame duration="0.05" x="37" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000069"
+frame duration="0.05" x="37" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_J"
-frame duration="0.05" x="32" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006A"
+frame duration="0.05" x="32" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_K"
-frame duration="0.05" x="27" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006B"
+frame duration="0.05" x="27" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_L"
-frame duration="0.05" x="22" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006C"
+frame duration="0.05" x="22" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_M"
-frame duration="0.05" x="17" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006D"
+frame duration="0.05" x="17" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_N"
-frame duration="0.05" x="12" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006E"
+frame duration="0.05" x="12" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_O"
-frame duration="0.05" x="208" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00006F"
+frame duration="0.05" x="208" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_P"
-frame duration="0.05" x="203" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000070"
+frame duration="0.05" x="203" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_Q"
-frame duration="0.05" x="198" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000071"
+frame duration="0.05" x="198" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_R"
-frame duration="0.05" x="193" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000072"
+frame duration="0.05" x="193" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_S"
-frame duration="0.05" x="134" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000073"
+frame duration="0.05" x="134" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_T"
-frame duration="0.05" x="129" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000074"
+frame duration="0.05" x="129" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_U"
-frame duration="0.05" x="124" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000075"
+frame duration="0.05" x="124" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_V"
-frame duration="0.05" x="55" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000076"
+frame duration="0.05" x="55" y="117" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_W"
-frame duration="0.05" x="186" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000077"
+frame duration="0.05" x="186" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_X"
-frame duration="0.05" x="160" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000078"
+frame duration="0.05" x="160" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_Y"
-frame duration="0.05" x="117" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000079"
+frame duration="0.05" x="117" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_LOWER_Z"
-frame duration="0.05" x="80" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00007A"
+frame duration="0.05" x="80" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_0"
-frame duration="0.05" x="231" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000030"
+frame duration="0.05" x="231" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_1"
-frame duration="0.05" x="226" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000031"
+frame duration="0.05" x="226" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_2"
-frame duration="0.05" x="151" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000032"
+frame duration="0.05" x="151" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_3"
-frame duration="0.05" x="146" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000033"
+frame duration="0.05" x="146" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_4"
-frame duration="0.05" x="141" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000034"
+frame duration="0.05" x="141" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_5"
-frame duration="0.05" x="5" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000035"
+frame duration="0.05" x="5" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_6"
-frame duration="0.05" x="0" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000036"
+frame duration="0.05" x="0" y="115" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_7"
-frame duration="0.05" x="193" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000037"
+frame duration="0.05" x="193" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_8"
-frame duration="0.05" x="249" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000038"
+frame duration="0.05" x="249" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_9"
-frame duration="0.05" x="244" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000039"
+frame duration="0.05" x="244" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_("
-frame duration="0.05" x="239" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000028"
+frame duration="0.05" x="239" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_)"
-frame duration="0.05" x="219" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000029"
+frame duration="0.05" x="219" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY__"
-frame duration="0.05" x="214" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00005F"
+frame duration="0.05" x="214" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_-"
-frame duration="0.05" x="71" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002D"
+frame duration="0.05" x="71" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_+"
-frame duration="0.05" x="66" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002B"
+frame duration="0.05" x="66" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_="
-frame duration="0.05" x="61" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003D"
+frame duration="0.05" x="61" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_\"
-frame duration="0.05" x="108" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00005C"
+frame duration="0.05" x="108" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_/"
-frame duration="0.05" x="103" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002F"
+frame duration="0.05" x="103" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_<"
-frame duration="0.05" x="93" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003C"
+frame duration="0.05" x="93" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_>"
-frame duration="0.05" x="47" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003E"
+frame duration="0.05" x="47" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_?"
-frame duration="0.05" x="42" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003F"
+frame duration="0.05" x="42" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_,"
-frame duration="0.05" x="32" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002C"
+frame duration="0.05" x="32" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_."
-frame duration="0.05" x="22" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002E"
+frame duration="0.05" x="22" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_!"
-frame duration="0.05" x="17" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000021"
+frame duration="0.05" x="17" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_@"
-frame duration="0.05" x="12" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000040"
+frame duration="0.05" x="12" y="113" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_#"
-frame duration="0.05" x="208" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000023"
+frame duration="0.05" x="208" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_$"
-frame duration="0.05" x="203" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000024"
+frame duration="0.05" x="203" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_%"
-frame duration="0.05" x="0" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000025"
+frame duration="0.05" x="0" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_^"
-frame duration="0.05" x="198" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00005E"
+frame duration="0.05" x="198" y="112" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_&"
-frame duration="0.05" x="172" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000026"
+frame duration="0.05" x="172" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_*"
-frame duration="0.05" x="181" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00002A"
+frame duration="0.05" x="181" y="116" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_'"
-frame duration="0.05" x="108" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000027"
+frame duration="0.05" x="108" y="118" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_QUOTE"
-frame duration="0.05" x="5" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U000022"
+frame duration="0.05" x="5" y="120" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_:"
-frame duration="0.05" x="87" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003A"
+frame duration="0.05" x="87" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="TINY_;"
-frame duration="0.05" x="167" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="TINY_U00003B"
+frame duration="0.05" x="167" y="114" w="5" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_A"
-frame duration="0.05" x="141" y="93" w="7" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000041"
+frame duration="0.05" x="141" y="93" w="7" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_B"
-frame duration="0.05" x="12" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000042"
+frame duration="0.05" x="12" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_C"
-frame duration="0.05" x="18" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000043"
+frame duration="0.05" x="18" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_D"
-frame duration="0.05" x="24" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000044"
+frame duration="0.05" x="24" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_E"
-frame duration="0.05" x="30" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000045"
+frame duration="0.05" x="30" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_F"
-frame duration="0.05" x="36" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000046"
+frame duration="0.05" x="36" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_G"
-frame duration="0.05" x="93" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000047"
+frame duration="0.05" x="93" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_H"
-frame duration="0.05" x="99" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000048"
+frame duration="0.05" x="99" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_I"
-frame duration="0.05" x="105" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000049"
+frame duration="0.05" x="105" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_J"
-frame duration="0.05" x="111" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004A"
+frame duration="0.05" x="111" y="103" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_K"
-frame duration="0.05" x="141" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004B"
+frame duration="0.05" x="141" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_L"
-frame duration="0.05" x="147" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004C"
+frame duration="0.05" x="147" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_M"
-frame duration="0.05" x="226" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004D"
+frame duration="0.05" x="226" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_N"
-frame duration="0.05" x="232" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004E"
+frame duration="0.05" x="232" y="105" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_O"
-frame duration="0.05" x="80" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00004F"
+frame duration="0.05" x="80" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_P"
-frame duration="0.05" x="117" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000050"
+frame duration="0.05" x="117" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_Q"
-frame duration="0.05" x="148" y="93" w="7" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000051"
+frame duration="0.05" x="148" y="93" w="7" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_R"
-frame duration="0.05" x="160" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000052"
+frame duration="0.05" x="160" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_S"
-frame duration="0.05" x="181" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000053"
+frame duration="0.05" x="181" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_T"
-frame duration="0.05" x="187" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000054"
+frame duration="0.05" x="187" y="106" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_U"
-frame duration="0.05" x="55" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000055"
+frame duration="0.05" x="55" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_V"
-frame duration="0.05" x="124" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000056"
+frame duration="0.05" x="124" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_W"
-frame duration="0.05" x="130" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000057"
+frame duration="0.05" x="130" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_X"
-frame duration="0.05" x="193" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000058"
+frame duration="0.05" x="193" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_Y"
-frame duration="0.05" x="199" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000059"
+frame duration="0.05" x="199" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_Z"
-frame duration="0.05" x="205" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00005A"
+frame duration="0.05" x="205" y="107" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_0"
-frame duration="0.05" x="12" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000030"
+frame duration="0.05" x="12" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_1"
-frame duration="0.05" x="18" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000031"
+frame duration="0.05" x="18" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_2"
-frame duration="0.05" x="24" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000032"
+frame duration="0.05" x="24" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_3"
-frame duration="0.05" x="30" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000033"
+frame duration="0.05" x="30" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_4"
-frame duration="0.05" x="36" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000034"
+frame duration="0.05" x="36" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_5"
-frame duration="0.05" x="232" y="100" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000035"
+frame duration="0.05" x="232" y="100" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_6"
-frame duration="0.05" x="42" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000036"
+frame duration="0.05" x="42" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_7"
-frame duration="0.05" x="48" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000037"
+frame duration="0.05" x="48" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_8"
-frame duration="0.05" x="93" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000038"
+frame duration="0.05" x="93" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_9"
-frame duration="0.05" x="99" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000039"
+frame duration="0.05" x="99" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_("
-frame duration="0.05" x="105" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000028"
+frame duration="0.05" x="105" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_)"
-frame duration="0.05" x="111" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000029"
+frame duration="0.05" x="111" y="108" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE__"
-frame duration="0.05" x="181" y="93" w="6" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00005F"
+frame duration="0.05" x="181" y="93" w="6" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_-"
-frame duration="0.05" x="61" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002D"
+frame duration="0.05" x="61" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_+"
-frame duration="0.05" x="67" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002B"
+frame duration="0.05" x="67" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_="
-frame duration="0.05" x="73" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003D"
+frame duration="0.05" x="73" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_\"
-frame duration="0.05" x="87" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00005C"
+frame duration="0.05" x="87" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_/"
-frame duration="0.05" x="167" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002F"
+frame duration="0.05" x="167" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_<"
-frame duration="0.05" x="173" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003C"
+frame duration="0.05" x="173" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_>"
-frame duration="0.05" x="214" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003E"
+frame duration="0.05" x="214" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_?"
-frame duration="0.05" x="220" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003F"
+frame duration="0.05" x="220" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_,"
-frame duration="0.05" x="239" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002C"
+frame duration="0.05" x="239" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_."
-frame duration="0.05" x="245" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002E"
+frame duration="0.05" x="245" y="109" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_!"
-frame duration="0.05" x="0" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000021"
+frame duration="0.05" x="0" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_@"
-frame duration="0.05" x="124" y="93" w="7" h="7" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000040"
+frame duration="0.05" x="124" y="93" w="7" h="7" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_#"
-frame duration="0.05" x="187" y="93" w="6" h="6" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000023"
+frame duration="0.05" x="187" y="93" w="6" h="6" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_$"
-frame duration="0.05" x="6" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000024"
+frame duration="0.05" x="6" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_%"
-frame duration="0.05" x="141" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000025"
+frame duration="0.05" x="141" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_^"
-frame duration="0.05" x="147" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00005E"
+frame duration="0.05" x="147" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_&"
-frame duration="0.05" x="153" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000026"
+frame duration="0.05" x="153" y="110" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_*"
-frame duration="0.05" x="226" y="100" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00002A"
+frame duration="0.05" x="226" y="100" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_'"
-frame duration="0.05" x="55" y="102" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000027"
+frame duration="0.05" x="55" y="102" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_QUOTE"
-frame duration="0.05" x="80" y="101" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U000022"
+frame duration="0.05" x="80" y="101" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_:"
-frame duration="0.05" x="117" y="101" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003A"
+frame duration="0.05" x="117" y="101" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="WIDE_;"
-frame duration="0.05" x="160" y="101" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="WIDE_U00003B"
+frame duration="0.05" x="160" y="101" w="6" h="5" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_A"
-frame duration="0.05" x="93" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000041"
+frame duration="0.05" x="93" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_B"
-frame duration="0.05" x="160" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000042"
+frame duration="0.05" x="160" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_C"
-frame duration="0.05" x="84" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000043"
+frame duration="0.05" x="84" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_D"
-frame duration="0.05" x="77" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000044"
+frame duration="0.05" x="77" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_E"
-frame duration="0.05" x="63" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000045"
+frame duration="0.05" x="63" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_F"
-frame duration="0.05" x="114" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000046"
+frame duration="0.05" x="114" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_G"
-frame duration="0.05" x="244" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000047"
+frame duration="0.05" x="244" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_H"
-frame duration="0.05" x="237" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000048"
+frame duration="0.05" x="237" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_I"
-frame duration="0.05" x="188" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000049"
+frame duration="0.05" x="188" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_J"
-frame duration="0.05" x="93" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004A"
+frame duration="0.05" x="93" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_K"
-frame duration="0.05" x="107" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004B"
+frame duration="0.05" x="107" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_L"
-frame duration="0.05" x="100" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004C"
+frame duration="0.05" x="100" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_M"
-frame duration="0.05" x="93" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004D"
+frame duration="0.05" x="93" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_N"
-frame duration="0.05" x="160" y="17" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004E"
+frame duration="0.05" x="160" y="17" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_O"
-frame duration="0.05" x="244" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00004F"
+frame duration="0.05" x="244" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_P"
-frame duration="0.05" x="237" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000050"
+frame duration="0.05" x="237" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_Q"
-frame duration="0.05" x="230" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000051"
+frame duration="0.05" x="230" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_R"
-frame duration="0.05" x="223" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000052"
+frame duration="0.05" x="223" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_S"
-frame duration="0.05" x="216" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000053"
+frame duration="0.05" x="216" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_T"
-frame duration="0.05" x="209" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000054"
+frame duration="0.05" x="209" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_U"
-frame duration="0.05" x="202" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000055"
+frame duration="0.05" x="202" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_V"
-frame duration="0.05" x="188" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000056"
+frame duration="0.05" x="188" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_W"
-frame duration="0.05" x="181" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000057"
+frame duration="0.05" x="181" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_X"
-frame duration="0.05" x="167" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000058"
+frame duration="0.05" x="167" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_Y"
-frame duration="0.05" x="142" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000059"
+frame duration="0.05" x="142" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_Z"
-frame duration="0.05" x="135" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005A"
+frame duration="0.05" x="135" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_:"
-frame duration="0.05" x="18" y="47" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003A"
+frame duration="0.05" x="18" y="47" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_&"
-frame duration="0.05" x="121" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000026"
+frame duration="0.05" x="121" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_'"
-frame duration="0.05" x="0" y="47" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000027"
+frame duration="0.05" x="0" y="47" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_="
-frame duration="0.05" x="100" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003D"
+frame duration="0.05" x="100" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_0"
-frame duration="0.05" x="149" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000030"
+frame duration="0.05" x="149" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_1"
-frame duration="0.05" x="142" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000031"
+frame duration="0.05" x="142" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_2"
-frame duration="0.05" x="135" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000032"
+frame duration="0.05" x="135" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_3"
-frame duration="0.05" x="128" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000033"
+frame duration="0.05" x="128" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_4"
-frame duration="0.05" x="121" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000034"
+frame duration="0.05" x="121" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_5"
-frame duration="0.05" x="195" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000035"
+frame duration="0.05" x="195" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_6"
-frame duration="0.05" x="174" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000036"
+frame duration="0.05" x="174" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_7"
-frame duration="0.05" x="128" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000037"
+frame duration="0.05" x="128" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_8"
-frame duration="0.05" x="114" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000038"
+frame duration="0.05" x="114" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_9"
-frame duration="0.05" x="244" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000039"
+frame duration="0.05" x="244" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_A"
-frame duration="0.05" x="237" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000061"
+frame duration="0.05" x="237" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_B"
-frame duration="0.05" x="230" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000062"
+frame duration="0.05" x="230" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_C"
-frame duration="0.05" x="195" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000063"
+frame duration="0.05" x="195" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_D"
-frame duration="0.05" x="223" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000064"
+frame duration="0.05" x="223" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_E"
-frame duration="0.05" x="216" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000065"
+frame duration="0.05" x="216" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_F"
-frame duration="0.05" x="12" y="47" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000066"
+frame duration="0.05" x="12" y="47" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_G"
-frame duration="0.05" x="160" y="0" w="7" h="17" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000067"
+frame duration="0.05" x="160" y="0" w="7" h="17" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_H"
-frame duration="0.05" x="209" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000068"
+frame duration="0.05" x="209" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_I"
-frame duration="0.05" x="156" y="31" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000069"
+frame duration="0.05" x="156" y="31" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_J"
-frame duration="0.05" x="100" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006A"
+frame duration="0.05" x="100" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_K"
-frame duration="0.05" x="202" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006B"
+frame duration="0.05" x="202" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_L"
-frame duration="0.05" x="156" y="16" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006C"
+frame duration="0.05" x="156" y="16" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_M"
-frame duration="0.05" x="195" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006D"
+frame duration="0.05" x="195" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_N"
-frame duration="0.05" x="188" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006E"
+frame duration="0.05" x="188" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_O"
-frame duration="0.05" x="181" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00006F"
+frame duration="0.05" x="181" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_P"
-frame duration="0.05" x="79" y="16" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000070"
+frame duration="0.05" x="79" y="16" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_Q"
-frame duration="0.05" x="72" y="16" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000071"
+frame duration="0.05" x="72" y="16" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_R"
-frame duration="0.05" x="6" y="47" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000072"
+frame duration="0.05" x="6" y="47" w="6" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_S"
-frame duration="0.05" x="174" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000073"
+frame duration="0.05" x="174" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_T"
-frame duration="0.05" x="70" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000074"
+frame duration="0.05" x="70" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_U"
-frame duration="0.05" x="167" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000075"
+frame duration="0.05" x="167" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_V"
-frame duration="0.05" x="149" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000076"
+frame duration="0.05" x="149" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_W"
-frame duration="0.05" x="142" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000077"
+frame duration="0.05" x="142" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_X"
-frame duration="0.05" x="135" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000078"
+frame duration="0.05" x="135" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_Y"
-frame duration="0.05" x="86" y="16" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000079"
+frame duration="0.05" x="86" y="16" w="7" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_LOWER_Z"
-frame duration="0.05" x="128" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00007A"
+frame duration="0.05" x="128" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_-"
-frame duration="0.05" x="121" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002D"
+frame duration="0.05" x="121" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_!"
-frame duration="0.05" x="251" y="16" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000021"
+frame duration="0.05" x="251" y="16" w="4" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_/"
-frame duration="0.05" x="114" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002F"
+frame duration="0.05" x="114" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_."
-frame duration="0.05" x="28" y="47" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002E"
+frame duration="0.05" x="28" y="47" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_?"
-frame duration="0.05" x="107" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003F"
+frame duration="0.05" x="107" y="46" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_,"
-frame duration="0.05" x="40" y="47" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002C"
+frame duration="0.05" x="40" y="47" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_0"
-frame duration="0.05" x="66" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000030"
+frame duration="0.05" x="66" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_1"
-frame duration="0.05" x="160" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000031"
+frame duration="0.05" x="160" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_2"
-frame duration="0.05" x="73" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000032"
+frame duration="0.05" x="73" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_3"
-frame duration="0.05" x="59" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000033"
+frame duration="0.05" x="59" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_4"
-frame duration="0.05" x="80" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000034"
+frame duration="0.05" x="80" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_5"
-frame duration="0.05" x="45" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000035"
+frame duration="0.05" x="45" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_6"
-frame duration="0.05" x="45" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000036"
+frame duration="0.05" x="45" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_7"
-frame duration="0.05" x="59" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000037"
+frame duration="0.05" x="59" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_8"
-frame duration="0.05" x="52" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000038"
+frame duration="0.05" x="52" y="47" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_9"
-frame duration="0.05" x="52" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000039"
+frame duration="0.05" x="52" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_S"
-frame duration="0.05" x="66" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U000053"
+frame duration="0.05" x="66" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_TALL_:"
-frame duration="0.05" x="73" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_TALL_U00003A"
+frame duration="0.05" x="73" y="59" w="7" h="12" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_0"
-frame duration="0.05" x="222" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000030"
+frame duration="0.05" x="222" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_1"
-frame duration="0.05" x="229" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000031"
+frame duration="0.05" x="229" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_2"
-frame duration="0.05" x="243" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000032"
+frame duration="0.05" x="243" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_3"
-frame duration="0.05" x="0" y="62" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000033"
+frame duration="0.05" x="0" y="62" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_4"
-frame duration="0.05" x="7" y="62" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000034"
+frame duration="0.05" x="7" y="62" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_5"
-frame duration="0.05" x="21" y="62" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000035"
+frame duration="0.05" x="21" y="62" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_6"
-frame duration="0.05" x="80" y="70" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000036"
+frame duration="0.05" x="80" y="70" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_7"
-frame duration="0.05" x="160" y="70" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000037"
+frame duration="0.05" x="160" y="70" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_8"
-frame duration="0.05" x="181" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000038"
+frame duration="0.05" x="181" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_9"
-frame duration="0.05" x="45" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_U000039"
+frame duration="0.05" x="45" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_0"
-frame duration="0.05" x="52" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000030"
+frame duration="0.05" x="52" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_1"
-frame duration="0.05" x="59" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000031"
+frame duration="0.05" x="59" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_2"
-frame duration="0.05" x="14" y="62" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000032"
+frame duration="0.05" x="14" y="62" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_3"
-frame duration="0.05" x="73" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000033"
+frame duration="0.05" x="73" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_4"
-frame duration="0.05" x="93" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000034"
+frame duration="0.05" x="93" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_5"
-frame duration="0.05" x="100" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000035"
+frame duration="0.05" x="100" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_6"
-frame duration="0.05" x="107" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000036"
+frame duration="0.05" x="107" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_7"
-frame duration="0.05" x="114" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000037"
+frame duration="0.05" x="114" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_8"
-frame duration="0.05" x="121" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000038"
+frame duration="0.05" x="121" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GOLD_9"
-frame duration="0.05" x="128" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GOLD_U000039"
+frame duration="0.05" x="128" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_0"
-frame duration="0.05" x="135" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000030"
+frame duration="0.05" x="135" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_1"
-frame duration="0.05" x="142" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000031"
+frame duration="0.05" x="142" y="72" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_2"
-frame duration="0.05" x="188" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000032"
+frame duration="0.05" x="188" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_3"
-frame duration="0.05" x="174" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000033"
+frame duration="0.05" x="174" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_4"
-frame duration="0.05" x="167" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000034"
+frame duration="0.05" x="167" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_5"
-frame duration="0.05" x="149" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000035"
+frame duration="0.05" x="149" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_6"
-frame duration="0.05" x="33" y="60" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000036"
+frame duration="0.05" x="33" y="60" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_7"
-frame duration="0.05" x="142" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000037"
+frame duration="0.05" x="142" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_8"
-frame duration="0.05" x="135" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000038"
+frame duration="0.05" x="135" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_GREEN_9"
-frame duration="0.05" x="128" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_GREEN_U000039"
+frame duration="0.05" x="128" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_0"
-frame duration="0.05" x="121" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000030"
+frame duration="0.05" x="121" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_1"
-frame duration="0.05" x="114" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000031"
+frame duration="0.05" x="114" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_2"
-frame duration="0.05" x="107" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000032"
+frame duration="0.05" x="107" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_3"
-frame duration="0.05" x="100" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000033"
+frame duration="0.05" x="100" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_4"
-frame duration="0.05" x="93" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000034"
+frame duration="0.05" x="93" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_5"
-frame duration="0.05" x="160" y="59" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000035"
+frame duration="0.05" x="160" y="59" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_6"
-frame duration="0.05" x="80" y="59" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000036"
+frame duration="0.05" x="80" y="59" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_7"
-frame duration="0.05" x="236" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000037"
+frame duration="0.05" x="236" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_8"
-frame duration="0.05" x="215" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000038"
+frame duration="0.05" x="215" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_9"
-frame duration="0.05" x="66" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U000039"
+frame duration="0.05" x="66" y="71" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="GRADIENT_ORANGE_+"
-frame duration="0.05" x="208" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="GRADIENT_ORANGE_U00002B"
+frame duration="0.05" x="208" y="61" w="7" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_SP"
-frame duration="0.05" x="181" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00E000"
+frame duration="0.05" x="181" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_EX"
-frame duration="0.05" x="227" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00E001"
+frame duration="0.05" x="227" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THICK_NM"
-frame duration="0.05" x="149" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THICK_U00E002"
+frame duration="0.05" x="149" y="72" w="6" h="11" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_QUOTE"
-frame duration="0.05" x="149" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000022"
+frame duration="0.05" x="149" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN__"
-frame duration="0.05" x="107" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005F"
+frame duration="0.05" x="107" y="16" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_$"
-frame duration="0.05" x="167" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000024"
+frame duration="0.05" x="167" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_("
-frame duration="0.05" x="174" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000028"
+frame duration="0.05" x="174" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_)"
-frame duration="0.05" x="181" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000029"
+frame duration="0.05" x="181" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_["
-frame duration="0.05" x="202" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005B"
+frame duration="0.05" x="202" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_]"
-frame duration="0.05" x="209" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005D"
+frame duration="0.05" x="209" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_*"
-frame duration="0.05" x="216" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002A"
+frame duration="0.05" x="216" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_~"
-frame duration="0.05" x="56" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00007E"
+frame duration="0.05" x="56" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_`"
-frame duration="0.05" x="223" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000060"
+frame duration="0.05" x="223" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_^"
-frame duration="0.05" x="230" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00005E"
+frame duration="0.05" x="230" y="31" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_+"
-frame duration="0.05" x="0" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00002B"
+frame duration="0.05" x="0" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_#"
-frame duration="0.05" x="7" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000023"
+frame duration="0.05" x="7" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_%"
-frame duration="0.05" x="14" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000025"
+frame duration="0.05" x="14" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_@"
-frame duration="0.05" x="21" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U000040"
+frame duration="0.05" x="21" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_<"
-frame duration="0.05" x="28" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003C"
+frame duration="0.05" x="28" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_>"
-frame duration="0.05" x="35" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003E"
+frame duration="0.05" x="35" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_{"
-frame duration="0.05" x="42" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00007B"
+frame duration="0.05" x="42" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_}"
-frame duration="0.05" x="49" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00007D"
+frame duration="0.05" x="49" y="32" w="7" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="THIN_;"
-frame duration="0.05" x="23" y="47" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="THIN_U00003B"
+frame duration="0.05" x="23" y="47" w="5" h="15" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_A"
-frame duration="0.05" x="48" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000041"
+frame duration="0.05" x="48" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_B"
-frame duration="0.05" x="40" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000042"
+frame duration="0.05" x="40" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_C"
-frame duration="0.05" x="32" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000043"
+frame duration="0.05" x="32" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_D"
-frame duration="0.05" x="24" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000044"
+frame duration="0.05" x="24" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_E"
-frame duration="0.05" x="80" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000045"
+frame duration="0.05" x="80" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_F"
-frame duration="0.05" x="16" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000046"
+frame duration="0.05" x="16" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_G"
-frame duration="0.05" x="8" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000047"
+frame duration="0.05" x="8" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_H"
-frame duration="0.05" x="0" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000048"
+frame duration="0.05" x="0" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_I"
-frame duration="0.05" x="32" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000049"
+frame duration="0.05" x="32" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_J"
-frame duration="0.05" x="64" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004A"
+frame duration="0.05" x="64" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_K"
-frame duration="0.05" x="56" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004B"
+frame duration="0.05" x="56" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_L"
-frame duration="0.05" x="48" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004C"
+frame duration="0.05" x="48" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_M"
-frame duration="0.05" x="40" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004D"
+frame duration="0.05" x="40" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_N"
-frame duration="0.05" x="247" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004E"
+frame duration="0.05" x="247" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_O"
-frame duration="0.05" x="56" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00004F"
+frame duration="0.05" x="56" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_P"
-frame duration="0.05" x="24" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000050"
+frame duration="0.05" x="24" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_Q"
-frame duration="0.05" x="16" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000051"
+frame duration="0.05" x="16" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_R"
-frame duration="0.05" x="8" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000052"
+frame duration="0.05" x="8" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_S"
-frame duration="0.05" x="0" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000053"
+frame duration="0.05" x="0" y="16" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_T"
-frame duration="0.05" x="239" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000054"
+frame duration="0.05" x="239" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_U"
-frame duration="0.05" x="231" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000055"
+frame duration="0.05" x="231" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_V"
-frame duration="0.05" x="215" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000056"
+frame duration="0.05" x="215" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_W"
-frame duration="0.05" x="207" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000057"
+frame duration="0.05" x="207" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_X"
-frame duration="0.05" x="199" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000058"
+frame duration="0.05" x="199" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_Y"
-frame duration="0.05" x="191" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000059"
+frame duration="0.05" x="191" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_Z"
-frame duration="0.05" x="183" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00005A"
+frame duration="0.05" x="183" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE__"
-frame duration="0.05" x="175" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00005F"
+frame duration="0.05" x="175" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_<"
-frame duration="0.05" x="167" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00003C"
+frame duration="0.05" x="167" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_>"
-frame duration="0.05" x="152" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U00003E"
+frame duration="0.05" x="152" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_!"
-frame duration="0.05" x="144" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000021"
+frame duration="0.05" x="144" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_0"
-frame duration="0.05" x="136" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000030"
+frame duration="0.05" x="136" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_1"
-frame duration="0.05" x="128" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000031"
+frame duration="0.05" x="128" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_2"
-frame duration="0.05" x="120" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000032"
+frame duration="0.05" x="120" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_3"
-frame duration="0.05" x="112" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000033"
+frame duration="0.05" x="112" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_4"
-frame duration="0.05" x="104" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000034"
+frame duration="0.05" x="104" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_5"
-frame duration="0.05" x="96" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000035"
+frame duration="0.05" x="96" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_6"
-frame duration="0.05" x="88" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000036"
+frame duration="0.05" x="88" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_7"
-frame duration="0.05" x="72" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000037"
+frame duration="0.05" x="72" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_8"
-frame duration="0.05" x="64" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000038"
+frame duration="0.05" x="64" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"
 
-animation state="BATTLE_9"
-frame duration="0.05" x="223" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0" 
+animation state="BATTLE_U000039"
+frame duration="0.05" x="223" y="0" w="8" h="16" originx="0" originy="0" flipx="0" flipy="0"


### PR DESCRIPTION
Characters in fonts are now named by their 21-bit Unicode codepoint, in the format STYLE_U######. The special character mapping has also been removed, in favor of using the Unicode Private Use Area:

U+E000: SP
U+E001: EX
U+E002: NM

This also revises bnText to use a UTF-8-aware text iterator: that is, the engine expects all text to be rendered to be UTF-8. The engine does not do anything fancy with the text, i.e. there is no normalization performed for compositions, so users must take care that their text should probably be in NFC form.

**Note:** This does not extend the font to support more than ANSI characters, so any attempt to use non-ANSI text will result in `AAAAAAAAAAAAAA` etc. being displayed.