### PR TITLE
Adds second element capabilities to hit props.

### DIFF
--- a/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
+++ b/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
@@ -164,12 +164,12 @@ void FreedomMissionMobScene::OnHit(Entity& victim, const Hit::Properties& props)
       GetSelectedCardsUI().SetMultiplier(2);
     }
 
-    if (player->IsSuperEffective(props.element)) {
+    if (player->IsSuperEffective(props.element) || player->IsSuperEffective(props.secondaryElement)) {
       playerDecross = true;
     }
   }
 
-  if (victim.IsSuperEffective(props.element) && props.damage > 0) {
+  if (victim.IsSuperEffective(props.element) && props.damage > 0 || victim.IsSuperEffective(props.secondaryElement) && props.damage > 0) {
     std::shared_ptr<ElementalDamage> seSymbol = std::make_shared<ElementalDamage>();
     seSymbol->SetLayer(-100);
     seSymbol->SetHeight(victim.GetHeight()+(victim.getLocalBounds().height*0.5f)); // place it at sprite height

--- a/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
+++ b/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
@@ -169,7 +169,7 @@ void FreedomMissionMobScene::OnHit(Entity& victim, const Hit::Properties& props)
     }
   }
 
-  if (victim.IsSuperEffective(props.element) && props.damage > 0 || victim.IsSuperEffective(props.secondaryElement) && props.damage > 0) {
+  if (props.damage > 0 && (victim.IsSuperEffective(props.element) || victim.IsSuperEffective(props.secondaryElement))) {
     std::shared_ptr<ElementalDamage> seSymbol = std::make_shared<ElementalDamage>();
     seSymbol->SetLayer(-100);
     seSymbol->SetHeight(victim.GetHeight()+(victim.getLocalBounds().height*0.5f)); // place it at sprite height

--- a/BattleNetwork/battlescene/bnMobBattleScene.cpp
+++ b/BattleNetwork/battlescene/bnMobBattleScene.cpp
@@ -179,7 +179,7 @@ void MobBattleScene::OnHit(Entity& victim, const Hit::Properties& props)
   }
 
   bool freezeBreak = victim.IsIceFrozen() && ((props.flags & Hit::breaking) == Hit::breaking);
-  bool superEffective = victim.IsSuperEffective(props.element) && props.damage > 0 || victim.IsSuperEffective(props.secondaryElement) && props.damage > 0;
+  bool superEffective = props.damage > 0 && (victim.IsSuperEffective(props.element) || victim.IsSuperEffective(props.secondaryElement));
 
   if (freezeBreak || superEffective) {
     std::shared_ptr<ElementalDamage> seSymbol = std::make_shared<ElementalDamage>();

--- a/BattleNetwork/battlescene/bnMobBattleScene.cpp
+++ b/BattleNetwork/battlescene/bnMobBattleScene.cpp
@@ -173,13 +173,13 @@ void MobBattleScene::OnHit(Entity& victim, const Hit::Properties& props)
       GetSelectedCardsUI().SetMultiplier(2);
     }
 
-    if (player->IsSuperEffective(props.element)) {
+    if (player->IsSuperEffective(props.element) || player->IsSuperEffective(props.secondaryElement)) {
       playerDecross = true;
     }
   }
 
   bool freezeBreak = victim.IsIceFrozen() && ((props.flags & Hit::breaking) == Hit::breaking);
-  bool superEffective = victim.IsSuperEffective(props.element) && props.damage > 0;
+  bool superEffective = victim.IsSuperEffective(props.element) && props.damage > 0 || victim.IsSuperEffective(props.secondaryElement) && props.damage > 0;
 
   if (freezeBreak || superEffective) {
     std::shared_ptr<ElementalDamage> seSymbol = std::make_shared<ElementalDamage>();

--- a/BattleNetwork/bindings/bnUserTypeHitbox.cpp
+++ b/BattleNetwork/bindings/bnUserTypeHitbox.cpp
@@ -109,8 +109,8 @@ void DefineHitboxUserTypes(sol::state& state, sol::table& battle_namespace) {
 
 
   state.new_usertype<Hit::Properties>("HitProps",
-    sol::factories([](int damage, Hit::Flags flags, Element element, std::optional<Hit::Context> contextOptional, Hit::Drag drag) {
-      Hit::Properties props = { damage, flags, element, 0, drag };
+    sol::factories([](int damage, Hit::Flags flags, Element element, Element secondaryElement, std::optional<Hit::Context> contextOptional, Hit::Drag drag) {
+      Hit::Properties props = { damage, flags, element, secondaryElement, 0, drag };
 
       if (contextOptional) {
         props.context = *contextOptional;
@@ -123,6 +123,7 @@ void DefineHitboxUserTypes(sol::state& state, sol::table& battle_namespace) {
     "damage", &Hit::Properties::damage,
     "drag", &Hit::Properties::drag,
     "element", &Hit::Properties::element,
+    "secondary_element", &Hit::Properties::secondaryElement,
     "flags", &Hit::Properties::flags
   );
 

--- a/BattleNetwork/bnChargeEffectSceneNode.cpp
+++ b/BattleNetwork/bnChargeEffectSceneNode.cpp
@@ -23,14 +23,13 @@ ChargeEffectSceneNode::~ChargeEffectSceneNode() {
 void ChargeEffectSceneNode::Update(double _elapsed) {
   if (charging) {
     chargeCounter += from_seconds(_elapsed);
-
+    setColor(chargeColor);
     if (chargeCounter >= maxChargeTime + i10) {
       if (isCharged == false) {
         // We're switching states
         Audio().Play(AudioType::BUSTER_CHARGED);
         animation.SetAnimation("CHARGED");
         animation << Animator::Mode::Loop;
-        setColor(chargeColor);
         SetShader(Shaders().GetShader(ShaderType::ADDITIVE));
       }
 
@@ -84,8 +83,5 @@ const bool ChargeEffectSceneNode::IsFullyCharged() const
 
 void ChargeEffectSceneNode::SetFullyChargedColor(const sf::Color color)
 {
-  if (isCharged) {
-    setColor(color);
-  }
   chargeColor = color;
 }

--- a/BattleNetwork/bnHitProperties.h
+++ b/BattleNetwork/bnHitProperties.h
@@ -48,6 +48,7 @@ namespace Hit {
     int damage{};
     Flags flags{ Hit::none };
     Element element{ Element::none };
+    Element secondaryElement{ Element::none };
     EntityID_t aggressor{};
     Drag drag{ }; // Used by Hit::drag flag
     Context context{};
@@ -56,6 +57,7 @@ namespace Hit {
   const constexpr Hit::Properties DefaultProperties = {
     0,
     Flags(Hit::flinch | Hit::impact),
+    Element::none,
     Element::none,
     0,
     Direction::none,

--- a/BattleNetwork/bnTile.cpp
+++ b/BattleNetwork/bnTile.cpp
@@ -676,7 +676,7 @@ namespace Battle {
       if (!character.HasFloatShoe()) {
         if (GetState() == TileState::poison) {
           if (elapsedBurnTime <= 0) {
-            if (character.Hit(Hit::Properties({ 1, Hit::pierce, Element::none, 0, Direction::none }))) {
+            if (character.Hit(Hit::Properties({ 1, Hit::pierce, Element::none, Element::none, 0, Direction::none }))) {
               elapsedBurnTime = burncycle;
             }
           }
@@ -686,7 +686,7 @@ namespace Battle {
         }
 
         if (GetState() == TileState::lava) {
-          Hit::Properties props = { 50, Hit::flash | Hit::flinch, Element::none, 0, Direction::none };
+          Hit::Properties props = { 50, Hit::flash | Hit::flinch, Element::none, Element::none, 0, Direction::none };
           if (character.HasCollision(props)) {
             character.Hit(props);
             field.AddEntity(std::make_shared<Explosion>(), GetX(), GetY());

--- a/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
+++ b/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
@@ -178,7 +178,7 @@ NetworkBattleScene::~NetworkBattleScene()
 void NetworkBattleScene::OnHit(Entity& victim, const Hit::Properties& props)
 {
   bool freezeBreak = victim.IsIceFrozen() && ((props.flags & Hit::breaking) == Hit::breaking);
-  bool superEffective = victim.IsSuperEffective(props.element) && props.damage > 0 || victim.IsSuperEffective(props.secondaryElement) && props.damage > 0;
+  bool superEffective = props.damage > 0 && (victim.IsSuperEffective(props.element) || victim.IsSuperEffective(props.secondaryElement));
 
   if (freezeBreak || superEffective) {
     std::shared_ptr<ElementalDamage> seSymbol = std::make_shared<ElementalDamage>();

--- a/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
+++ b/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
@@ -178,7 +178,7 @@ NetworkBattleScene::~NetworkBattleScene()
 void NetworkBattleScene::OnHit(Entity& victim, const Hit::Properties& props)
 {
   bool freezeBreak = victim.IsIceFrozen() && ((props.flags & Hit::breaking) == Hit::breaking);
-  bool superEffective = victim.IsSuperEffective(props.element) && props.damage > 0;
+  bool superEffective = victim.IsSuperEffective(props.element) && props.damage > 0 || victim.IsSuperEffective(props.secondaryElement) && props.damage > 0;
 
   if (freezeBreak || superEffective) {
     std::shared_ptr<ElementalDamage> seSymbol = std::make_shared<ElementalDamage>();
@@ -202,7 +202,7 @@ void NetworkBattleScene::OnHit(Entity& victim, const Hit::Properties& props)
       }
     }
 
-    if (player->IsSuperEffective(props.element)) {
+    if (player->IsSuperEffective(props.element) || player->IsSuperEffective(props.secondaryElement)) {
       // animate the transformation back to default form
       TrackedFormData& formData = GetPlayerFormData(player);
 


### PR DESCRIPTION
Adds seemingly full support to the engine for these secondary elements. While they remain hidden (as per BN6) they deal double damage to targets weak to them, de-cross targets who are in crosses, activate special effects such as freeze on ice tiles, and so forth.

After a merge from Konst this no longer breaks mods using HitProps. Mods are free to continue existing as they are if they don't need to use this system.

Awaiting review.