### PR TITLE
Folder Scene fix.

### DIFF
--- a/BattleNetwork/bnFolderScene.cpp
+++ b/BattleNetwork/bnFolderScene.cpp
@@ -609,8 +609,12 @@ void FolderScene::onDraw(sf::RenderTexture& surface) {
   cursor.setPosition(2.0, y);
 
   if (!folder) return;
-
-  if (folder->GetSize() != 0) {
+  //Once the folder is confirmed to exist, update the size.
+  //This avoids a crash when updating folders.
+  numOfCards = folder->GetSize();
+  //And since size was just called, we don't need to call it again anymore.
+  //Editing this to use a call to the variable.
+  if (numOfCards != 0) {
     // Move the card library iterator to the current highlighted card
     CardFolder::Iter iter = folder->Begin();
 


### PR DESCRIPTION
Fixes a bug within Folder Scene wherein updating the scene would crash the game, at least in debug mode, if you edited a folder by removing chips in any way. Testing included popping chips out of the folder & going back to the Folder scene and deleting a folder from the scene itself. Presumably slotting a chip snugly back into the pack by hand and returning to the folder scene would also cause the same issue.