### PR TITLE
Allows changing of charge shot color at max charge.

### DIFF
--- a/BattleNetwork/bnChargeEffectSceneNode.cpp
+++ b/BattleNetwork/bnChargeEffectSceneNode.cpp
@@ -84,5 +84,8 @@ const bool ChargeEffectSceneNode::IsFullyCharged() const
 
 void ChargeEffectSceneNode::SetFullyChargedColor(const sf::Color color)
 {
+  if (isCharged) {
+    setColor(color);
+  }
   chargeColor = color;
 }


### PR DESCRIPTION
This is for tiered charge shot signaling in mods. It will allow lua modders to conditionally change the charge shot's color, with the usecase of "tiered charge shots", ala Battle Network 1. This allows for more fluid and dynamic multiple charge shots instead of the clunk "switch with special key" or "switch on charge shot use".