### PR TITLE
Expose L & R to lua.

### DIFF
--- a/BattleNetwork/bnScriptResourceManager.cpp
+++ b/BattleNetwork/bnScriptResourceManager.cpp
@@ -633,7 +633,9 @@ void ScriptResourceManager::ConfigureEnvironment(ScriptPackage& scriptPackage) {
     "Down", InputEvents::pressed_move_down,
     "Use", InputEvents::pressed_use_chip,
     "Special", InputEvents::pressed_special,
-    "Shoot", InputEvents::pressed_shoot
+    "Shoot", InputEvents::pressed_shoot,
+    "Left_Shoulder", InputEvents::pressed_shoulder_left,
+    "Right_Shoulder", InputEvents::pressed_shoulder_right
   );
 
   input_event_record.new_enum("Held",
@@ -643,7 +645,9 @@ void ScriptResourceManager::ConfigureEnvironment(ScriptPackage& scriptPackage) {
     "Down", InputEvents::held_move_down,
     "Use", InputEvents::held_use_chip,
     "Special", InputEvents::held_special,
-    "Shoot", InputEvents::held_shoot
+    "Shoot", InputEvents::held_shoot,
+    "Left_Shoulder", InputEvents::held_shoulder_left,
+    "Right_Shoulder", InputEvents::held_shoulder_right
   );
 
   input_event_record.new_enum("Released",
@@ -653,7 +657,9 @@ void ScriptResourceManager::ConfigureEnvironment(ScriptPackage& scriptPackage) {
     "Down", InputEvents::released_move_down,
     "Use", InputEvents::released_use_chip,
     "Special", InputEvents::released_special,
-    "Shoot", InputEvents::released_shoot
+    "Shoot", InputEvents::released_shoot,
+    "Left_Shoulder", InputEvents::released_shoulder_left,
+    "Right_Shoulder", InputEvents::released_shoulder_right
   );
 
   const auto& character_rank_record = state.new_enum("Rank",


### PR DESCRIPTION
Some mods, like the Django series, use the L & R buttons in their button combos to activate secret effects. Without them we are forced to adjust to using other buttons.

As K1rbY just finished the Django series, this is especially relevant.