### PR TITLE
Development

### DIFF
--- a/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
+++ b/BattleNetwork/battlescene/bnFreedomMissionMobScene.cpp
@@ -182,14 +182,15 @@ void FreedomMissionMobScene::OnHit(Entity& victim, const Hit::Properties& props)
 
 void FreedomMissionMobScene::onUpdate(double elapsed)
 {
-  if (GetCurrentState() == combatPtr) {
-    ProcessLocalPlayerInputQueue();
+  auto state = GetCurrentState();
+  if (state == combatPtr || state == timeFreezePtr) {
+     ProcessLocalPlayerInputQueue();
+  }
 
-    if (playerCanFlip) {
-      std::shared_ptr<Player> localPlayer = GetLocalPlayer();
-      if (localPlayer->IsActionable() && localPlayer->InputState().Has(InputEvents::pressed_option)) {
-        localPlayer->SetFacing(localPlayer->GetFacingAway());
-      }
+  if (state == combatPtr && playerCanFlip) {
+    std::shared_ptr<Player> localPlayer = GetLocalPlayer();
+    if (localPlayer->IsActionable() && localPlayer->InputState().Has(InputEvents::pressed_option)) {
+      localPlayer->SetFacing(localPlayer->GetFacingAway());
     }
   }
 


### PR DESCRIPTION
The changes from tfEvents->Begin() to tfEvents->end()-1 are additional places I didn't realize I'd missed last time. This places the summon label correctly during TFC.

The changes to bnFreedomMissionMobScene allow for input during time freeze in a freedom mission, which means attacks that take special inputs work. Summon cards are of note for this.