### PR TITLE
Battle + Scripting Fixes, Blacklist packet

### DIFF
--- a/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
+++ b/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
@@ -127,6 +127,7 @@ void FreedomMissionMobScene::Init()
   }
   else {
     playerCanFlip = mob.PlayerCanFlip();
+    LoadBlueTeamMob(mob);
   }
 
   if (mob.HasPlayerSpawnPoint(1)) {

--- a/BattleNetwork/bindings/bnScriptedArtifact.cpp
+++ b/BattleNetwork/bindings/bnScriptedArtifact.cpp
@@ -43,6 +43,32 @@ void ScriptedArtifact::OnSpawn(Battle::Tile& tile)
   }
 }
 
+void ScriptedArtifact::OnBattleStart() {
+  if (battle_start_func.valid()) 
+  {
+    auto result = CallLuaCallback(battle_start_func, weakWrap);
+
+    if (result.is_error()) {
+      Logger::Log(LogLevel::critical, result.error_cstr());
+    }
+  }
+
+  Artifact::OnBattleStart();
+}
+
+void ScriptedArtifact::OnBattleStop() {
+  Artifact::OnBattleStop();
+
+  if (battle_end_func.valid()) 
+  {
+    auto result = CallLuaCallback(battle_end_func, weakWrap);
+
+    if (result.is_error()) {
+      Logger::Log(LogLevel::critical, result.error_cstr());
+    }
+  }
+}
+
 void ScriptedArtifact::OnDelete()
 {
   if (delete_func.valid()) 

--- a/BattleNetwork/bindings/bnScriptedArtifact.h
+++ b/BattleNetwork/bindings/bnScriptedArtifact.h
@@ -7,42 +7,44 @@
 #include "../bnAnimationComponent.h"
 #include "bnWeakWrapper.h"
 
-	/**
-	 * \class ScriptedArtifact
-	 * \brief An object in control of battlefield visual effects, with support for Lua scripting.
-	 * 
-	 */
+  /**
+   * \class ScriptedArtifact
+   * \brief An object in control of battlefield visual effects, with support for Lua scripting.
+   * 
+   */
 class ScriptedArtifact final : public Artifact, public dynamic_object
 {
-	std::shared_ptr<AnimationComponent> animationComponent{ nullptr };
-	sf::Vector2f scriptedOffset{ };
-	WeakWrapper<ScriptedArtifact> weakWrap;
+  std::shared_ptr<AnimationComponent> animationComponent{ nullptr };
+  sf::Vector2f scriptedOffset{ };
+  WeakWrapper<ScriptedArtifact> weakWrap;
 
 public:
-	ScriptedArtifact();
-	~ScriptedArtifact();
+  ScriptedArtifact();
+  ~ScriptedArtifact();
 
-	void Init() override;
+  void Init() override;
 
-	/**
-	 * Centers the animation on the tile, offsets it by its internal offsets, then invokes the function assigned to onUpdate if present.
-	 * @param _elapsed: The amount of elapsed time since the last frame.
-	 */
-	void OnUpdate(double _elapsed) override;
-	void OnDelete() override;
-	bool CanMoveTo(Battle::Tile* next) override;
-	void OnSpawn(Battle::Tile& spawn) override;
+  /**
+   * Centers the animation on the tile, offsets it by its internal offsets, then invokes the function assigned to onUpdate if present.
+   * @param _elapsed: The amount of elapsed time since the last frame.
+   */
+  void OnUpdate(double _elapsed) override;
+  void OnDelete() override;
+  bool CanMoveTo(Battle::Tile* next) override;
+  void OnSpawn(Battle::Tile& spawn) override;
+  void OnBattleStart() override;
+  void OnBattleStop() override;
 
-	void SetAnimation(const std::string& path);
-	Animation& GetAnimationObject();
-	Battle::Tile* GetCurrentTile() const;
+  void SetAnimation(const std::string& path);
+  Animation& GetAnimationObject();
+  Battle::Tile* GetCurrentTile() const;
 
-	sol::object update_func;
-	sol::object on_spawn_func;
-	sol::object delete_func;
-	sol::object can_move_to_func;
-	sol::object battle_start_func;
-	sol::object battle_end_func;
+  sol::object update_func;
+  sol::object on_spawn_func;
+  sol::object delete_func;
+  sol::object can_move_to_func;
+  sol::object battle_start_func;
+  sol::object battle_end_func;
 };
 
 #endif

--- a/BattleNetwork/bindings/bnScriptedObstacle.cpp
+++ b/BattleNetwork/bindings/bnScriptedObstacle.cpp
@@ -101,6 +101,32 @@ void ScriptedObstacle::OnSpawn(Battle::Tile& spawn)
   }
 }
 
+void ScriptedObstacle::OnBattleStart() {
+  if (battle_start_func.valid()) 
+  {
+    auto result = CallLuaCallback(battle_start_func, weakWrap);
+
+    if (result.is_error()) {
+      Logger::Log(LogLevel::critical, result.error_cstr());
+    }
+  }
+
+  Obstacle::OnBattleStart();
+}
+
+void ScriptedObstacle::OnBattleStop() {
+  Obstacle::OnBattleStop();
+
+  if (battle_end_func.valid()) 
+  {
+    auto result = CallLuaCallback(battle_end_func, weakWrap);
+
+    if (result.is_error()) {
+      Logger::Log(LogLevel::critical, result.error_cstr());
+    }
+  }
+}
+
 const float ScriptedObstacle::GetHeight() const
 {
   return height;

--- a/BattleNetwork/bindings/bnScriptedObstacle.h
+++ b/BattleNetwork/bindings/bnScriptedObstacle.h
@@ -24,6 +24,8 @@ public:
   void OnCollision(const std::shared_ptr<Entity> other) override;
   void Attack(std::shared_ptr<Entity> e) override;
   void OnSpawn(Battle::Tile& spawn) override;
+  void OnBattleStart() override;
+  void OnBattleStop() override;
   const float GetHeight() const;
   void SetHeight(const float height);
 

--- a/BattleNetwork/bindings/bnScriptedSpell.cpp
+++ b/BattleNetwork/bindings/bnScriptedSpell.cpp
@@ -93,6 +93,32 @@ void ScriptedSpell::OnSpawn(Battle::Tile& spawn)
   }
 }
 
+void ScriptedSpell::OnBattleStart() {
+  if (battle_start_func.valid()) 
+  {
+    auto result = CallLuaCallback(battle_start_func, weakWrap);
+
+    if (result.is_error()) {
+      Logger::Log(LogLevel::critical, result.error_cstr());
+    }
+  }
+
+  Spell::OnBattleStart();
+}
+
+void ScriptedSpell::OnBattleStop() {
+  Spell::OnBattleStop();
+
+  if (battle_end_func.valid()) 
+  {
+    auto result = CallLuaCallback(battle_end_func, weakWrap);
+
+    if (result.is_error()) {
+      Logger::Log(LogLevel::critical, result.error_cstr());
+    }
+  }
+}
+
 const float ScriptedSpell::GetHeight() const
 {
   return height;

--- a/BattleNetwork/bindings/bnScriptedSpell.h
+++ b/BattleNetwork/bindings/bnScriptedSpell.h
@@ -24,6 +24,8 @@ public:
   bool CanMoveTo(Battle::Tile * next) override;
   void Attack(std::shared_ptr<Entity> e) override;
   void OnSpawn(Battle::Tile& spawn) override;
+  void OnBattleStart() override;
+  void OnBattleStop() override;
   const float GetHeight() const;
   void SetHeight(const float height);
 

--- a/BattleNetwork/bindings/bnUserTypeEntity.h
+++ b/BattleNetwork/bindings/bnUserTypeEntity.h
@@ -207,6 +207,9 @@ void DefineEntityFunctionsOn(sol::basic_usertype<WeakWrapper<E>, sol::basic_refe
   entity_table["is_moving"] = [](WeakWrapper<E>& entity) -> bool {
     return entity.Unwrap()->IsMoving();
   };
+  entity_table["set_passthrough"] = [](WeakWrapper<E>& entity, bool passthrough) {
+    entity.Unwrap()->SetPassthrough(passthrough);
+  };
   entity_table["is_passthrough"] = [](WeakWrapper<E>& entity) -> bool {
     return entity.Unwrap()->IsPassthrough();
   };

--- a/BattleNetwork/bindings/bnUserTypeEntity.h
+++ b/BattleNetwork/bindings/bnUserTypeEntity.h
@@ -5,6 +5,7 @@
 #include "bnWeakWrapper.h"
 #include "bnUserTypeAnimation.h"
 #include "bnScriptedComponent.h"
+#include "bnScriptedDefenseRule.h"
 #include "../bnEntity.h"
 #include "../bnAnimationComponent.h"
 #include "../bnSolHelpers.h"
@@ -239,12 +240,22 @@ void DefineEntityFunctionsOn(sol::basic_usertype<WeakWrapper<E>, sol::basic_refe
   entity_table["register_component"] = [](WeakWrapper<E>& entity, WeakWrapper<ScriptedComponent>& component) {
     entity.Unwrap()->RegisterComponent(component.UnwrapAndRelease());
   };
-  entity_table["add_defense_rule"] = [](WeakWrapper<E>& entity, DefenseRule& defenseRule) {
-    entity.Unwrap()->AddDefenseRule(defenseRule.shared_from_this());
-  };
-  entity_table["remove_defense_rule"] = [](WeakWrapper<E>& entity, DefenseRule* defenseRule) {
-    entity.Unwrap()->RemoveDefenseRule(defenseRule);
-  };
+  entity_table["add_defense_rule"] = sol::overload(
+    [](WeakWrapper<E>& entity, WeakWrapper<DefenseRule> defenseRule) {
+      entity.Unwrap()->AddDefenseRule(defenseRule.UnwrapAndRelease());
+    },
+    [](WeakWrapper<E>& entity, WeakWrapper<ScriptedDefenseRule> defenseRule) {
+      entity.Unwrap()->AddDefenseRule(defenseRule.UnwrapAndRelease());
+    }
+  );
+  entity_table["remove_defense_rule"] = sol::overload(
+    [](WeakWrapper<E>& entity, WeakWrapper<DefenseRule> defenseRule) {
+      entity.Unwrap()->RemoveDefenseRule(defenseRule.Unwrap());
+    },
+    [](WeakWrapper<E>& entity, WeakWrapper<ScriptedDefenseRule> defenseRule) {
+      entity.Unwrap()->RemoveDefenseRule(defenseRule.Unwrap());
+    }
+  );
   entity_table["ignore_common_aggressor"] = [](WeakWrapper<E>& entity, bool enable) {
     entity.Unwrap()->IgnoreCommonAggressor(enable);
   };

--- a/BattleNetwork/bnAnimation.cpp
+++ b/BattleNetwork/bnAnimation.cpp
@@ -330,8 +330,6 @@ void Animation::Update(double elapsed, sf::Sprite& target) {
     // apply new state to target on same frame
     animator(frames(0), target, animations[currAnimation]);
     progress = frames(0);
-
-    HandleInterrupted();
   }
 
   const frame_time_t duration = animations[currAnimation].GetTotalDuration();

--- a/BattleNetwork/bnBubbleTrap.cpp
+++ b/BattleNetwork/bnBubbleTrap.cpp
@@ -28,20 +28,24 @@ BubbleTrap::BubbleTrap(std::weak_ptr<Entity> owner) :
 }
 
 void BubbleTrap::Inject(BattleSceneBase& bs) {
+}
+
+void BubbleTrap::OnUpdate(double _elapsed) {
   auto asCharacter = GetOwnerAs<Character>();
 
   if (!asCharacter || asCharacter->IsDeleted()) {
     this->Eject();
   }
-  else {
+
+  if (!init) {
     // Bubbles have to pop when hit
     defense = std::make_shared<DefenseBubbleWrap>();
     asCharacter->AddDefenseRule(defense);
     asCharacter->AddNode(shared_from_base<BubbleTrap>());
-  }
-}
 
-void BubbleTrap::OnUpdate(double _elapsed) {
+    init = true;
+  }
+
   auto keyTestThunk = [this](const InputEvent& key) {
     bool pass = false;
 
@@ -83,7 +87,7 @@ void BubbleTrap::OnUpdate(double _elapsed) {
     Pop();
   }
 
-  auto y = -GetOwnerAs<Character>()->GetHeight() / 4.0f;
+  auto y = -asCharacter->GetHeight() / 4.0f;
   setPosition(0.f, y);
 
   animation.Update(_elapsed, getSprite());

--- a/BattleNetwork/bnBubbleTrap.h
+++ b/BattleNetwork/bnBubbleTrap.h
@@ -24,6 +24,7 @@ private:
   std::shared_ptr<DefenseBubbleWrap> defense; /*!< Add BubbleWrapTrap defense rule */
   bool willDelete;
   std::vector<InputEvent> lastFrameStates;
+  bool init{};
 public:
   /**
    * @brief Attaches to the owner, sets the animation */

--- a/BattleNetwork/bnDefenseRule.cpp
+++ b/BattleNetwork/bnDefenseRule.cpp
@@ -19,6 +19,14 @@ const DefenseOrder DefenseRule::GetDefenseOrder() const
   return order;
 }
 
+bool DefenseRule::Added() const {
+  return added;
+}
+
+void DefenseRule::OnAdd() {
+  added = true;
+}
+
 const bool DefenseRule::IsReplaced() const
 {
   return replaced;

--- a/BattleNetwork/bnDefenseRule.h
+++ b/BattleNetwork/bnDefenseRule.h
@@ -26,6 +26,7 @@ private:
   DefenseOrder order; /*!< Some defenses only check if there was a collision */
   Priority priorityLevel; /*!< Lowest priority goes first */
   bool replaced{}; /*!< If this rule has been replaced by another one in the entity*/
+  bool added{};
 
 public:
   friend class Entity;
@@ -44,11 +45,21 @@ public:
   * @brief Returns the defense order of this defense rule
   */
   const DefenseOrder GetDefenseOrder() const;
-  
+
   /**
   * @brief True if the defense rule has been flagged for replacement by another with a priority level of equal value
   */
   const bool IsReplaced() const;
+
+  /**
+  * @brief True if the defense rule has been added to an entity
+  */
+  bool Added() const;
+
+  /**
+  * @brief Marks as `added`
+  */
+  void OnAdd();
 
   /**
   * @brief Frame-perfect cleanup code after being replaced

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -1675,6 +1675,11 @@ void Entity::AddDefenseRule(std::shared_ptr<DefenseRule> rule)
 {
   if (!rule) return;
 
+  if (rule->Added()) {
+    // caught by bindings, crashes if entirely c++ to give line number
+    throw std::runtime_error("DefenseRule has already been added to an entity");
+  }
+
   auto iter = std::find_if(defenses.begin(), defenses.end(), [rule](auto other) { return rule->GetPriorityLevel() == other->GetPriorityLevel(); });
 
   if (rule && iter == defenses.end()) {
@@ -1689,6 +1694,8 @@ void Entity::AddDefenseRule(std::shared_ptr<DefenseRule> rule)
     // call again, adding new rule this time
     AddDefenseRule(rule);
   }
+
+  rule->OnAdd();
 }
 
 void Entity::RemoveDefenseRule(std::shared_ptr<DefenseRule> rule)

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -388,7 +388,7 @@ void Entity::Update(double _elapsed) {
     rootCooldown -= from_seconds(_elapsed);
 
     // Root is cancelled if these conditions are met
-    if (rootCooldown <= frames(0) || invincibilityCooldown > frames(0) || IsPassthrough()) {
+    if (rootCooldown <= frames(0) || IsPassthrough()) {
       rootCooldown = frames(0);
     }
   }
@@ -895,7 +895,7 @@ void Entity::SetPassthrough(bool state)
 
 bool Entity::IsPassthrough()
 {
-  return passthrough;
+  return invincibilityCooldown > frames(0) || passthrough;
 }
 
 void Entity::SetFloatShoe(bool state)
@@ -1278,7 +1278,7 @@ const bool Entity::HasCollision(const Hit::Properties & props)
 {
   // Pierce status hits even when passthrough or flinched
   if ((props.flags & Hit::pierce) != Hit::pierce) {
-    if (invincibilityCooldown > frames(0) || IsPassthrough() || !hitboxEnabled) return false;
+    if (IsPassthrough() || !hitboxEnabled) return false;
   }
 
   return true;

--- a/BattleNetwork/bnField.cpp
+++ b/BattleNetwork/bnField.cpp
@@ -723,8 +723,6 @@ void Field::HandleMissingLayout()
       if (t->ogTeam == Team::unset) {
         t->SetTeam(team);
       }
-
-      t->BattleStart();
     }
   }
 }

--- a/BattleNetwork/bnPackageManager.h
+++ b/BattleNetwork/bnPackageManager.h
@@ -477,7 +477,7 @@ stx::result_t<std::string> PackageManager<MetaClass>::RemovePackageByID(const st
     delete iter->second;
     packages.erase(iter);
 
-    return stx::ok(path);
+    return stx::ok<std::string>(path);
   }
 
   return stx::error<std::string>("No package with that ID");

--- a/BattleNetwork/overworld/bnOverworldOnlineArea.h
+++ b/BattleNetwork/overworld/bnOverworldOnlineArea.h
@@ -202,7 +202,8 @@ namespace Overworld {
     void receivePVPSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveLoadPackageSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receivePackageOfferSignal(BufferReader& reader, const Poco::Buffer<char>&);
-    void receiveModWhitelistSignal(BufferReader& reader, const Poco::Buffer<char>& buffer);
+    void receiveModWhitelistSignal(BufferReader& reader, const Poco::Buffer<char>&);
+    void receiveModBlacklistSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveMobSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveActorConnectedSignal(BufferReader& reader, const Poco::Buffer<char>&);
     void receiveActorDisconnectedSignal(BufferReader& reader, const Poco::Buffer<char>&);

--- a/BattleNetwork/overworld/bnOverworldPacketHeaders.h
+++ b/BattleNetwork/overworld/bnOverworldPacketHeaders.h
@@ -6,7 +6,7 @@
 namespace Overworld
 {
   constexpr std::string_view VERSION_ID = "https://github.com/ArthurCose/Scriptable-OpenNetBattle-Server";
-  const uint64_t VERSION_ITERATION = 43;
+  const uint64_t VERSION_ITERATION = 44;
 
   constexpr double PACKET_RESEND_RATE = 1.0 / 20.0;
 
@@ -105,6 +105,7 @@ namespace Overworld
     package_offer,
     load_package,
     mod_whitelist,
+    mod_blacklist,
     initiate_mob,
     initiate_pvp,
     actor_connected,


### PR DESCRIPTION
Changes:
 - Add blacklist packet
 - Load blue team mob in freedom missions to allow custom music to play
 - Expose set_passthrough for invis, as well as use invincibility cooldown as part of IsPassthrough
 - Fix animation interrupt callback called multiple times
   - once from set_state, another one frame later in an update
   - only apparent when a new interrupt callback is added after the old one is replaced
 - Fix DefenseRule lua memory leak by using WeakWrapper and preventing adding one rule to multiple entities
   - IsReplaced made it clear that defense rules should not be reused and allowed for this change
 - Fix bubble trap segfault from my bad change
 - Fix BattleStart called on first frame
 - Fix battle start/end callbacks not called on non player classes