### PR TITLE
Replace SyncedRand with SyncedRandBelow and SyncedRandFloat.

### DIFF
--- a/BattleNetwork/battlescene/bnBattleSceneBase.cpp
+++ b/BattleNetwork/battlescene/bnBattleSceneBase.cpp
@@ -77,7 +77,7 @@ BattleSceneBase::BattleSceneBase(ActivityController& controller, BattleSceneBase
   background = props.background;
 
   if (!background) {
-    int randBG = SyncedRand() % 8;
+    int randBG = SyncedRandBelow(8);
 
     if (randBG == 0) {
       background = std::make_shared<LanBackground>();
@@ -274,7 +274,7 @@ void BattleSceneBase::OnDeleteEvent(Character& pending)
 
   Character* pendingPtr = &pending;
 
-  // Find any AI using this character as a target and free that pointer  
+  // Find any AI using this character as a target and free that pointer
   field->ForEachEntity([pendingPtr](std::shared_ptr<Entity>& in) {
     Agent* agent = dynamic_cast<Agent*>(in.get());
 
@@ -286,7 +286,7 @@ void BattleSceneBase::OnDeleteEvent(Character& pending)
   });
 
   Logger::Logf(LogLevel::debug, "Removing %s from battle (ID: %d)", pending.GetName().c_str(), pending.GetID());
-  
+
   bool redTeamClear = false;
   bool blueTeamClear = false;
   if (redTeamMob) {
@@ -311,7 +311,7 @@ const BattleSceneState* BattleSceneBase::GetCurrentState() const
   return current;
 }
 
-const int BattleSceneBase::ComboDeleteSize() const 
+const int BattleSceneBase::ComboDeleteSize() const
 {
   return comboInfoTimer.elapsed() <= COUNTER_HIT_THRESHOLD_FRAMES ? comboDeleteCounter : 0;
 }
@@ -487,7 +487,7 @@ void BattleSceneBase::SpawnOtherPlayer(std::shared_ptr<Player> player, int x, in
   if (!player->HasInit()) {
     player->Init();
   }
-  player->ChangeState<PlayerIdleState>();  
+  player->ChangeState<PlayerIdleState>();
   player->SetTeam(team);
   field->AddEntity(player, x, y);
 
@@ -798,7 +798,7 @@ void BattleSceneBase::onUpdate(double elapsed) {
   }
 
   // cleanup trackers for ex-mob enemies when they are fully removed from the field
-  // 
+  //
   // red team mobs
   for (auto iter = deletingRedMobs.begin(); iter != deletingRedMobs.end(); /*skip*/) {
     if (!field->GetEntity(*iter)) {
@@ -1072,7 +1072,7 @@ void BattleSceneBase::DrawWithPerspective(Text& text, sf::RenderTarget& surf)
   surf.draw(text);
 
   text.setPosition(position);
-  text.setOrigin(origin);  
+  text.setOrigin(origin);
 }
 
 void BattleSceneBase::PerspectiveFlip(bool flipped)
@@ -1249,7 +1249,7 @@ std::vector<std::reference_wrapper<const Character>> BattleSceneBase::BlueTeamMo
 }
 
 void BattleSceneBase::Quit(const FadeOut& mode) {
-  if(quitting) return; 
+  if(quitting) return;
 
   // end the current state
   if(current) {
@@ -1264,7 +1264,7 @@ void BattleSceneBase::Quit(const FadeOut& mode) {
     return;
   }
 
-  // Depending on the mode, use Swoosh's 
+  // Depending on the mode, use Swoosh's
   // activity controller to fadeout with the right
   // visual appearance
   if(mode == FadeOut::white) {
@@ -1308,7 +1308,7 @@ void BattleSceneBase::Inject(std::shared_ptr<Component> other)
 
 void BattleSceneBase::Eject(Component::ID_t ID)
 {
-  auto iter = std::find_if(components.begin(), components.end(), 
+  auto iter = std::find_if(components.begin(), components.end(),
     [ID](std::shared_ptr<Component>& in) { return in->GetID() == ID; }
   );
 
@@ -1317,8 +1317,8 @@ void BattleSceneBase::Eject(Component::ID_t ID)
 
     SceneNode* node = dynamic_cast<SceneNode*>(&component);
     // TODO: dynamic casting could be entirely avoided by hashing IDs
-    auto iter2 = std::find_if(scenenodes.begin(), scenenodes.end(), 
-      [node](std::shared_ptr<SceneNode>& in) { 
+    auto iter2 = std::find_if(scenenodes.begin(), scenenodes.end(),
+      [node](std::shared_ptr<SceneNode>& in) {
         return in.get() == node;
       }
     );

--- a/BattleNetwork/bnBuster.cpp
+++ b/BattleNetwork/bnBuster.cpp
@@ -93,10 +93,10 @@ void Buster::OnCollision(const std::shared_ptr<Entity> entity)
   hitHeight = std::floor(entity->GetHeight());
 
   if (!isCharged) {
-    random *= SyncedRand() % 2 == 0 ? -1.0f : 1.0f;
+    random *= SyncedRandBelow(2) == 0 ? -1.0f : 1.0f;
 
     if (hitHeight > 0) {
-      hitHeight = (float)(SyncedRand() % (int)hitHeight);
+      hitHeight = (float)(SyncedRandBelow(hitHeight));
     }
   }
   else {

--- a/BattleNetwork/bnExplosion.cpp
+++ b/BattleNetwork/bnExplosion.cpp
@@ -7,7 +7,7 @@
 
 using sf::IntRect;
 
-Explosion::Explosion(int _numOfExplosions, double _playbackSpeed) : 
+Explosion::Explosion(int _numOfExplosions, double _playbackSpeed) :
   Artifact()
 {
   root = this;
@@ -50,7 +50,7 @@ void Explosion::Init() {
 
   /**
    * Tell root to increment explosion count on frame 12
-   * 
+   *
    * Similar to the root constructor, if there are more explosions
    * Spawn a copy on frame 8
    */
@@ -86,7 +86,7 @@ void Explosion::OnUpdate(double _elapsed) {
     }
   }
 
-  // The first explosion spawns inside of the entity 
+  // The first explosion spawns inside of the entity
   // all other explosions use the offset to explode around the entity
   if (numOfExplosions != 1) {
     Entity::drawOffset += {offset.x, offset.y};
@@ -114,14 +114,14 @@ void Explosion::SetOffsetArea(sf::Vector2f area)
 
   offsetArea = area;
 
-  int randX = SyncedRand() % (int)(area.x+0.5f);
-  int randY = SyncedRand() % (int)(area.y+0.5f);
+  int randX = SyncedRandBelow((int)(area.x+0.5f));
+  int randY = SyncedRandBelow((int)(area.y+0.5f));
 
   int randNegX = 1;
   int randNegY = 1;
 
-  if (SyncedRand() % 10 > 5) randNegX = -1;
-  if (SyncedRand() % 10 > 5) randNegY = -1;
+  if (SyncedRandBelow(10) > 5) randNegX = -1;
+  if (SyncedRandBelow(10) > 5) randNegY = -1;
 
   randX *= randNegX;
   randY = -randY;

--- a/BattleNetwork/bnExplosionSpriteNode.cpp
+++ b/BattleNetwork/bnExplosionSpriteNode.cpp
@@ -9,7 +9,7 @@ using sf::IntRect;
 
 const char* ANIM_PATH = "resources/scenes/battle/mob_explosion.animation";
 
-ExplosionSpriteNode::ExplosionSpriteNode(SceneNode* parent, int _numOfExplosions, double _playbackSpeed) : 
+ExplosionSpriteNode::ExplosionSpriteNode(SceneNode* parent, int _numOfExplosions, double _playbackSpeed) :
   SpriteProxyNode(), animation(ANIM_PATH), parent(parent)
 {
   root = this;
@@ -28,16 +28,16 @@ ExplosionSpriteNode::ExplosionSpriteNode(SceneNode* parent, int _numOfExplosions
     this->done = true;
     this->Hide();
   };
-  
+
   animation.Refresh(getSprite());
 
   /*
-   * On the 12th frame, increment the explosion count, and turn the first 
+   * On the 12th frame, increment the explosion count, and turn the first
    * explosion transpatent.
-   * 
+   *
    * If there are more explosions expected, spawn a copy on frame 8
    */
-  animation << Animator::On(12, 
+  animation << Animator::On(12,
     [this]() {
       root->IncrementExplosionCount();
     },
@@ -60,7 +60,7 @@ ExplosionSpriteNode::ExplosionSpriteNode(SceneNode* parent, int _numOfExplosions
   Update(0);
 }
 
-ExplosionSpriteNode::ExplosionSpriteNode(const ExplosionSpriteNode& copy) 
+ExplosionSpriteNode::ExplosionSpriteNode(const ExplosionSpriteNode& copy)
   : SpriteProxyNode(), animation(ANIM_PATH)
 {
   root = copy.root;
@@ -85,7 +85,7 @@ ExplosionSpriteNode::ExplosionSpriteNode(const ExplosionSpriteNode& copy)
 
   /**
    * Tell root to increment explosion count on frame 12
-   * 
+   *
    * Similar to the root constructor, if there are more explosions
    * Spawn a copy on frame 8
    */
@@ -144,14 +144,14 @@ void ExplosionSpriteNode::SetOffsetArea(sf::Vector2f area)
 
   offsetArea = area;
 
-  int randX = SyncedRand() % (int)(area.x+0.5f);
-  int randY = SyncedRand() % (int)(area.y+0.5f);
+  int randX = SyncedRandBelow((int)(area.x+0.5f));
+  int randY = SyncedRandBelow((int)(area.y+0.5f));
 
   int randNegX = 1;
   int randNegY = 1;
 
-  if (SyncedRand() % 10 > 5) randNegX = -1;
-  if (SyncedRand() % 10 > 5) randNegY = -1;
+  if (SyncedRandBelow(10) > 5) randNegX = -1;
+  if (SyncedRandBelow(10) > 5) randNegY = -1;
 
   randX *= randNegX;
   randY = -randY;

--- a/BattleNetwork/bnRandom.cpp
+++ b/BattleNetwork/bnRandom.cpp
@@ -10,12 +10,19 @@ static std::mersenne_twister_engine<
   0xefc60000, 18, 1812433253
 > randomGenerator;
 
-uint32_t SyncedRand() {
-  return randomGenerator();
+uint32_t SyncedRandBelow(uint32_t n) {
+  std::uniform_int_distribution<> dist(0, n - 1);
+  return dist(randomGenerator);
 }
 
-uint32_t SyncedRandMax() {
-  return randomGenerator.max();
+float SyncedRandFloat() {
+  // https://stackoverflow.com/a/25669510
+  double rd = std::generate_canonical<double, std::numeric_limits<float>::digits>(randomGenerator);
+  float rf = rd;
+  if (rf > rd) {
+    rf = std::nextafter(rf, -std::numeric_limits<float>::infinity());
+  }
+  return rf;
 }
 
 void SeedSyncedRand(uint32_t seed) {

--- a/BattleNetwork/bnRandom.h
+++ b/BattleNetwork/bnRandom.h
@@ -3,6 +3,6 @@
 
 // for random values that need to be synced, use these in lockstep only where necessary
 
-uint32_t SyncedRand();
-uint32_t SyncedRandMax();
+uint32_t SyncedRandBelow(uint32_t n);
+float SyncedRandFloat();
 void SeedSyncedRand(uint32_t seed);

--- a/BattleNetwork/bnScriptResourceManager.cpp
+++ b/BattleNetwork/bnScriptResourceManager.cpp
@@ -106,13 +106,13 @@ void ScriptResourceManager::SetSystemFunctions(ScriptPackage& scriptPackage)
   state["math"]["random"] = sol::overload(
     [] (int n, int m) -> int { // [n, m]
       int range = m - n;
-      return SyncedRand() % (range + 1) + n;
+      return SyncedRandBelow(range + 1) + n;
     },
     [] (int n) -> int { // [1, n]
-      return SyncedRand() % n + 1;
+      return SyncedRandBelow(n + 1) + 1;
     },
     [] () -> float { // [0, 1)
-      return (float)SyncedRand() / ((float)(SyncedRandMax()) + 1);
+      return SyncedRandFloat();
     }
   );
 

--- a/BattleNetwork/netplay/bnDownloadScene.cpp
+++ b/BattleNetwork/netplay/bnDownloadScene.cpp
@@ -114,8 +114,8 @@ void DownloadScene::SendCoinFlip() {
   // this is intentionally desynced here from the SeedRand above, but syncs back up later when the scene exits to pvp
   // we want to use the same random generator due to implemenation differences of RAND_MAX
   // on linux RAND_MAX is 2147483647 while on windows it is 32767,
-  // giving a far higher probability of being player 2 on linux when using rand() instead of SyncedRand()
-  coinValue = SyncedRand();
+  // giving a far higher probability of being player 2 on linux when using rand() instead of SyncedRandBelow()
+  coinValue = SyncedRandBelow(std::numeric_limits<uint32_t>::max());
 
   writer.Write<uint32_t>(buffer, coinValue);
 


### PR DESCRIPTION
This replaces the use of modulus with std::uniform_{int,real}_distribution, which does not have left-bias when the top of the range is not a factor of the modulus.