### PR TITLE
See comment for details.

### DIFF
--- a/BattleNetwork/battlescene/bnBattleSceneBase.cpp
+++ b/BattleNetwork/battlescene/bnBattleSceneBase.cpp
@@ -435,8 +435,8 @@ void BattleSceneBase::SpawnLocalPlayer(int x, int y)
   this->SubscribeToCardActions(*localPlayer);
   this->SubscribeToCardActions(*cardUI);
 
-  auto healthUI = localPlayer->CreateComponent<PlayerHealthUIComponent>(localPlayer);
-  healthUI->setScale(2.f, 2.f); // TODO: this should be upscaled by cardCustGUI transforms... why is it not?
+  this->healthUI = localPlayer->CreateComponent<PlayerHealthUIComponent>(localPlayer);
+  this->healthUI->setScale(2.f, 2.f); // TODO: this should be upscaled by cardCustGUI transforms... why is it not?
 
   cardCustGUI.AddNode(healthUI);
 
@@ -1171,6 +1171,11 @@ PlayerSelectedCardsUI& BattleSceneBase::GetSelectedCardsUI() {
 PlayerEmotionUI& BattleSceneBase::GetEmotionWindow()
 {
   return *emotionUI;
+}
+
+PlayerHealthUIComponent& BattleSceneBase::GetHealthWindow()
+{
+    return *healthUI;
 }
 
 Camera& BattleSceneBase::GetCamera()

--- a/BattleNetwork/battlescene/bnBattleSceneBase.h
+++ b/BattleNetwork/battlescene/bnBattleSceneBase.h
@@ -13,6 +13,7 @@
 #include "../bnScene.h"
 #include "../bnComponent.h"
 #include "../bnPA.h"
+#include "../bnPlayerHealthUI.h"
 #include "../bnMobHealthUI.h"
 #include "../bnAnimation.h"
 #include "../bnCamera.h"
@@ -111,6 +112,7 @@ private:
   RealtimeCardActionUseListener cardActionListener; /*!< Card use listener handles one card at a time */
   std::shared_ptr<PlayerSelectedCardsUI> cardUI{ nullptr }; /*!< Player's Card UI implementation */
   std::shared_ptr<PlayerEmotionUI> emotionUI{ nullptr }; /*!< Player's Emotion Window */
+  std::shared_ptr<PlayerHealthUIComponent> healthUI{ nullptr }; /*!< Player's Health Window */
   Camera camera; /*!< Camera object - will shake screen */
   sf::Sprite mobEdgeSprite, mobBackdropSprite; /*!< name backdrop images*/
   PA& programAdvance; /*!< PA object loads PA database and returns matching PA card from input */
@@ -397,6 +399,7 @@ public:
   CardSelectionCust& GetCardSelectWidget();
   PlayerSelectedCardsUI& GetSelectedCardsUI();
   PlayerEmotionUI& GetEmotionWindow();
+  PlayerHealthUIComponent& GetHealthWindow();
   Camera& GetCamera();
   PA& GetPA();
   BattleResults& BattleResultsObj();

--- a/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
+++ b/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
@@ -138,7 +138,7 @@ void FreedomMissionMobScene::Init()
     SpawnLocalPlayer(2, 2);
   }
 
-  // Run block programs on the remote player now that they are spawned
+  // Run block programs on the local player now that they are spawned
   BlockPackageManager& blockPackages = getController().BlockPackagePartitioner().GetPartition(Game::LocalPartition);
   for (const std::string& blockID : props.blocks) {
     if (!blockPackages.HasPackage(blockID)) continue;
@@ -146,6 +146,9 @@ void FreedomMissionMobScene::Init()
     auto& blockMeta = blockPackages.FindPackageByID(blockID);
     blockMeta.mutator(*GetLocalPlayer());
   }
+
+  //This should be run to ensure Health UI snaps to the user's current health.
+  GetHealthWindow().ResetHP(GetLocalPlayer()->GetHealth());
 
   CardSelectionCust& cardSelectWidget = GetCardSelectWidget();
   cardSelectWidget.PreventRetreat();

--- a/BattleNetwork/battlescene/bnMobBattleScene.cpp
+++ b/BattleNetwork/battlescene/bnMobBattleScene.cpp
@@ -149,7 +149,7 @@ void MobBattleScene::Init()
     SpawnLocalPlayer(2, 2);
   }
 
-  // Run block programs on the remote player now that they are spawned
+  // Run block programs on the local player now that they are spawned
   BlockPackageManager& blockPackages = getController().BlockPackagePartitioner().GetPartition(Game::LocalPartition);
   for (const std::string& blockID : props.blocks) {
     if (!blockPackages.HasPackage(blockID)) continue;
@@ -157,7 +157,9 @@ void MobBattleScene::Init()
     auto& blockMeta = blockPackages.FindPackageByID(blockID);
     blockMeta.mutator(*GetLocalPlayer());
   }
-
+  
+  //This should be run to ensure Health UI snaps to the user's current health.
+  GetHealthWindow().ResetHP(GetLocalPlayer()->GetHealth());
   GetCardSelectWidget().SetSpeaker(props.mug, props.anim);
   GetEmotionWindow().SetTexture(props.emotion);
 }

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -1678,8 +1678,6 @@ void Entity::ResolveFrameBattleDamage()
 }
 
 void Entity::SetHealth(const int _health) {
-  std::shared_ptr<Field> fieldPtr = field.lock();
-
   health = _health;
 
   if (maxHealth == 0) {

--- a/BattleNetwork/bnPlayerHealthUI.cpp
+++ b/BattleNetwork/bnPlayerHealthUI.cpp
@@ -107,6 +107,11 @@ void PlayerHealthUI::draw(sf::RenderTarget& target, sf::RenderStates states) con
   target.draw(glyphs, states);
 }
 
+void PlayerHealthUI::ResetHP(int newHP) {
+  targetHP = std::max(newHP, 0);
+  currHP = lastHP = newHP;
+}
+
 ////////////////////////////////////
 // class PlayerHealthUIComponent  //
 ////////////////////////////////////
@@ -119,6 +124,11 @@ PlayerHealthUIComponent::PlayerHealthUIComponent(std::weak_ptr<Player> _player) 
   ui.SetHP(startHP);
   SetDrawOnUIPass(false);
   OnUpdate(0); // refresh and prepare for the 1st frame
+}
+
+void PlayerHealthUIComponent::ResetHP(int newHP) {
+  ui.ResetHP(newHP);
+  startHP = newHP;
 }
 
 PlayerHealthUIComponent::~PlayerHealthUIComponent() {

--- a/BattleNetwork/bnPlayerHealthUI.h
+++ b/BattleNetwork/bnPlayerHealthUI.h
@@ -36,6 +36,7 @@ public:
 
   void SetFontStyle(Font::Style style);
   void SetHP(int hp);
+  void ResetHP(int newHP);
   void Update(double elapsed);
   void draw(sf::RenderTarget& target, sf::RenderStates states) const override final;
 
@@ -60,6 +61,8 @@ public:
    * \brief Sets the player owner. Sets hp tracker to current health.
    */
   PlayerHealthUIComponent(std::weak_ptr<Player> _player);
+
+  void ResetHP(int newHP);
   
   /**
    * @brief No memory needs to be freed

--- a/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
+++ b/BattleNetwork/netplay/battlescene/bnNetworkBattleScene.cpp
@@ -406,7 +406,7 @@ void NetworkBattleScene::Init()
       SpawnRemotePlayer(p, x, y);
     }
 
-    // Run block programs on the remote player now that they are spawned
+    // Run block programs on the current player now that they are spawned
     for (const PackageAddress& addr: blocks) {
       BlockPackageManager& blockPackages = partition.GetPartition(addr.namespaceId);
       if (!blockPackages.HasPackage(addr.packageId)) continue;
@@ -417,7 +417,8 @@ void NetworkBattleScene::Init()
 
     idx++;
   }
-
+  //This should be run to ensure Health UI snaps to the user's current health.
+  GetHealthWindow().ResetHP(GetLocalPlayer()->GetHealth());
   std::shared_ptr<MobHealthUI> ui = remotePlayer->GetFirstComponent<MobHealthUI>();
 
   if (ui) {


### PR DESCRIPTION
1. `bnBattleSceneBase.h` and `.cpp`: I have included `bnPlayerHealthUI.h` in order to create a healthUI property, similar to the emotionUI property, which can be grabbed from battle scenes of all kinds with the new function `GetHealthWindow()`.
2. `bnPlayerHealthUI.h` and `.cpp`: The code as you described to me to forcibly set the Health counter to a number has been implemented.
3. `bnNetworkBattleScene.cpp`, `bnMobBattleScene.cpp`, and `bnFreedomMissionMobScene.cpp`: I have added a line of code calling the new `GetEmotionWindow()` and using your `ResetHP()` function to forcibly set the UI's numbering to the current health of the player. This is not set to Max HP as I figure if the player is at max health, it will set to max health. This way, we respect lowering health amounts in future use cases & edge cases.
4. `bnEntity.cpp`: I forgot to delete a line of code when initially changing the check for `isBattleActive` over to the `Delete()` function. It has been removed for compactness' sake.