### PR TITLE
Make frame recording thread safe, async, and write to disk immediately.

### DIFF
--- a/BattleNetwork/bnFrameRecorder.cpp
+++ b/BattleNetwork/bnFrameRecorder.cpp
@@ -1,0 +1,99 @@
+#include "bnFrameRecorder.h"
+#include "bnLogger.h"
+
+#include <SFML/Window.hpp>
+
+constexpr int maxOutstandingFrames = 10;
+
+FrameRecorder::FrameRecorder(const sf::Window &window)
+    : window(window), consumerThread([this] {
+        Logger::Log(LogLevel::info, "Starting recording consumer thread!");
+        while (true) {
+          sf::Texture tex;
+
+          {
+            std::unique_lock<std::mutex> lk(usedTexturesLock);
+            usedTexturesCv.wait(lk, [this] { return usedTextures.size() > 0 || stopped; });
+            if (stopped && usedTextures.empty()) {
+              break;
+            }
+            tex = std::move(usedTextures.front());
+            usedTextures.pop_front();
+          }
+          usedTexturesCv.notify_one();
+
+          // This operation is unavoidably expensive, but at least we don't have to hold up writers while doing it.
+          sf::Image img = tex.copyToImage();
+
+          {
+            std::unique_lock<std::mutex> lk(freeTexturesLock);
+            freeTextures.push_back(std::move(tex));
+          }
+          freeTexturesCv.notify_one();
+
+          // TODO: Something more useful with with img.
+          img.saveToFile("recording/frame_" +
+                         std::to_string(totalFramesProcessed) + ".bmp");
+
+          ++totalFramesProcessed;
+        }
+        Logger::Log(LogLevel::info, "Recording consumer thread stopped.");
+      }) {
+  for (int i = 0; i < maxOutstandingFrames; ++i) {
+    sf::Texture tex;
+    tex.create(window.getSize().x, window.getSize().y);
+    freeTextures.push_back(std::move(tex));
+  }
+}
+
+void FrameRecorder::capture() {
+  {
+    std::unique_lock<std::mutex> lk(usedTexturesLock);
+    if (stopped) {
+      // Cannot add frame to stopped recorder. This should never happen!
+      return;
+    }
+  }
+
+  sf::Texture tex;
+  {
+    std::unique_lock<std::mutex> lk(freeTexturesLock);
+    if (freeTextures.empty()) {
+      Logger::Log(LogLevel::info, "Recording is stalling.");
+    }
+    freeTexturesCv.wait(lk, [this] { return !freeTextures.empty(); });
+    tex = std::move(freeTextures.back());
+    freeTextures.pop_back();
+  }
+  freeTexturesCv.notify_one();
+
+  tex.update(window);
+
+  {
+    std::unique_lock<std::mutex> lk(usedTexturesLock);
+    usedTextures.push_back(std::move(tex));
+  }
+  usedTexturesCv.notify_one();
+}
+
+void FrameRecorder::flush() {
+  Logger::Log(LogLevel::info, "Flushing recording...");
+
+  {
+    std::unique_lock<std::mutex> lk(usedTexturesLock);
+    stopped = true;
+  }
+  usedTexturesCv.notify_one();
+
+  {
+    std::unique_lock<std::mutex> lk(usedTexturesLock);
+    usedTexturesCv.wait(lk, [this] { return usedTextures.empty(); });
+  }
+
+  consumerThread.join();
+  Logger::Logf(LogLevel::info,
+               "Flushed! Recording session processed %d frames.",
+               totalFramesProcessed);
+}
+
+FrameRecorder::~FrameRecorder() { flush(); }

--- a/BattleNetwork/bnFrameRecorder.h
+++ b/BattleNetwork/bnFrameRecorder.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <SFML/Graphics/Texture.hpp>
+#include <condition_variable>
+#include <deque>
+#include <filesystem>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+class FrameRecorder {
+private:
+  const sf::Window &window;
+
+  std::thread consumerThread;
+
+  bool stopped = false;
+  std::deque<sf::Texture> usedTextures;
+  std::mutex usedTexturesLock;
+  std::condition_variable usedTexturesCv;
+
+  std::vector<sf::Texture> freeTextures;
+  std::mutex freeTexturesLock;
+  std::condition_variable freeTexturesCv;
+
+  int totalFramesProcessed = 0;
+
+  void flush();
+
+public:
+  explicit FrameRecorder(const sf::Window &window);
+  ~FrameRecorder();
+
+  void capture();
+};

--- a/BattleNetwork/bnGame.cpp
+++ b/BattleNetwork/bnGame.cpp
@@ -113,10 +113,6 @@ Game::~Game() {
     renderThread.join();
   }
 
-  if (recordOutThread.joinable()) {
-    recordOutThread.join();
-  }
-
   delete session;
 
 #ifdef BN_MOD_SUPPORT
@@ -268,11 +264,6 @@ bool Game::NextFrame()
 
 void Game::HandleRecordingEvents()
 {
-  return; // for v2, disable this function by returning early.
-
-  if (isRecordOutSaving)
-    return;
-
   if (!inputManager.Has(InputEvents::pressed_record_frames)) {
     recordPressed = false;
     return;
@@ -284,30 +275,12 @@ void Game::HandleRecordingEvents()
   recordPressed = true;
 
   if (!IsRecording()) {
-    Record(true);
+    StartRecording();
     window.SetSubtitle("[RECORDING]");
-    return;
-  }
-
-  recordOutThread = std::thread([this]() {
-    isRecordOutSaving = true;
-    Record(false);
-
-    Logger::Logf(LogLevel::info, "Saving recording to disk, please wait.");
-    window.SetSubtitle("[SAVING]");
-
-    for (auto& pair : recordedFrames) {
-      pair.second.saveToFile("recording/frame_" + std::to_string(pair.first) + ".png");
-    }
-
-    Logger::Logf(LogLevel::info, "Wrote %i frames to disk", (int)recordedFrames.size());
-    recordedFrames.clear();
+  } else {
+    StopRecording();
     window.SetSubtitle("");
-
-    isRecordOutSaving = false;
-  });
-
-  recordOutThread.detach();
+  }
 }
 
 void Game::UpdateMouse(double dt)
@@ -343,16 +316,15 @@ void Game::ProcessFrame()
     if (NextFrame()) {
       HandleRecordingEvents();
       this->update(delta);  // update game logic
-
-      if (isRecording) {
-        sf::Image image = window.GetRenderWindow()->capture();
-        recordedFrames.push_back(std::pair(FrameNumber(), image));
-      }
     }
 
     this->draw();        // draw game
     mouse.draw(*window.GetRenderWindow());
     window.Display(); // display to screen
+
+    if (frameRecorder) {
+      frameRecorder->capture();
+    }
 
     scope_elapsed = clock.getElapsedTime().asSeconds();
   }
@@ -392,6 +364,10 @@ void Game::RunSingleThreaded()
     this->draw();        // draw game
     mouse.draw(*window.GetRenderWindow());
     window.Display(); // display to screen
+
+    if (frameRecorder) {
+      frameRecorder->capture();
+    }
 
     quitting = getStackSize() == 0;
 
@@ -513,12 +489,17 @@ bool Game::IsSingleThreaded() const
 
 bool Game::IsRecording() const
 {
-  return isRecording;
+  return frameRecorder != nullptr;
 }
 
-void Game::Record(bool enabled)
+void Game::StartRecording()
 {
-  isRecording = enabled;
+  frameRecorder = std::make_unique<FrameRecorder>(*window.GetRenderWindow());
+}
+
+void Game::StopRecording()
+{
+  frameRecorder = nullptr;
 }
 
 void Game::SetSubtitle(const std::string& subtitle)

--- a/BattleNetwork/bnGame.h
+++ b/BattleNetwork/bnGame.h
@@ -8,6 +8,7 @@
 #include "bnDrawWindow.h"
 #include "bnConfigReader.h"
 #include "bnConfigSettings.h"
+#include "bnFrameRecorder.h"
 #include "bnSpriteProxyNode.h"
 #include "bnAnimation.h"
 #include "bnNetManager.h"
@@ -62,8 +63,9 @@ private:
   double mouseAlpha{};
   bool showScreenBars{};
   bool frameByFrame{}, isDebug{}, quitting{ false };
-  bool singlethreaded{ false };
-  bool isRecording{}, isRecordOutSaving{}, recordPressed{};
+  bool singlethreaded{ false }, recordPressed{ false };
+
+  std::unique_ptr<FrameRecorder> frameRecorder;
 
   TextureResourceManager textureManager;
   AudioResourceManager audioManager;
@@ -107,10 +109,9 @@ private:
   Endianness endian{ Endianness::big };
   std::vector<cxxopts::KeyValue> commandlineArgs; /*!< User-provided values from the command line*/
   cxxopts::ParseResult const* commandline{ nullptr }; /*!< Final values parsed from the command line configuration*/
-  std::vector<std::pair<unsigned, sf::Image>> recordedFrames;
   std::atomic<int> progress{ 0 };
   std::mutex windowMutex;
-  std::thread renderThread, recordOutThread;
+  std::thread renderThread;
 
   void HandleRecordingEvents();
   void UpdateMouse(double dt);
@@ -143,7 +144,8 @@ public:
   const unsigned int GetRandSeed() const;
   bool IsSingleThreaded() const;
   bool IsRecording() const;
-  void Record(bool enabled = true);
+  void StartRecording();
+  void StopRecording();
   void SetSubtitle(const std::string& subtitle);
 
   const std::filesystem::path AppDataPath();


### PR DESCRIPTION
Recording frames asynchronously allows us to not block the render thread (up until the buffer is full, at least). We also cache a bunch of textures that we can reuse to avoid allocating a new one every time, and also write immediately to disk at the first chance we get. We also write BMPs for now instead of PNGs, because PNG encoding time takes too long and wtill stall recording.