### PR TITLE
Allow modders to change the player animation during battle

### DIFF
--- a/BattleNetwork/bindings/bnScriptedPlayer.cpp
+++ b/BattleNetwork/bindings/bnScriptedPlayer.cpp
@@ -22,7 +22,6 @@ void ScriptedPlayer::Init() {
     Logger::Log(LogLevel::critical, initResult.error_cstr());
   }
 
-  animationComponent->Reload();
   FinishConstructor();
 
   weakWrap = WeakWrapper(weak_from_base<ScriptedPlayer>());
@@ -49,6 +48,7 @@ void ScriptedPlayer::SetHeight(const float height)
 void ScriptedPlayer::SetAnimation(const std::string& path)
 {
   animationComponent->SetPath(path);
+  animationComponent->Reload();
 }
 
 const float ScriptedPlayer::GetHeight() const

--- a/BattleNetwork/bnAnimation.h
+++ b/BattleNetwork/bnAnimation.h
@@ -13,6 +13,12 @@ using std::to_string;
 
 #define ANIMATION_EXTENSION ".animation"
 
+struct AnimationOverride {
+  std::string state;
+  std::list<OverrideFrame> frames;
+  std::string id;
+};
+
 /**
  * @class Animation
  * @author mav
@@ -206,6 +212,7 @@ public:
 
 private:
   void HandleInterrupted();
+  void ReapplyOverrides();
 protected:
   bool noAnim{ false }; /*!< If the requested state was not found, hide the sprite when updating */
   bool handlingInterrupt{ false }; /*!< Whether or not the interupt handler is executing (for nested animations) */
@@ -216,4 +223,5 @@ protected:
   double playbackSpeed{ 1.0 }; /*!< Factor to multiply against update `dt`*/
   std::map<string, FrameList> animations; /*!< Dictionary of FrameLists read from file */
   std::function<void()> interruptCallback;
+  std::vector<AnimationOverride> animationOverrides;
 };

--- a/BattleNetwork/bnAnimationComponent.cpp
+++ b/BattleNetwork/bnAnimationComponent.cpp
@@ -45,6 +45,10 @@ void AnimationComponent::Load() {
 void AnimationComponent::Reload() {
   animation = Animation(path);
   animation.Reload();
+
+  for (AnimationOverride& animOverride : animationOverrides) {
+    animation.OverrideAnimationFrames(animOverride.state, animOverride.frames, animOverride.id);
+  }
 }
 
 void AnimationComponent::CopyFrom(const AnimationComponent& rhs)
@@ -178,15 +182,31 @@ void AnimationComponent::OverrideAnimationFrames(const std::string& animation, s
   for (auto& o : syncList) {
     o.anim->OverrideAnimationFrames(animation, data, uuid);
   }
+
+  // must occur after the above statements, as parameters may get mutated
+  AnimationOverride animOverride;
+  animOverride.state = animation;
+  animOverride.frames = data;
+  animOverride.id = uuid;
+
+  animationOverrides.push_back(animOverride);
 }
 
 void AnimationComponent::SyncAnimation(Animation & other)
 {
+  for (AnimationOverride& animOverride : animationOverrides) {
+    other.OverrideAnimationFrames(animOverride.state, animOverride.frames, animOverride.id);
+  }
+
   animation.SyncAnimation(other);
 }
 
 void AnimationComponent::SyncAnimation(std::shared_ptr<AnimationComponent> other)
 {
+  for (AnimationOverride& animOverride : animationOverrides) {
+    other->OverrideAnimationFrames(animOverride.state, animOverride.frames, animOverride.id);
+  }
+
   animation.SyncAnimation(other->animation);
   other->OnUpdate(0);
 }

--- a/BattleNetwork/bnAnimationComponent.cpp
+++ b/BattleNetwork/bnAnimationComponent.cpp
@@ -194,25 +194,21 @@ void AnimationComponent::OverrideAnimationFrames(const std::string& animation, s
 
 void AnimationComponent::SyncAnimation(Animation & other)
 {
-  for (AnimationOverride& animOverride : animationOverrides) {
-    other.OverrideAnimationFrames(animOverride.state, animOverride.frames, animOverride.id);
-  }
-
   animation.SyncAnimation(other);
 }
 
 void AnimationComponent::SyncAnimation(std::shared_ptr<AnimationComponent> other)
 {
-  for (AnimationOverride& animOverride : animationOverrides) {
-    other->OverrideAnimationFrames(animOverride.state, animOverride.frames, animOverride.id);
-  }
-
   animation.SyncAnimation(other->animation);
   other->OnUpdate(0);
 }
 
 void AnimationComponent::AddToSyncList(const AnimationComponent::SyncItem& item)
 {
+  for (AnimationOverride& animOverride : animationOverrides) {
+    item.anim->OverrideAnimationFrames(animOverride.state, animOverride.frames, animOverride.id);
+  }
+
   auto iter = std::find_if(syncList.begin(), syncList.end(), [item](auto in) {
     return std::tie(in.anim, in.node, in.point) == std::tie(item.anim, item.node, item.point);
   });

--- a/BattleNetwork/bnAnimationComponent.h
+++ b/BattleNetwork/bnAnimationComponent.h
@@ -174,6 +174,7 @@ private:
   Animation animation; /*!< Animation object */
   bool couldUpdateLastFrame{ true };
   std::vector<SyncItem> syncList;
+  std::vector<AnimationOverride> animationOverrides;
 
   void RefreshSyncItem(SyncItem& item);
   void UpdateAnimationObjects(sf::Sprite& sprite, double elapsed);

--- a/BattleNetwork/bnBusterCardAction.cpp
+++ b/BattleNetwork/bnBusterCardAction.cpp
@@ -20,7 +20,7 @@ BusterCardAction::BusterCardAction(std::weak_ptr<Character> actorWeak, bool char
   busterAttachment = &AddAttachment("buster");
 
   Animation& busterAnim = busterAttachment->GetAnimationObject();
-  busterAnim.Load(actor->GetFirstComponent<AnimationComponent>()->GetFilePath());
+  busterAnim.CopyFrom(actor->GetFirstComponent<AnimationComponent>()->GetAnimationObject());
   busterAnim.SetAnimation("BUSTER");
 
   buster = busterAttachment->GetSpriteNode();

--- a/BattleNetwork/bnPlayer.cpp
+++ b/BattleNetwork/bnPlayer.cpp
@@ -376,8 +376,6 @@ void Player::ActivateFormAt(int index)
     if (activeForm) {
       SaveStats();
       activeForm->OnActivate(shared_from_base<Player>());
-      CreateMoveAnimHash();
-      CreateRecoilAnimHash();
       animationComponent->Refresh();
     }
   }
@@ -398,7 +396,6 @@ void Player::DeactivateForm()
   if (activeForm) {
     activeForm->OnDeactivate(shared_from_base<Player>());
     RevertStats();
-    CreateMoveAnimHash();
   }
 }
 


### PR DESCRIPTION
Supported at the Animation + AnimationComponent level for overrides to be reapplied in any similar situation
Modders can use `player:get_animation():load()` or `player:set_animation()`

Changes:
 - Fixed Animation::Load not replacing existing frames
 - Storing the list of overrides applied to reapply when loading a new animation or adding new sync nodes
   - Removes the need to reapply overrides (`CreateMoveAnimHash` `CreateRecoilAnimHash`)
 - Buster: Copying the animation from memory instead of reloading using the path on the AnimationComponent, as the path may not match the Animation (and should be faster than reading from disk)