### PR TITLE
Development

### DIFF
--- a/BattleNetwork/battlescene/States/bnTimeFreezeBattleState.cpp
+++ b/BattleNetwork/battlescene/States/bnTimeFreezeBattleState.cpp
@@ -380,7 +380,7 @@ void TimeFreezeBattleState::DrawCardData(const sf::Vector2f& pos, const sf::Vect
     dmgOffset = 10.0f;
   }
   
-  if (multiplierValue != 1 && unmodDamage != 0) {
+  if (multiplierValue > 1 && unmodDamage != 0) {
     // add "x N" where N is the multiplier
     std::string multStr = "x" + std::to_string(multiplierValue);
     multiplier.SetString(multStr);

--- a/BattleNetwork/bnCardSelectionCust.cpp
+++ b/BattleNetwork/bnCardSelectionCust.cpp
@@ -349,7 +349,10 @@ bool CardSelectionCust::CursorAction() {
   if (cursorPos == 5 && cursorRow == 0) {
     // End card select
     areCardsReady = true;
-  } if (playerSpecialButton1 && playerSpecialButton1Ready && cursorPos == 5 && cursorRow == 1) {
+    // Return true if the cards are ready; we don't want to send any extra cards.
+    return true;
+  }
+  if (playerSpecialButton1 && playerSpecialButton1Ready && cursorPos == 5 && cursorRow == 1) {
     // make a vector for callbacks
     std::vector<Battle::Card::Properties*> currentSelection;
     for (int i = 0; i < newSelectCount; i++) {

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -1073,7 +1073,6 @@ void Entity::ToggleTimeFreeze(bool state)
 {
   if (state) {
     if (currentStatus.statusName != "None") {
-      previousStatus = currentStatus;
       if (currentStatus.statusName == "Freeze") {
         previousStatus.remainingTime = freezeCooldown;
         freezeCooldown = frames(0);
@@ -1082,6 +1081,7 @@ void Entity::ToggleTimeFreeze(bool state)
         previousStatus.remainingTime = stunCooldown;
         stunCooldown = frames(0);
       }
+      previousStatus = currentStatus;
       currentStatus.statusName = "None";
       currentStatus.remainingTime = frames(0);
     }
@@ -1097,7 +1097,6 @@ void Entity::ToggleTimeFreeze(bool state)
         currentStatus.remainingTime = previousStatus.remainingTime;
         stunCooldown = previousStatus.remainingTime;
       }
-      Logger::Log(LogLevel::critical, "current cooldown is: " + std::to_string(currentStatus.remainingTime.count()));
       previousStatus.statusName = "None";
       previousStatus.remainingTime = frames(0);
     }
@@ -1838,6 +1837,9 @@ void Entity::Stun(frame_time_t maxCooldown)
   std::string statusName = "Stun";
   AppliedStatus stunStatus = { statusName, maxCooldown };
   currentStatus = stunStatus;
+  if (IsTimeFrozen()) {
+    previousStatus = stunStatus;
+  }
 }
 
 void Entity::Root(frame_time_t maxCooldown)
@@ -1873,6 +1875,9 @@ void Entity::IceFreeze(frame_time_t maxCooldown)
   std::string statusName = "Freeze";
   AppliedStatus freezeStatus { statusName, maxCooldown };
   currentStatus = freezeStatus;
+  if (IsTimeFrozen()) {
+    previousStatus = freezeStatus;
+  }
 }
 
 void Entity::Blind(frame_time_t maxCooldown)

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -1071,6 +1071,37 @@ void Entity::AdoptNextTile()
 
 void Entity::ToggleTimeFreeze(bool state)
 {
+  if (state) {
+    if (currentStatus.statusName != "None") {
+      previousStatus = currentStatus;
+      if (currentStatus.statusName == "Freeze") {
+        previousStatus.remainingTime = freezeCooldown;
+        freezeCooldown = frames(0);
+      }
+      else if (currentStatus.statusName == "Stun") {
+        previousStatus.remainingTime = stunCooldown;
+        stunCooldown = frames(0);
+      }
+      currentStatus.statusName = "None";
+      currentStatus.remainingTime = frames(0);
+    }
+  }
+  else {
+    if (previousStatus.statusName != "None") {
+      currentStatus = previousStatus;
+      if (previousStatus.statusName == "Freeze") {
+        currentStatus.remainingTime = previousStatus.remainingTime;
+        freezeCooldown = previousStatus.remainingTime;
+      }
+      else if (previousStatus.statusName == "Stun") {
+        currentStatus.remainingTime = previousStatus.remainingTime;
+        stunCooldown = previousStatus.remainingTime;
+      }
+      Logger::Log(LogLevel::critical, "current cooldown is: " + std::to_string(currentStatus.remainingTime.count()));
+      previousStatus.statusName = "None";
+      previousStatus.remainingTime = frames(0);
+    }
+  }
   isTimeFrozen = state;
 }
 
@@ -1804,6 +1835,9 @@ void Entity::Stun(frame_time_t maxCooldown)
   invincibilityCooldown = frames(0); // cancel flash
   freezeCooldown = frames(0); // cancel freeze
   stunCooldown = maxCooldown;
+  std::string statusName = "Stun";
+  AppliedStatus stunStatus = { statusName, maxCooldown };
+  currentStatus = stunStatus;
 }
 
 void Entity::Root(frame_time_t maxCooldown)
@@ -1836,6 +1870,9 @@ void Entity::IceFreeze(frame_time_t maxCooldown)
   }
 
   iceFxAnimation.Refresh(iceFx->getSprite());
+  std::string statusName = "Freeze";
+  AppliedStatus freezeStatus { statusName, maxCooldown };
+  currentStatus = freezeStatus;
 }
 
 void Entity::Blind(frame_time_t maxCooldown)

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -79,7 +79,8 @@ Entity::Entity() :
   confusedFx->SetLayer(-2);
   confusedFx->Hide(); // default: hidden
   AddNode(confusedFx);
-
+  
+  // Add the status behavior director so we can manage time freeze statuses like Stun and Freeze.
   statusDirector = StatusBehaviorDirector();
 
   iceFxAnimation = Animation(AnimationPaths::ICE_FX);
@@ -1075,6 +1076,8 @@ void Entity::ToggleTimeFreeze(bool state)
 {
   AppliedStatus statusToCheck = statusDirector.GetStatus(false);
   statusDirector.SetNextStatus(statusToCheck.statusFlag, statusToCheck.remainingTime, state);
+  // When entering Time Freeze, force Stun, Freeze cooldowns to 0. Hide Ice, and refresh Shader.
+  // This is to allow animations during Time Freeze.
   if (state) {
     stunCooldown = frames(0);
     freezeCooldown = frames(0);

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -79,9 +79,6 @@ Entity::Entity() :
   confusedFx->SetLayer(-2);
   confusedFx->Hide(); // default: hidden
   AddNode(confusedFx);
-  
-  // Add the status behavior director so we can manage time freeze statuses like Stun and Freeze.
-  statusDirector = StatusBehaviorDirector();
 
   iceFxAnimation = Animation(AnimationPaths::ICE_FX);
   blindFxAnimation = Animation(AnimationPaths::BLIND_FX);

--- a/BattleNetwork/bnEntity.cpp
+++ b/BattleNetwork/bnEntity.cpp
@@ -1072,32 +1072,32 @@ void Entity::AdoptNextTile()
 void Entity::ToggleTimeFreeze(bool state)
 {
   if (state) {
-    if (currentStatus.statusName != "None") {
-      if (currentStatus.statusName == "Freeze") {
+    if (currentStatus.statusFlag != Hit::none) {
+      if (currentStatus.statusFlag == Hit::freeze) {
         previousStatus.remainingTime = freezeCooldown;
         freezeCooldown = frames(0);
       }
-      else if (currentStatus.statusName == "Stun") {
+      else if (currentStatus.statusFlag == Hit::stun) {
         previousStatus.remainingTime = stunCooldown;
         stunCooldown = frames(0);
       }
       previousStatus = currentStatus;
-      currentStatus.statusName = "None";
+      currentStatus.statusFlag = Hit::none;
       currentStatus.remainingTime = frames(0);
     }
   }
   else {
-    if (previousStatus.statusName != "None") {
+    if (previousStatus.statusFlag != Hit::none) {
       currentStatus = previousStatus;
-      if (previousStatus.statusName == "Freeze") {
+      if (previousStatus.statusFlag == Hit::none) {
         currentStatus.remainingTime = previousStatus.remainingTime;
         freezeCooldown = previousStatus.remainingTime;
       }
-      else if (previousStatus.statusName == "Stun") {
+      else if (previousStatus.statusFlag == Hit::stun) {
         currentStatus.remainingTime = previousStatus.remainingTime;
         stunCooldown = previousStatus.remainingTime;
       }
-      previousStatus.statusName = "None";
+      previousStatus.statusFlag = Hit::none;
       previousStatus.remainingTime = frames(0);
     }
   }
@@ -1834,8 +1834,8 @@ void Entity::Stun(frame_time_t maxCooldown)
   invincibilityCooldown = frames(0); // cancel flash
   freezeCooldown = frames(0); // cancel freeze
   stunCooldown = maxCooldown;
-  std::string statusName = "Stun";
-  AppliedStatus stunStatus = { statusName, maxCooldown };
+  Hit::flags statusFlag = Hit::stun;
+  AppliedStatus stunStatus = { statusFlag, maxCooldown };
   currentStatus = stunStatus;
   if (IsTimeFrozen()) {
     previousStatus = stunStatus;
@@ -1872,8 +1872,8 @@ void Entity::IceFreeze(frame_time_t maxCooldown)
   }
 
   iceFxAnimation.Refresh(iceFx->getSprite());
-  std::string statusName = "Freeze";
-  AppliedStatus freezeStatus { statusName, maxCooldown };
+  Hit::Flags statusFlag = Hit::freeze;
+  AppliedStatus freezeStatus { statusFlag, maxCooldown };
   currentStatus = freezeStatus;
   if (IsTimeFrozen()) {
     previousStatus = freezeStatus;

--- a/BattleNetwork/bnEntity.h
+++ b/BattleNetwork/bnEntity.h
@@ -95,6 +95,11 @@ struct EntityComparitor {
   bool operator()(Entity* f, Entity* s) const;
 };
 
+struct AppliedStatus {
+  std::string statusName;
+  frame_time_t remainingTime;
+};
+
 class Entity :
   public SpriteProxyNode,
   public ResourceHandle,
@@ -132,6 +137,8 @@ private:
   EventBus::Channel channel; /*!< Our event bus channel to emit events */
   MoveEvent currMoveEvent{};
   VirtualInputState inputState;
+  AppliedStatus previousStatus{ "None", frames(0) }; /*!< The previous status, Stun or Freeze, applied when time freeze started.*/
+  AppliedStatus currentStatus{ "None", frames(0) }; /*!< The current status, Stun or Freeze, which is applied. Removed when timer hits 0.*/
   std::shared_ptr<SpriteProxyNode> shadow{ nullptr };
   std::shared_ptr<SpriteProxyNode> iceFx{ nullptr };
   std::shared_ptr<SpriteProxyNode> blindFx{ nullptr };

--- a/BattleNetwork/bnEntity.h
+++ b/BattleNetwork/bnEntity.h
@@ -135,10 +135,6 @@ private:
   VirtualInputState inputState;
   StatusBehaviorDirector statusDirector{};
   std::shared_ptr<SpriteProxyNode> shadow{ nullptr };
-  std::shared_ptr<SpriteProxyNode> iceFx{ nullptr };
-  std::shared_ptr<SpriteProxyNode> blindFx{ nullptr };
-  std::shared_ptr<SpriteProxyNode> confusedFx{ nullptr };
-  Animation iceFxAnimation, blindFxAnimation, confusedFxAnimation;
   /**
    * @brief Frees one component with the same ID
    * @param ID ID of the component to remove
@@ -160,6 +156,8 @@ public:
   void Spawn(Battle::Tile& start);
 
   bool HasSpawned();
+
+  bool canUpdateThisFrame;
 
   virtual void OnSpawn(Battle::Tile& start) { };
 
@@ -784,12 +782,6 @@ protected:
   frame_time_t moveStartupDelay{};
   std::optional<frame_time_t> moveEndlagDelay;
   frame_time_t grassHealCooldown{ 0 }; /*!< Timer until next healing is allowed */
-  frame_time_t stunCooldown{ 0 }; /*!< Timer until stun is over */
-  frame_time_t rootCooldown{ 0 }; /*!< Timer until root is over */
-  frame_time_t freezeCooldown{ 0 }; /*!< Timer until freeze is over */
-  frame_time_t blindCooldown{ 0 }; /*!< Timer until blind is over */
-  frame_time_t confusedCooldown{ 0 }; /*!< Timer until confusion is over */
-  frame_time_t confusedSfxCooldown{ 0 }; /*!< Timer to replay confusion SFX */
   frame_time_t invincibilityCooldown{ 0 }; /*!< Timer until invincibility is over */
   bool counterable{};
   bool hit{}; /*!< Was hit this frame */

--- a/BattleNetwork/bnEntity.h
+++ b/BattleNetwork/bnEntity.h
@@ -36,6 +36,7 @@ using std::string;
 #include "bnDefenseFrameStateJudge.h"
 #include "bnDefenseRule.h"
 #include "bnHitProperties.h"
+#include "bnStatusDirectior.h"
 #include "stx/memory.h"
 
 namespace Battle {
@@ -95,11 +96,6 @@ struct EntityComparitor {
   bool operator()(Entity* f, Entity* s) const;
 };
 
-struct AppliedStatus {
-  Hit::Flags statusFlag;
-  frame_time_t remainingTime;
-};
-
 class Entity :
   public SpriteProxyNode,
   public ResourceHandle,
@@ -137,8 +133,7 @@ private:
   EventBus::Channel channel; /*!< Our event bus channel to emit events */
   MoveEvent currMoveEvent{};
   VirtualInputState inputState;
-  AppliedStatus previousStatus{ Hit::none, frames(0) }; /*!< The previous status, Stun or Freeze, applied when time freeze started.*/
-  AppliedStatus currentStatus{ Hit::none, frames(0) }; /*!< The current status, Stun or Freeze, which is applied.*/
+  StatusBehaviorDirector statusDirector;
   std::shared_ptr<SpriteProxyNode> shadow{ nullptr };
   std::shared_ptr<SpriteProxyNode> iceFx{ nullptr };
   std::shared_ptr<SpriteProxyNode> blindFx{ nullptr };

--- a/BattleNetwork/bnEntity.h
+++ b/BattleNetwork/bnEntity.h
@@ -96,7 +96,7 @@ struct EntityComparitor {
 };
 
 struct AppliedStatus {
-  std::string statusName;
+  Hit::Flags statusFlag;
   frame_time_t remainingTime;
 };
 
@@ -137,8 +137,8 @@ private:
   EventBus::Channel channel; /*!< Our event bus channel to emit events */
   MoveEvent currMoveEvent{};
   VirtualInputState inputState;
-  AppliedStatus previousStatus{ "None", frames(0) }; /*!< The previous status, Stun or Freeze, applied when time freeze started.*/
-  AppliedStatus currentStatus{ "None", frames(0) }; /*!< The current status, Stun or Freeze, which is applied. Removed when timer hits 0.*/
+  AppliedStatus previousStatus{ Hit::none, frames(0) }; /*!< The previous status, Stun or Freeze, applied when time freeze started.*/
+  AppliedStatus currentStatus{ Hit::none, frames(0) }; /*!< The current status, Stun or Freeze, which is applied.*/
   std::shared_ptr<SpriteProxyNode> shadow{ nullptr };
   std::shared_ptr<SpriteProxyNode> iceFx{ nullptr };
   std::shared_ptr<SpriteProxyNode> blindFx{ nullptr };

--- a/BattleNetwork/bnEntity.h
+++ b/BattleNetwork/bnEntity.h
@@ -133,7 +133,7 @@ private:
   EventBus::Channel channel; /*!< Our event bus channel to emit events */
   MoveEvent currMoveEvent{};
   VirtualInputState inputState;
-  StatusBehaviorDirector statusDirector;
+  StatusBehaviorDirector statusDirector{};
   std::shared_ptr<SpriteProxyNode> shadow{ nullptr };
   std::shared_ptr<SpriteProxyNode> iceFx{ nullptr };
   std::shared_ptr<SpriteProxyNode> blindFx{ nullptr };

--- a/BattleNetwork/bnStatusDirectior.cpp
+++ b/BattleNetwork/bnStatusDirectior.cpp
@@ -2,28 +2,31 @@
 
 StatusBehaviorDirector::StatusBehaviorDirector()
 {
+    // At creation, make sure both statuses are default.
     previousStatus = AppliedStatus{ Hit::none, frames(0) };
     currentStatus = AppliedStatus{ Hit::none, frames(0) };
 }
 
 void StatusBehaviorDirector::SetNextStatus(Hit::Flags statusFlag, frame_time_t maxCooldown, bool deffer) {
-    currentStatus = AppliedStatus{ statusFlag, maxCooldown };
+    // Since we might use it twice, create it once. No need to repeat code.
+    AppliedStatus statusToSet{ statusFlag, maxCooldown };
+    // Set the current status. It will be used later.
+    currentStatus = statusToSet;
     if (deffer) {
-        previousStatus = AppliedStatus{ statusFlag, maxCooldown };
+        // If necessary, set the previous status as well.
+        previousStatus = statusToSet;
     }
 };
 
 AppliedStatus StatusBehaviorDirector::GetStatus(bool isPrevious) {
+    // If the previous status is being called, grab it.
     if (isPrevious) {
-        return previousStatus; //Everything works, but it says Do Not Slice - seems to be a warning about data management. I can't seem to crack it.
+        return previousStatus;
     }
+    // Otherwise return the current.
     return currentStatus;
 };
 
-
 StatusBehaviorDirector::~StatusBehaviorDirector()
 {
-    //Reset both statuses to default when deleting.
-    previousStatus = AppliedStatus{ Hit::none, frames(0) };
-    currentStatus = AppliedStatus{ Hit::none, frames(0) };
 }

--- a/BattleNetwork/bnStatusDirectior.cpp
+++ b/BattleNetwork/bnStatusDirectior.cpp
@@ -1,30 +1,160 @@
 #include "bnStatusDirectior.h"
+#include "bnEntity.h"
 
 StatusBehaviorDirector::StatusBehaviorDirector()
 {
     // At creation, make sure both statuses are default.
-    previousStatus = AppliedStatus{ Hit::none, frames(0) };
-    currentStatus = AppliedStatus{ Hit::none, frames(0) };
+    previousStatus = std::vector<AppliedStatus>{};
+    currentStatus = std::vector<AppliedStatus>{};
 }
 
-void StatusBehaviorDirector::SetNextStatus(Hit::Flags statusFlag, frame_time_t maxCooldown, bool deffer) {
-    // Since we might use it twice, create it once. No need to repeat code.
-    AppliedStatus statusToSet{ statusFlag, maxCooldown };
-    // Set the current status. It will be used later.
-    currentStatus = statusToSet;
+void StatusBehaviorDirector::AddStatus(Hit::Flags statusFlag, frame_time_t maxCooldown, bool deffer) {
+    // Check if we already have it. We might be overwriting a cooldown.
+    AppliedStatus statusToCheck = HasStatus(statusFlag, deffer);
+    if (statusToCheck.statusFlag == Hit::none) {
+        // We didn't find the status, so create the new one.
+        AppliedStatus statusToSet{ statusFlag, maxCooldown };
+        // Add the current status to the vector.
+        currentStatus.push_back(statusToSet);
+    }
+    else {
+
+    }
     if (deffer) {
-        // If necessary, set the previous status as well.
-        previousStatus = statusToSet;
+        stunCooldown = frames(0);
+        freezeCooldown = frames(0);
+        iceFx->Hide();
+        // If necessary, set the previous status to the current status vector.
+        previousStatus = currentStatus;
     }
 };
 
-AppliedStatus StatusBehaviorDirector::GetStatus(bool isPrevious) {
+std::vector<AppliedStatus> StatusBehaviorDirector::GetStatusList(bool isPrevious) {
     // If the previous status is being called, grab it.
     if (isPrevious) {
         return previousStatus;
     }
     // Otherwise return the current.
     return currentStatus;
+}
+
+AppliedStatus StatusBehaviorDirector::HasStatus(Hit::Flags flag, bool isPrevious)
+{
+   std::vector<AppliedStatus> list = isPrevious ? previousStatus : currentStatus;
+   for (int i = 0; list.size(); i++) {
+       AppliedStatus found = list[i];
+       if (found.statusFlag == flag) {
+           return list.at(i);
+       }
+   }
+   return AppliedStatus{ Hit::none, frames(0) };
+}
+
+void StatusBehaviorDirector::Initialize(Entity* entityToAffect)
+{
+    
+    if (entityToAffect != nullptr) {
+        this->owner = entityToAffect;
+        // Ensure statuses do not play out at battle start
+        stunCooldown = frames(0);
+        rootCooldown = frames(0);
+
+        iceFx = std::make_shared<SpriteProxyNode>();
+        iceFx->setTexture(manager.Textures().LoadFromFile(TexturePaths::ICE_FX));
+        iceFx->SetLayer(-2);
+        iceFx->Hide(); // default: hidden
+        entityToAffect->AddNode(iceFx);
+
+        blindFx = std::make_shared<SpriteProxyNode>();
+        blindFx->setTexture(manager.Textures().LoadFromFile(TexturePaths::BLIND_FX));
+        blindFx->SetLayer(-2);
+        blindFx->Hide(); // default: hidden
+        entityToAffect->AddNode(blindFx);
+
+        confusedFx = std::make_shared<SpriteProxyNode>();
+        confusedFx->setTexture(manager.Textures().LoadFromFile(TexturePaths::CONFUSED_FX));
+        confusedFx->SetLayer(-2);
+        confusedFx->Hide(); // default: hidden
+        entityToAffect->AddNode(confusedFx);
+
+        iceFxAnimation = Animation(AnimationPaths::ICE_FX);
+        blindFxAnimation = Animation(AnimationPaths::BLIND_FX);
+        confusedFxAnimation = Animation(AnimationPaths::CONFUSED_FX);
+    }
+}
+
+void StatusBehaviorDirector::UpdateAnimations(double _elapsed)
+{
+    if (rootCooldown > frames(0)) {
+        rootCooldown -= from_seconds(_elapsed);
+
+        // Root is cancelled if these conditions are met
+        if (rootCooldown <= frames(0)/* || IsPassthrough() */) {
+            rootCooldown = frames(0);
+        }
+    }
+
+    owner->canUpdateThisFrame = true;
+
+    if (stunCooldown > frames(0)) {
+        owner->canUpdateThisFrame = false;
+        stunCooldown -= from_seconds(_elapsed);
+
+        if (stunCooldown <= frames(0)) {
+            stunCooldown = frames(0);
+        }
+    }
+
+    // assume this is hidden, will flip to visible if not
+    iceFx->Hide();
+    if (freezeCooldown > frames(0)) {
+        iceFxAnimation.Update(_elapsed, iceFx->getSprite());
+        iceFx->Reveal();
+
+        owner->canUpdateThisFrame = false;
+        freezeCooldown -= from_seconds(_elapsed);
+
+        if (freezeCooldown <= frames(0)) {
+            freezeCooldown = frames(0);
+        }
+    }
+
+    // assume this is hidden, will flip to visible if not
+    blindFx->Hide();
+    if (blindCooldown > frames(0)) {
+        blindFxAnimation.Update(_elapsed, blindFx->getSprite());
+        blindFx->Reveal();
+
+        blindCooldown -= from_seconds(_elapsed);
+
+        if (blindCooldown <= frames(0)) {
+            blindCooldown = frames(0);
+        }
+    }
+
+
+    // assume this is hidden, will flip to visible if not
+    confusedFx->Hide();
+    if (confusedCooldown > frames(0)) {
+        confusedFxAnimation.Update(_elapsed, confusedFx->getSprite());
+        confusedFx->Reveal();
+
+        confusedSfxCooldown -= from_seconds(_elapsed);
+        // Unclear if 55i is the correct timing: this seems to be the one used in MMBN6, though, as the confusion SFX only plays twice during a 110i confusion period.
+        constexpr frame_time_t CONFUSED_SFX_INTERVAL{ 55 };
+        if (confusedSfxCooldown <= frames(0)) {
+            static std::shared_ptr<sf::SoundBuffer> confusedsfx = manager.Audio().LoadFromFile(SoundPaths::CONFUSED_FX);
+            manager.Audio().Play(confusedsfx, AudioPriority::highest);
+            confusedSfxCooldown = CONFUSED_SFX_INTERVAL;
+        }
+
+        confusedCooldown -= from_seconds(_elapsed);
+
+        if (confusedCooldown <= frames(0)) {
+            confusedCooldown = frames(0);
+            confusedSfxCooldown = frames(0);
+        }
+    }
 };
 
 StatusBehaviorDirector::~StatusBehaviorDirector()

--- a/BattleNetwork/bnStatusDirectior.cpp
+++ b/BattleNetwork/bnStatusDirectior.cpp
@@ -1,0 +1,29 @@
+#include "bnStatusDirectior.h"
+
+StatusBehaviorDirector::StatusBehaviorDirector()
+{
+    previousStatus = AppliedStatus{ Hit::none, frames(0) };
+    currentStatus = AppliedStatus{ Hit::none, frames(0) };
+}
+
+void StatusBehaviorDirector::SetNextStatus(Hit::Flags statusFlag, frame_time_t maxCooldown, bool deffer) {
+    currentStatus = AppliedStatus{ statusFlag, maxCooldown };
+    if (deffer) {
+        previousStatus = AppliedStatus{ statusFlag, maxCooldown };
+    }
+};
+
+AppliedStatus StatusBehaviorDirector::GetStatus(bool isPrevious) {
+    if (isPrevious) {
+        return previousStatus; //Everything works, but it says Do Not Slice - seems to be a warning about data management. I can't seem to crack it.
+    }
+    return currentStatus;
+};
+
+
+StatusBehaviorDirector::~StatusBehaviorDirector()
+{
+    //Reset both statuses to default when deleting.
+    previousStatus = AppliedStatus{ Hit::none, frames(0) };
+    currentStatus = AppliedStatus{ Hit::none, frames(0) };
+}

--- a/BattleNetwork/bnStatusDirectior.h
+++ b/BattleNetwork/bnStatusDirectior.h
@@ -2,6 +2,12 @@
 
 #include "bnHitProperties.h"
 #include "bnFrameTimeUtils.h"
+#include "bnSpriteProxyNode.h"
+#include "bnShaderResourceManager.h"
+#include "bnTextureResourceManager.h"
+#include "bnAudioResourceManager.h"
+
+class Entity;
 
 struct AppliedStatus {
     Hit::Flags statusFlag;
@@ -12,9 +18,24 @@ class StatusBehaviorDirector {
 public:
     StatusBehaviorDirector();
     virtual ~StatusBehaviorDirector();
-    void SetNextStatus(Hit::Flags statusFlag, frame_time_t maxCooldown, bool deffer);
-    AppliedStatus GetStatus(bool isPrevious);
+    void AddStatus(Hit::Flags statusFlag, frame_time_t maxCooldown, bool deffer);
+    std::vector<AppliedStatus> GetStatusList(bool isPrevious);
+    AppliedStatus HasStatus(Hit::Flags flag, bool isPrevious);
+    void Initialize(Entity*);
+    void UpdateAnimations(double _elapsed);
 private:
-    AppliedStatus previousStatus{ Hit::none, frames(0) };
-    AppliedStatus currentStatus{ Hit::none, frames(0) };
+    Entity* owner;
+    ResourceHandle manager;
+    std::vector<AppliedStatus> previousStatus;
+    std::vector<AppliedStatus> currentStatus;
+    std::shared_ptr<SpriteProxyNode> iceFx{ nullptr };
+    std::shared_ptr<SpriteProxyNode> blindFx{ nullptr };
+    std::shared_ptr<SpriteProxyNode> confusedFx{ nullptr };
+    frame_time_t stunCooldown{ 0 }; /*!< Timer until stun is over */
+    frame_time_t rootCooldown{ 0 }; /*!< Timer until root is over */
+    frame_time_t freezeCooldown{ 0 }; /*!< Timer until freeze is over */
+    frame_time_t blindCooldown{ 0 }; /*!< Timer until blind is over */
+    frame_time_t confusedCooldown{ 0 }; /*!< Timer until confusion is over */
+    frame_time_t confusedSfxCooldown{ 0 }; /*!< Timer to replay confusion SFX */
+    Animation iceFxAnimation, blindFxAnimation, confusedFxAnimation;
 };

--- a/BattleNetwork/bnStatusDirectior.h
+++ b/BattleNetwork/bnStatusDirectior.h
@@ -8,14 +8,13 @@ struct AppliedStatus {
     frame_time_t remainingTime;
 };
 
-class StatusBehaviorDirector :
-    public AppliedStatus
-{
+class StatusBehaviorDirector {
 public:
     StatusBehaviorDirector();
     virtual ~StatusBehaviorDirector();
     void SetNextStatus(Hit::Flags statusFlag, frame_time_t maxCooldown, bool deffer);
     AppliedStatus GetStatus(bool isPrevious);
+private:
     AppliedStatus previousStatus{ Hit::none, frames(0) };
     AppliedStatus currentStatus{ Hit::none, frames(0) };
 };

--- a/BattleNetwork/bnStatusDirectior.h
+++ b/BattleNetwork/bnStatusDirectior.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "bnHitProperties.h"
+#include "bnFrameTimeUtils.h"
+
+struct AppliedStatus {
+    Hit::Flags statusFlag;
+    frame_time_t remainingTime;
+};
+
+class StatusBehaviorDirector :
+    public AppliedStatus
+{
+public:
+    StatusBehaviorDirector();
+    virtual ~StatusBehaviorDirector();
+    void SetNextStatus(Hit::Flags statusFlag, frame_time_t maxCooldown, bool deffer);
+    AppliedStatus GetStatus(bool isPrevious);
+    AppliedStatus previousStatus{ Hit::none, frames(0) };
+    AppliedStatus currentStatus{ Hit::none, frames(0) };
+};

--- a/BattleNetwork/bnTile.cpp
+++ b/BattleNetwork/bnTile.cpp
@@ -57,8 +57,8 @@ namespace Battle {
     flickerTeamCooldown = teamCooldown = frames(0);
     red_team_atlas = blue_team_atlas = nullptr; // Set by field
 
-    burncycle = frames(1);
-    elapsedBurnTime = burncycle;
+    burncycle = frames(7); // Drain 1 HP every 7 Frames. Game accurate.
+    elapsedBurnTime = frames(0); //Instantly drain 1 HP. Game accurate.
 
     highlightMode = TileHighlight::none;
 

--- a/BattleNetwork/bnTitleScene.cpp
+++ b/BattleNetwork/bnTitleScene.cpp
@@ -210,7 +210,9 @@ void TitleScene::onDraw(sf::RenderTexture & surface)
     surface.draw(startLabel);
   }
 
-  surface.draw(textbox);
+  if (textbox.IsOpen()) {
+    surface.draw(textbox);
+  }
 }
 
 void TitleScene::onEnd()

--- a/BattleNetwork/resources/ui/navigator.animation
+++ b/BattleNetwork/resources/ui/navigator.animation
@@ -5,3 +5,16 @@ frame duration="0.04" x="27" y="131" w="235" h="2" originx="0" originy="0" flipx
 frame duration="0.04" x="13" y="83" w="236" h="27" originx="0" originy="14" flipx="0" flipy="0" 
 frame duration="0.04" x="0" y="0" w="236" h="43" originx="0" originy="22" flipx="0" flipy="0" 
 frame duration="0.04" x="271" y="16" w="236" h="59" originx="0" originy="28" flipx="0" flipy="0" 
+
+animation state="TALK"
+frame duration="0.05" x="0" y="0" w="40" h="48" originx="0" originy="0"
+frame duration="0.05" x="42" y="0" w="40" h="48" originx="0" originy="0"
+frame duration="0.05" x="84" y="0" w="40" h="48" originx="0" originy="0"
+frame duration="0.05" x="42" y="0" w="40" h="48" originx="0" originy="0"
+
+animation state="IDLE"
+frame duration="0.05" x="84" y="0" w="40" h="48" originx="0" originy="0"
+frame duration="0.05" x="126" y="0" w="40" h="48" originx="0" originy="0"
+frame duration="0.05" x="168" y="0" w="40" h="48" originx="0" originy="0"
+frame duration="0.05" x="126" y="0" w="40" h="48" originx="0" originy="0"
+frame duration="2.0" x="84" y="0" w="40" h="48" originx="0" originy="0"

--- a/BattleNetwork/sfMidi/include/sfMidi/Midi.h
+++ b/BattleNetwork/sfMidi/include/sfMidi/Midi.h
@@ -89,6 +89,7 @@ public:
   bool loadMidiFromMemory(const void* data, unsigned int size);
 
   void play();
+  void stop();
 
 
 private:

--- a/BattleNetwork/sfMidi/src/sfMidi/Midi.cpp
+++ b/BattleNetwork/sfMidi/src/sfMidi/Midi.cpp
@@ -318,6 +318,13 @@ void sfmidi::Midi::play()
     SoundStream::play();
 }
 
+void sfmidi::Midi::stop()
+{
+  fluid_player_seek(player_, 0);
+  fluid_player_stop(player_);
+  SoundStream::stop();
+}
+
 
 bool sfmidi::Midi::onGetData(sf::SoundStream::Chunk& data)
 {


### PR DESCRIPTION
Changes:

1. Revert my reckless usage of `tfEvents.end()-1` to `tfEvents.begin()` to properly re-allow Time Freeze Counter. My mistake, and I apologize.
2. Attempt at enabling card action animations while time frozen by disabling Freeze/Stun status effects, storing their timers, and re-applying them after time freeze is over. This works, but may not be what was asked for, so I am submitting it for review.
3. Game-accurate Time Freeze Counter mechanics; it's not if you're actionable, strictly speaking, but if you're not in a card lockout. You can actually TFC while in another animation, as long as you're not dead or in a card lockout of some kind.
4. Poison Tiles were draining Health every frame. Accuracy dictates it be every 7 frames. I am not sure if this was for debugging purposes, but I have set it back to every 7 frames.